### PR TITLE
fix(static): serve files with async pread, not blocking pread

### DIFF
--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -1,8 +1,9 @@
-//! Static file serving — pread into arena + send, with ETag/Last-Modified caching.
+//! Static file serving — async pread + send, with ETag/Last-Modified caching.
 //!
 //! Zig-native, no Lua involvement. Route configuration via keyway.static.
-//! Small files (< STATIC_READ_SIZE) are served in a single read+send.
-//! Large files are served via pread+send loop using Content-Length (size known from stat).
+//! Headers are sent first, then the body is streamed via an async pread+send
+//! loop (one chunk per STATIC_READ_SIZE) using Content-Length (size from stat).
+//! pread runs on the worker's xev loop (io_uring), never blocking it.
 //!
 //! Path safety: std.fs.path.resolve + verify result starts with configured root.
 
@@ -22,6 +23,7 @@ pub const StaticState = struct {
     file_size: u64,
     bytes_sent: u64,
     read_buf: []u8,
+    pread_completion: xev.Completion = .{},
 
     pub fn deinit(self: *StaticState, allocator: std.mem.Allocator) void {
         std.posix.close(self.fd);
@@ -238,25 +240,8 @@ pub fn serveStaticFile(
         return;
     }
 
-    // Small file fast path: single allocation, pread directly into combined buffer
-    if (file_size <= config.STATIC_READ_SIZE) {
-        const combined = alloc.alloc(u8, headers_text.len + @as(usize, @intCast(file_size))) catch {
-            std.posix.close(fd);
-            self.send500InternalError();
-            return;
-        };
-        @memcpy(combined[0..headers_text.len], headers_text);
-        const bytes_read = std.posix.pread(fd, combined[headers_text.len..], 0) catch {
-            std.posix.close(fd);
-            self.send500InternalError();
-            return;
-        };
-        std.posix.close(fd);
-        self.sendRawResponse(combined[0 .. headers_text.len + bytes_read]);
-        return;
-    }
-
-    // Large file: send headers first, then pread+send loop
+    // Send headers first, then drive an async pread+send loop. Files up to
+    // STATIC_READ_SIZE complete in a single chunk; larger files span several.
     const read_buf = self.base_allocator.alloc(u8, config.STATIC_READ_SIZE) catch {
         std.posix.close(fd);
         self.send500InternalError();
@@ -288,7 +273,7 @@ fn onStaticHeadersSent(
     return .disarm;
 }
 
-/// Read the next chunk from file and send it.
+/// Submit an async pread for the next chunk from the file.
 fn sendNextChunk(self: *Connection) void {
     const ss = &self.static_state.?;
 
@@ -301,22 +286,55 @@ fn sendNextChunk(self: *Connection) void {
     const remaining = ss.file_size - ss.bytes_sent;
     const to_read = @min(remaining, ss.read_buf.len);
 
-    const bytes_read = std.posix.pread(ss.fd, ss.read_buf[0..to_read], ss.bytes_sent) catch {
-        self.close();
-        return;
+    // Async pread on the worker's xev loop (io_uring) — never blocks. The
+    // completion lives in StaticState (stable address until the read fires).
+    ss.pread_completion = .{
+        .op = .{ .pread = .{
+            .fd = ss.fd,
+            .buffer = .{ .slice = ss.read_buf[0..to_read] },
+            .offset = ss.bytes_sent,
+        } },
+        .userdata = self,
+        .callback = onStaticPreadComplete,
     };
+    self.pending_io_ops += 1;
+    self.loop.add(&ss.pread_completion);
+}
 
-    if (bytes_read == 0) {
-        // EOF before expected — file truncated
-        finishStaticFile(self);
-        return;
+/// Callback after an async pread completes — send the chunk we just read.
+fn onStaticPreadComplete(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    const self = castUserdata(Connection, userdata);
+    self.pending_io_ops -= 1;
+
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
     }
 
+    const bytes_read = result.pread catch |err| {
+        if (err == error.EOF) {
+            // File truncated under us — stop, send what was already delivered.
+            finishStaticFile(self);
+        } else {
+            self.close();
+        }
+        return .disarm;
+    };
+
+    const ss = &self.static_state.?;
     ss.bytes_sent += bytes_read;
 
-    // read_buf is stable during async send — pread overwrites it only in sendNextChunk,
-    // which runs after onStaticChunkSent fires. No dupe needed.
+    // read_buf is stable during the async send — it is overwritten only by the
+    // next pread, which is submitted from onStaticChunkSent after the send fires.
     self.submitSend(ss.read_buf[0..bytes_read], onStaticChunkSent, false);
+    return .disarm;
 }
 
 /// Callback after a static file chunk is sent — continue or finish.

--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -1,0 +1,80 @@
+// Static file serving — exercises the async pread+send path (issue #53).
+//
+// The dashboard route (dashboard/keyway.lua) serves dashboard/public at
+// /__keyway/dashboard, so we read those assets back over HTTP and compare
+// them byte-for-byte against disk. Files larger than STATIC_READ_SIZE (64 KB)
+// span multiple async pread chunks — the case where a blocking/truncating
+// read would corrupt the body.
+
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const base = () => globalThis.__KEYWAY_BASE;
+const PUBLIC = resolve(import.meta.dir, "../../dashboard/public");
+
+async function diskBytes(name: string): Promise<Uint8Array> {
+  return new Uint8Array(await Bun.file(resolve(PUBLIC, name)).arrayBuffer());
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+describe("static file serving", () => {
+  // Small file: served in a single pread chunk.
+  test("serves a small file intact (single chunk)", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/favicon.svg`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/svg+xml");
+
+    const got = new Uint8Array(await res.arrayBuffer());
+    const want = await diskBytes("favicon.svg");
+    expect(got.length).toBe(want.length);
+    expect(bytesEqual(got, want)).toBe(true);
+  });
+
+  // Large file (~470 KB): spans ~8 async pread chunks. This is the regression
+  // target for #53 — a blocking/truncating read would corrupt or short the body.
+  test("serves a large file intact across multiple chunks", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/main.js`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/javascript");
+
+    const got = new Uint8Array(await res.arrayBuffer());
+    const want = await diskBytes("main.js");
+    expect(got.length).toBe(want.length);
+    expect(Number(res.headers.get("content-length"))).toBe(want.length);
+    expect(bytesEqual(got, want)).toBe(true);
+  });
+
+  // Chunk-boundary case: ~92 KB file straddles the 64 KB chunk size.
+  test("serves a file that straddles the chunk boundary", async () => {
+    const res = await fetch(
+      `${base()}/__keyway/dashboard/fonts/JetBrainsMono-Regular.woff2`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("font/woff2");
+
+    const got = new Uint8Array(await res.arrayBuffer());
+    const want = await diskBytes("fonts/JetBrainsMono-Regular.woff2");
+    expect(got.length).toBe(want.length);
+    expect(bytesEqual(got, want)).toBe(true);
+  });
+
+  // ETag round-trip: a matching If-None-Match yields 304 with no body.
+  test("returns 304 for a matching ETag", async () => {
+    const first = await fetch(`${base()}/__keyway/dashboard/main.js`);
+    expect(first.status).toBe(200);
+    await first.arrayBuffer();
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
+
+    const second = await fetch(`${base()}/__keyway/dashboard/main.js`, {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+    expect((await second.text()).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #53

## Problem
Both the small-file fast path and the large-file chunk loop in `src/http/static.zig` used blocking `std.posix.pread()`, which stalls the worker's xev loop on slow storage — a proactor-model violation (cf. #29 for the proxy equivalent).

## Change
Collapse the two read sites into a single path: send headers, then stream the body via an **async pread+send loop** using the io_uring `.pread` completion op (lowers to `sqe.prep_read` with offset — no threadpool, no blocking on the worker thread).

- The small-file fast-path special case is removed; files up to `STATIC_READ_SIZE` (64 KB) now simply complete in a single chunk through the same loop.
- The pread `xev.Completion` lives in `StaticState` for a stable address until the read fires.
- `pending_io_ops` is incremented on submit / decremented in the callback, so a connection closing mid-read defers `deinit` until the read completes (same discipline as `startRead`).
- EOF (truncation under us) finishes gracefully with what was already delivered; other errors close the connection.

## Tests
Adds `tests/integration/static.test.ts` — the **first** integration coverage for static serving:
- small file (single chunk), large file ~470 KB (~8 async chunks), and a ~92 KB chunk-boundary file, each verified **byte-for-byte** against disk;
- ETag 304 round-trip.

`zig build test` and the full bun integration suite (19 tests) pass.