### PR TITLE
fix(ring): fail loud on CompletionRing overflow instead of silent drop

### DIFF
--- a/src/io/ring.zig
+++ b/src/io/ring.zig
@@ -7,7 +7,6 @@
 //! Fixed-size (RING_DEPTH=16), per-connection, inline, reset per request.
 
 const std = @import("std");
-const log = @import("../observability/log.zig");
 const config = @import("../util/config.zig");
 const TlsMode = @import("io_request.zig").TlsMode;
 const ErrorCategory = @import("../http/error_response.zig").ErrorCategory;
@@ -93,9 +92,13 @@ pub const CompletionRing = struct {
     pub const MAX_DEPTH = config.RING_DEPTH;
 
     pub inline fn push(self: *CompletionRing, entry: CQEntry) void {
+        // Unreachable by construction: SubmissionRing.MAX_DEPTH == CompletionRing.MAX_DEPTH
+        // and each SQE yields exactly one CQE into a ring reset per batch, so the CQ can
+        // never exceed capacity. If this fires, the SQ/CQ symmetry invariant has been
+        // broken — fail loud rather than silently drop a completion (which would leave the
+        // waiting Lua coroutine hung or hand it an out-of-range result).
         if (self.tail >= MAX_DEPTH) {
-            log.err().string("msg", "CompletionRing overflow").int("tail", self.tail).int("max", MAX_DEPTH).log();
-            return;
+            std.debug.panic("CompletionRing overflow: tail={d} max={d}; SQ/CQ invariant violated", .{ self.tail, MAX_DEPTH });
         }
         self.entries[self.tail] = entry;
         self.tail += 1;
@@ -168,6 +171,21 @@ test "CompletionRing: push/get/reset" {
     try std.testing.expectEqual(@as(i32, 6), cq.get(1).result);
     try std.testing.expectEqualStrings("PONG\r\n", cq.get(1).buf.?);
     try std.testing.expect(cq.get(0).buf == null);
+
+    cq.reset();
+    try std.testing.expectEqual(@as(u8, 0), cq.tail);
+}
+
+test "CompletionRing: fills to capacity without overflow" {
+    var cq = CompletionRing{};
+
+    // Fill to exactly MAX_DEPTH — the boundary just below the overflow guard.
+    // One more push would panic (SQ/CQ invariant violation), which is the spec.
+    for (0..CompletionRing.MAX_DEPTH) |i| {
+        cq.push(.{ .result = @intCast(i) });
+    }
+    try std.testing.expectEqual(@as(u8, CompletionRing.MAX_DEPTH), cq.tail);
+    try std.testing.expectEqual(@as(i32, CompletionRing.MAX_DEPTH - 1), cq.get(CompletionRing.MAX_DEPTH - 1).result);
 
     cq.reset();
     try std.testing.expectEqual(@as(u8, 0), cq.tail);


### PR DESCRIPTION
Closes #41

## What changed
`CompletionRing.push()` previously logged a warning and `return`ed on overflow — silently dropping the I/O completion. Now it `std.debug.panic`s instead.

A dropped CQE is corrupting: the waiting Lua coroutine either hangs (if `pending_completions` ever skews) or is handed an out-of-range result by `ring_result`. `std.debug.panic` fires in **all** build modes (unlike `std.debug.assert`, which is stripped in release — see `.claude/rules/zig-gotchas.md`).

Also: removed the now-orphaned `log` import, and added a capacity-boundary unit test (`CompletionRing: fills to capacity without overflow`).

## Why panic, not `error{RingFull}` (the SubmissionRing pattern)
**Honest framing:** the overflow is **unreachable today by construction** — `SubmissionRing.MAX_DEPTH == CompletionRing.MAX_DEPTH`, each SQE produces exactly one CQE, and the CQ is reset per batch. So `cq.tail` can never exceed capacity through the current submit path. The issue's literal "17th completion vanishes → hang" does not reproduce against today's code.

This is therefore a **broken-invariant / programmer-error** guard, not a runtime condition:

- `SubmissionRing.push` returns `error{RingFull}` because SQ overflow happens **at the Lua boundary**, where `lua.raiseError()` converts it to a clean request failure. That's the right tool for a runtime condition.
- CQ overflow happens **inside xev callbacks** with no Lua context — `raiseError` is impossible there, and threading a typed error through all ~25 call sites (several mid-batch in the event loop) would be large churn to handle a path that cannot occur. That collides with CLAUDE.md's "no error handling for impossible scenarios / surgical changes."

Fail-loud documents the invariant and makes a future SQ/CQ symmetry break surface **immediately** instead of silently corrupting or hanging a request.

If the reviewer prefers the typed-error refactor across all call sites, that's a re-plan rather than a tweak — happy to take it there.

## Spun off (anti-drift)
- #75 — `CompletionRing.get()` uses `std.debug.assert` as a runtime bounds guard (same release-stripped defect class, distinct location; index is Lua-influenced).

## Verification
- `zig build` — clean
- `zig build test` — green (includes new boundary test)
- Full bun integration suite deferred to `/verify-close`.