### PR TITLE
fix(proxy): make reverse proxy fully async (no blocking syscalls on the loop)

### DIFF
--- a/dashboard/keyway.lua
+++ b/dashboard/keyway.lua
@@ -197,6 +197,11 @@ keyway.static = {
 
 keyway.proxy = {
     ["/__keyway/grafana"] = { host = "127.0.0.1", port = 3000, redirect = "/__keyway/dashboard/grafana.html", strip_prefix = false },
+    -- Integration-test upstreams (see tests/integration/proxy.test.ts).
+    -- The live upstream is spawned by the test on this fixed port; the dead
+    -- one points at a closed port to exercise the 502 connect-failure path.
+    ["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true },
+    ["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true },
 }
 
 -- ─── Routes ──────────────────────────────────────────────────────────

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -38,6 +38,7 @@ const WorkerMetrics = @import("../observability/metrics.zig").WorkerMetrics;
 const metrics_mod = @import("../observability/metrics.zig");
 const prom = @import("../observability/prom.zig");
 const static_mod = @import("../http/static.zig");
+const proxy_mod = @import("../http/proxy.zig");
 
 const ParamArray = params.ParamArray;
 const QueryArray = params.QueryArray;
@@ -127,7 +128,7 @@ pub const CosocketState = struct {
 
 /// Connection handler - manages HTTP request/response lifecycle
 pub const Connection = struct {
-    pub const State = enum { reading, processing, writing, websocket, sse, streaming, static_file, closing };
+    pub const State = enum { reading, processing, writing, websocket, sse, streaming, static_file, proxying, closing };
     pub const List = std.DoublyLinkedList;
 
     // Intrusive linked list node for Server.connections tracking.
@@ -177,6 +178,9 @@ pub const Connection = struct {
 
     // Static file: non-null when serving a static file
     static_state: ?static_mod.StaticState = null,
+
+    // Reverse proxy: non-null while an upstream exchange is in flight
+    proxy_state: ?proxy_mod.ProxyState = null,
 
     // Per-request timeout: timer fires after REQUEST_TIMEOUT_MS, sending 504
     // Completions initialized to .{} per xev requirements (Pitfall 3: never undefined)
@@ -308,6 +312,10 @@ pub const Connection = struct {
         if (self.sse_state) |*ss| ss.deinit(self);
         // Clean up static file state
         if (self.static_state) |*ss| ss.deinit(self.base_allocator);
+        // Clean up reverse-proxy state (closes upstream fd, frees buffers).
+        // pending_io_ops gates maybeFinishClose, so any in-flight upstream op
+        // has already fired before deinit runs.
+        if (self.proxy_state) |*ps| ps.deinit(self.base_allocator);
         // Clean up TLS resources
         self.tls_state.deinit(self.base_allocator);
         std.posix.close(self.socket);
@@ -707,7 +715,7 @@ pub const Connection = struct {
 
         // Reverse proxy routes: forward matching prefixes to upstream servers
         if (self.router.matchProxy(clean_path)) |proxy_match| {
-            self.proxyRequest(request, proxy_match, self.arena.allocator());
+            proxy_mod.serveProxy(self, request, proxy_match);
             return null;
         }
 
@@ -879,108 +887,6 @@ pub const Connection = struct {
         } else {
             self.sendJsonResponse(alloc, 503, "Service Unavailable", "{\"error\":\"reload not available\"}");
         }
-    }
-
-    /// Reverse proxy: connect to upstream, forward request, relay response.
-    fn proxyRequest(self: *Connection, request: *const http.Request, proxy_match: Router.ProxyMatch, alloc: std.mem.Allocator) void {
-        const prefix = proxy_match.route.prefix;
-
-        // Bare prefix with a configured redirect → 302
-        if (proxy_match.route.redirect) |redirect| {
-            if (proxy_match.suffix.len == 0 or std.mem.eql(u8, proxy_match.suffix, "/")) {
-                const resp = std.fmt.allocPrint(alloc, "HTTP/1.1 302 Found\r\nLocation: {s}\r\nContent-Length: 0\r\n\r\n", .{redirect}) catch {
-                    error_response.sendError(self, .server_error, "proxy redirect failed");
-                    return;
-                };
-                self.logAccess(302);
-                self.sendRawResponse(resp);
-                return;
-            }
-        }
-
-        // Build upstream path
-        const raw_path = request.path;
-        const upstream_path: []const u8 = if (proxy_match.route.strip_prefix)
-            (if (raw_path.len >= prefix.len and std.mem.startsWith(u8, raw_path, prefix))
-                (if (raw_path[prefix.len..].len == 0) "/" else raw_path[prefix.len..])
-            else
-                "/")
-        else
-            raw_path;
-
-        // Connect to upstream
-        const stream = std.net.tcpConnectToHost(alloc, proxy_match.route.upstream_host, proxy_match.route.upstream_port) catch {
-            error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
-            return;
-        };
-        defer stream.close();
-
-        // Build upstream HTTP request
-        var req_buf = std.ArrayList(u8).initCapacity(alloc, 1024) catch {
-            error_response.sendErrorStatus(self, 502, "proxy request alloc failed");
-            return;
-        };
-        const req_writer = req_buf.writer(alloc);
-        std.fmt.format(req_writer, "{s} {s} HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n", .{
-            request.method,
-            upstream_path,
-            proxy_match.route.upstream_host,
-            proxy_match.route.upstream_port,
-        }) catch {
-            error_response.sendErrorStatus(self, 502, "proxy request build failed");
-            return;
-        };
-        for (request.headers) |h| {
-            if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
-            if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
-            std.fmt.format(req_writer, "{s}: {s}\r\n", .{ h.name, h.value }) catch {
-                error_response.sendErrorStatus(self, 502, "proxy header build failed");
-                return;
-            };
-        }
-        req_writer.writeAll("\r\n") catch {
-            error_response.sendErrorStatus(self, 502, "proxy request build failed");
-            return;
-        };
-
-        // Send request + body
-        stream.writeAll(req_buf.items) catch {
-            error_response.sendErrorStatus(self, 502, "proxy upstream write failed");
-            return;
-        };
-        if (request.body.len > 0) {
-            stream.writeAll(request.body) catch {
-                error_response.sendErrorStatus(self, 502, "proxy upstream body write failed");
-                return;
-            };
-        }
-
-        // Read entire upstream response
-        var resp_buf = std.ArrayList(u8).initCapacity(alloc, 4096) catch {
-            error_response.sendErrorStatus(self, 502, "proxy response alloc failed");
-            return;
-        };
-        var read_buf: [8192]u8 = undefined;
-        while (true) {
-            const n = stream.read(&read_buf) catch {
-                error_response.sendErrorStatus(self, 502, "proxy upstream read failed");
-                return;
-            };
-            if (n == 0) break;
-            resp_buf.appendSlice(alloc, read_buf[0..n]) catch {
-                error_response.sendErrorStatus(self, 502, "proxy response buffer failed");
-                return;
-            };
-        }
-
-        const upstream_response = resp_buf.items;
-        if (upstream_response.len == 0) {
-            error_response.sendErrorStatus(self, 502, "proxy upstream empty response");
-            return;
-        }
-
-        self.logAccess(200);
-        self.sendRawResponse(upstream_response);
     }
 
     fn onWrite(

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1,0 +1,285 @@
+//! Reverse proxy — async connect/send/recv to upstream, relay response to client.
+//!
+//! Zig-native, no Lua involvement. Route configuration via keyway.proxy.
+//! Proactor model: every upstream I/O step runs on the worker's xev loop
+//! (io_uring) and never blocks it.
+//!
+//! Response framing: we send `Connection: close` upstream and read until EOF,
+//! buffering the whole response before relaying it (no Content-Length/chunked
+//! parsing). Upstream hosts are pre-resolved to an address at route
+//! registration, so the data path never does DNS.
+//!
+//! Known gaps tracked as follow-ups: no upstream deadline (#72), access status
+//! always logged as 200 (#73).
+
+const std = @import("std");
+const xev = @import("xev");
+const handler_mod = @import("../core/handler.zig");
+const Connection = handler_mod.Connection;
+const http = @import("http.zig");
+const castUserdata = @import("../util/helpers.zig").castUserdata;
+const error_response = @import("error_response.zig");
+const router_mod = @import("router.zig");
+
+/// Size of each upstream recv chunk (bytes), appended to the response buffer.
+const RECV_CHUNK = 16384;
+
+/// State for an in-progress reverse-proxy exchange.
+///
+/// Owned by base_allocator so its address is stable across the async ops.
+/// Exactly one upstream completion is in flight at a time, so a single
+/// `completion` drives the connect → send → recv phases — never submit a new
+/// upstream op except from inside the previous op's callback.
+pub const ProxyState = struct {
+    upstream_fd: std.posix.socket_t,
+    completion: xev.Completion = .{},
+    request_buf: []const u8, // upstream request bytes (headers + body); outlives the send
+    sent: usize = 0, // bytes of request_buf already sent (short-send loop)
+    recv_buf: []u8, // fixed-size upstream recv chunk
+    response: std.ArrayListUnmanaged(u8) = .{}, // accumulated upstream response
+
+    pub fn deinit(self: *ProxyState, allocator: std.mem.Allocator) void {
+        std.posix.close(self.upstream_fd);
+        allocator.free(self.request_buf);
+        allocator.free(self.recv_buf);
+        self.response.deinit(allocator);
+    }
+};
+
+/// Reverse proxy a request to its upstream. Called from handler.zig routeRequest.
+pub fn serveProxy(self: *Connection, request: *const http.Request, proxy_match: router_mod.Router.ProxyMatch) void {
+    const route = proxy_match.route;
+    const prefix = route.prefix;
+
+    // Bare prefix with a configured redirect → 302 (synchronous, no upstream).
+    if (route.redirect) |redirect| {
+        if (proxy_match.suffix.len == 0 or std.mem.eql(u8, proxy_match.suffix, "/")) {
+            const resp = std.fmt.allocPrint(self.arena.allocator(), "HTTP/1.1 302 Found\r\nLocation: {s}\r\nContent-Length: 0\r\n\r\n", .{redirect}) catch {
+                error_response.sendError(self, .server_error, "proxy redirect failed");
+                return;
+            };
+            self.logAccess(302);
+            self.sendRawResponse(resp);
+            return;
+        }
+    }
+
+    // Compute the upstream request-target path.
+    const raw_path = request.path;
+    const upstream_path: []const u8 = if (route.strip_prefix)
+        (if (raw_path.len >= prefix.len and std.mem.startsWith(u8, raw_path, prefix))
+            (if (raw_path[prefix.len..].len == 0) "/" else raw_path[prefix.len..])
+        else
+            "/")
+    else
+        raw_path;
+
+    // Build the upstream request bytes on base_allocator: they must outlive the
+    // per-request arena and keep a stable address for the async send.
+    const request_buf = buildUpstreamRequest(self.base_allocator, request, route, upstream_path) catch {
+        error_response.sendErrorStatus(self, 502, "proxy request build failed");
+        return;
+    };
+
+    const sock = std.posix.socket(
+        std.posix.AF.INET,
+        std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
+        0,
+    ) catch {
+        self.base_allocator.free(request_buf);
+        error_response.sendErrorStatus(self, 502, "proxy socket creation failed");
+        return;
+    };
+
+    const recv_buf = self.base_allocator.alloc(u8, RECV_CHUNK) catch {
+        std.posix.close(sock);
+        self.base_allocator.free(request_buf);
+        error_response.sendErrorStatus(self, 502, "proxy buffer alloc failed");
+        return;
+    };
+
+    self.proxy_state = .{
+        .upstream_fd = sock,
+        .request_buf = request_buf,
+        .recv_buf = recv_buf,
+    };
+    self.state = .proxying;
+
+    // Async connect to the pre-resolved upstream address.
+    const ps = &self.proxy_state.?;
+    ps.completion = .{
+        .op = .{ .connect = .{ .socket = sock, .addr = route.upstream_addr } },
+        .userdata = self,
+        .callback = onProxyConnect,
+    };
+    self.pending_io_ops += 1;
+    self.loop.add(&ps.completion);
+}
+
+/// Build the HTTP/1.1 request to send upstream: request line, rewritten Host,
+/// forced `Connection: close`, forwarded client headers, then the body.
+fn buildUpstreamRequest(
+    allocator: std.mem.Allocator,
+    request: *const http.Request,
+    route: router_mod.ProxyRoute,
+    upstream_path: []const u8,
+) ![]const u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(allocator);
+
+    const writer = buf.writer(allocator);
+    try writer.print("{s} {s} HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n", .{
+        request.method,
+        upstream_path,
+        route.upstream_host,
+        route.upstream_port,
+    });
+    for (request.headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
+        if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
+        try writer.print("{s}: {s}\r\n", .{ h.name, h.value });
+    }
+    try writer.writeAll("\r\n");
+    if (request.body.len > 0) try buf.appendSlice(allocator, request.body);
+
+    return try buf.toOwnedSlice(allocator);
+}
+
+/// Connect completed — start sending the upstream request.
+fn onProxyConnect(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    const self = castUserdata(Connection, userdata);
+    self.pending_io_ops -= 1;
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    _ = result.connect catch {
+        proxyFail(self, 502, "proxy upstream connect failed");
+        return .disarm;
+    };
+    submitUpstreamSend(self);
+    return .disarm;
+}
+
+/// Submit a send of the not-yet-sent tail of the upstream request.
+fn submitUpstreamSend(self: *Connection) void {
+    const ps = &self.proxy_state.?;
+    ps.completion = .{
+        .op = .{ .send = .{ .fd = ps.upstream_fd, .buffer = .{ .slice = ps.request_buf[ps.sent..] } } },
+        .userdata = self,
+        .callback = onProxyUpstreamSent,
+    };
+    self.pending_io_ops += 1;
+    self.loop.add(&ps.completion);
+}
+
+/// A send completed — loop on short sends, then start reading the response.
+fn onProxyUpstreamSent(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    const self = castUserdata(Connection, userdata);
+    self.pending_io_ops -= 1;
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    const n = result.send catch {
+        proxyFail(self, 502, "proxy upstream write failed");
+        return .disarm;
+    };
+    const ps = &self.proxy_state.?;
+    ps.sent += n;
+    if (ps.sent < ps.request_buf.len) {
+        submitUpstreamSend(self); // short send — send the remainder
+        return .disarm;
+    }
+    submitUpstreamRecv(self);
+    return .disarm;
+}
+
+/// Submit a recv of the next upstream response chunk.
+fn submitUpstreamRecv(self: *Connection) void {
+    const ps = &self.proxy_state.?;
+    ps.completion = .{
+        .op = .{ .recv = .{ .fd = ps.upstream_fd, .buffer = .{ .slice = ps.recv_buf } } },
+        .userdata = self,
+        .callback = onProxyUpstreamRecv,
+    };
+    self.pending_io_ops += 1;
+    self.loop.add(&ps.completion);
+}
+
+/// A recv completed — accumulate the chunk and keep reading until EOF.
+fn onProxyUpstreamRecv(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    const self = castUserdata(Connection, userdata);
+    self.pending_io_ops -= 1;
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    const n = result.recv catch |err| {
+        // EOF (upstream honored Connection: close) means the response is complete.
+        if (err == error.EOF) {
+            forwardProxyResponse(self);
+        } else {
+            proxyFail(self, 502, "proxy upstream read failed");
+        }
+        return .disarm;
+    };
+    const ps = &self.proxy_state.?;
+    ps.response.appendSlice(self.base_allocator, ps.recv_buf[0..n]) catch {
+        proxyFail(self, 502, "proxy response buffer failed");
+        return .disarm;
+    };
+    submitUpstreamRecv(self);
+    return .disarm;
+}
+
+/// Relay the buffered upstream response to the client and tear down proxy state.
+fn forwardProxyResponse(self: *Connection) void {
+    const ps = &self.proxy_state.?;
+    if (ps.response.items.len == 0) {
+        proxyFail(self, 502, "proxy upstream empty response");
+        return;
+    }
+    self.logAccess(200);
+    // sendRawResponse arena-dupes the bytes before queuing the send, so the
+    // proxy_state buffers can be freed immediately afterward. State becomes
+    // .writing; onWrite → handleHttpPostWrite resumes keep-alive.
+    self.sendRawResponse(ps.response.items);
+    cleanupProxy(self);
+}
+
+/// Send an error to the client and tear down proxy state. Safe to call from any
+/// upstream callback: we are inside the only in-flight op (already decremented),
+/// so no upstream completion references the fd we close here.
+fn proxyFail(self: *Connection, status: u16, internal_msg: []const u8) void {
+    cleanupProxy(self);
+    error_response.sendErrorStatus(self, status, internal_msg);
+}
+
+fn cleanupProxy(self: *Connection) void {
+    if (self.proxy_state) |*ps| {
+        ps.deinit(self.base_allocator);
+        self.proxy_state = null;
+    }
+}

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -89,8 +89,9 @@ pub const StaticRoute = struct {
 /// Reverse proxy route configuration.
 pub const ProxyRoute = struct {
     prefix: []const u8, // e.g. "/__keyway/grafana"
-    upstream_host: []const u8, // e.g. "127.0.0.1"
+    upstream_host: []const u8, // e.g. "127.0.0.1" — kept for the upstream Host header
     upstream_port: u16, // e.g. 3000
+    upstream_addr: std.net.Address, // resolved once at registration (no per-request DNS)
     redirect: ?[]const u8 = null, // if set, bare prefix requests 302 to this URL
     strip_prefix: bool = true, // if false, forward the full path to upstream
 };
@@ -134,7 +135,13 @@ pub const Router = struct {
     }
 
     /// Register a reverse proxy route.
+    /// Resolves the upstream host to an address at registration time (blocking DNS
+    /// here is fine — it's config load, not the request hot path) so the proactor
+    /// data path never blocks on resolution. Mirrors nginx's resolve-at-config
+    /// default. Picks the first IPv4 result; errors if the host has none.
     pub fn addProxyRoute(self: *Router, prefix: []const u8, upstream_host: []const u8, upstream_port: u16, redirect: []const u8, strip_prefix: bool) !void {
+        const upstream_addr = try resolveUpstream(self.allocator, upstream_host, upstream_port);
+
         const prefix_copy = try self.allocator.dupe(u8, prefix);
         const host_copy = try self.allocator.dupe(u8, upstream_host);
         const redirect_copy: ?[]const u8 = if (redirect.len > 0) try self.allocator.dupe(u8, redirect) else null;
@@ -142,9 +149,22 @@ pub const Router = struct {
             .prefix = prefix_copy,
             .upstream_host = host_copy,
             .upstream_port = upstream_port,
+            .upstream_addr = upstream_addr,
             .redirect = redirect_copy,
             .strip_prefix = strip_prefix,
         });
+    }
+
+    /// Resolve an upstream host:port to the first available IPv4 address.
+    /// IPv6 / multiple upstream targets are intentionally out of scope for now.
+    fn resolveUpstream(allocator: std.mem.Allocator, host: []const u8, port: u16) !std.net.Address {
+        const list = try std.net.getAddressList(allocator, host, port);
+        defer list.deinit();
+        for (list.addrs) |addr| {
+            if (addr.any.family == std.posix.AF.INET) return addr;
+        }
+        log.err().string("msg", "proxy upstream has no IPv4 address").string("host", host).log();
+        return error.NoIpv4Address;
     }
 
     pub const ProxyMatch = PrefixMatch(ProxyRoute);

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,0 +1,93 @@
+// Reverse proxy — exercises the async connect/send/recv path (issue #29).
+//
+// The dashboard config (dashboard/keyway.lua) registers two proxy routes:
+//   /__keyway/test-proxy       -> 127.0.0.1:38291 (the upstream spawned below)
+//   /__keyway/test-proxy-dead  -> 127.0.0.1:1     (closed port -> 502)
+// strip_prefix=true, so /__keyway/test-proxy/small forwards as /small upstream.
+//
+// We spin up a tiny Bun upstream here so the proxy has something real to talk
+// to. The large-response case is the regression target: the upstream reply
+// spans many async recv chunks, where a blocking/truncating relay would
+// corrupt or short the body.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import type { Server } from "bun";
+
+const base = () => globalThis.__KEYWAY_BASE;
+const UPSTREAM_PORT = 38291;
+const LARGE_SIZE = 500_000; // ~32 chunks at a 16 KB recv buffer
+const LARGE_BODY = "x".repeat(LARGE_SIZE);
+
+let upstream: Server | null = null;
+
+beforeAll(() => {
+  upstream = Bun.serve({
+    port: UPSTREAM_PORT,
+    async fetch(req) {
+      const url = new URL(req.url);
+      switch (url.pathname) {
+        case "/small":
+          return new Response("hello from upstream", {
+            headers: { "X-Upstream": "yes" },
+          });
+        case "/large":
+          return new Response(LARGE_BODY);
+        case "/echo":
+          return new Response(await req.text());
+        case "/header":
+          // Reflect a forwarded request header back in the body.
+          return new Response(req.headers.get("X-Client-Header") ?? "(none)");
+        case "/status500":
+          return new Response("upstream error", { status: 500 });
+        default:
+          return new Response("not found", { status: 404 });
+      }
+    },
+  });
+});
+
+afterAll(() => {
+  upstream?.stop(true);
+  upstream = null;
+});
+
+describe("reverse proxy", () => {
+  test("forwards a small GET and relays the upstream body + headers", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/small`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello from upstream");
+    expect(res.headers.get("x-upstream")).toBe("yes");
+  });
+
+  // Regression target for #29: response spans many async recv chunks.
+  test("relays a large upstream response intact across many chunks", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/large`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body.length).toBe(LARGE_SIZE);
+    expect(body).toBe(LARGE_BODY);
+  });
+
+  test("forwards the request body to the upstream (POST)", async () => {
+    const payload = "the quick brown fox".repeat(1000);
+    const res = await fetch(`${base()}/__keyway/test-proxy/echo`, {
+      method: "POST",
+      body: payload,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(payload);
+  });
+
+  test("forwards request headers to the upstream", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/header`, {
+      headers: { "X-Client-Header": "keyway-rocks" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("keyway-rocks");
+  });
+
+  test("returns 502 when the upstream connection is refused", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy-dead/whatever`);
+    expect(res.status).toBe(502);
+  });
+});


### PR DESCRIPTION
Closes #29

Part of the proactor-violation cluster with #53 / PR #71 (static file `pread`).

## Problem
`proxyRequest()` used `std.net.tcpConnectToHost()`, `stream.writeAll()`, and a blocking `stream.read()` loop — all synchronous syscalls on the worker thread, stalling **every** connection on that xev loop. Direct violation of the proactor model (MANIFEST.md).

## Change
Rewrite the reverse proxy as an async io_uring state machine in a dedicated **`src/http/proxy.zig`** module (mirroring `static.zig`):

```
connect → send (short-send loop) → recv until EOF → relay to client
```

- Exactly **one upstream op is in flight at a time**, so a single reused `xev.Completion` in `ProxyState` drives all phases (invariant documented on the field).
- `pending_io_ops` is incremented on every upstream op and decremented in its callback, so a mid-flight `close()` defers `deinit` until the op fires (same discipline as `static`/`startRead`). `Connection.deinit` tears down the upstream fd + buffers.
- Response framing unchanged: send `Connection: close` upstream, read until EOF, buffer, relay via `sendRawResponse` (which arena-dupes before queuing, so proxy state is freed immediately after).
- Short sends on the upstream request are handled with a send-offset loop.

### DNS: pre-resolve at registration
`addProxyRoute` now resolves the upstream host to an address **once at route registration** (`getAddressList`, first IPv4) so the data path never does DNS — matching nginx's resolve-at-config default. IPv6 / multiple upstream targets are intentionally out of scope.

**Trade-off (not a regression):** hot reload (`/__keyway/reload`) re-runs `processProxyTable` → `addProxyRoute` on each worker's loop, so upstream hosts are re-resolved there. For IP-literal upstreams (all current routes) this is a fast sockaddr fill; for public hostnames it's a brief blocking DNS round trip per route per worker during reload. This is the cost of "no DNS on the hot path" and is strictly better than the old per-request resolution. Fully async DNS remains a separate, deferred subproject.

## Tests
`tests/integration/proxy.test.ts` with a Bun upstream (route registered in `dashboard/keyway.lua`, the project's integration-test config):
- small relay (body + headers),
- **500 KB response across many async recv chunks** (the regression target),
- POST request-body forwarding,
- request-header forwarding,
- 502 on connection refused.

`zig build test` and the full bun integration suite pass.

## Follow-ups filed (anti-drift)
- #72 — no upstream timeout (hung/non-compliant upstream ties up a connection)
- #73 — proxy always logs access status 200 regardless of upstream status