### PR TITLE
refactor(zig): migrate 0.15.0 -> 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
 
       - name: Install OpenSSL dev headers
         run: sudo apt-get update && sudo apt-get install -y libssl-dev
@@ -33,7 +33,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
 
       - name: Install OpenSSL dev headers
         run: sudo apt-get update && sudo apt-get install -y libssl-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
 
       - name: Install OpenSSL dev headers
         run: sudo apt-get update && sudo apt-get install -y libssl-dev

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,20 @@ node_modules/
 # Planning artifacts
 .planning/
 
+# Serena (local semantic-nav tooling)
+.serena/
+
+# Regenerable analysis artifacts (review skill, graphify skill)
+review/
+graphify-out/
+src/graphify-out/
+
 # Test results
 tests/test-results/
 
 # Profiling
 perf.data*
 *.svg
+
+# Zig fetched dependency cache (regenerable from build.zig.zon)
+zig-pkg/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates xz-utils libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Zig 0.15.0
-ADD https://ziglang.org/download/0.15.0/zig-x86_64-linux-0.15.0.tar.xz /tmp/zig.tar.xz
+# Install Zig 0.16.0
+ADD https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz /tmp/zig.tar.xz
 RUN tar -xf /tmp/zig.tar.xz -C /opt && \
-    ln -s /opt/zig-x86_64-linux-0.15.0/zig /usr/local/bin/zig && \
+    ln -s /opt/zig-x86_64-linux-0.16.0/zig /usr/local/bin/zig && \
     rm /tmp/zig.tar.xz
 
 WORKDIR /build

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,10 +5,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Zig 0.15.0
-ADD https://ziglang.org/download/0.15.0/zig-x86_64-linux-0.15.0.tar.xz /tmp/zig.tar.xz
+# Install Zig 0.16.0
+ADD https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz /tmp/zig.tar.xz
 RUN tar -xf /tmp/zig.tar.xz -C /opt && \
-    ln -s /opt/zig-x86_64-linux-0.15.0/zig /usr/local/bin/zig && \
+    ln -s /opt/zig-x86_64-linux-0.16.0/zig /usr/local/bin/zig && \
     rm /tmp/zig.tar.xz
 
 # Install Bun

--- a/build.zig
+++ b/build.zig
@@ -83,14 +83,14 @@ fn addSharedDeps(
     compile.root_module.addImport("stdlib", b.createModule(.{
         .root_source_file = b.path("lua/stdlib.zig"),
     }));
-    compile.addCSourceFile(.{
+    compile.root_module.addCSourceFile(.{
         .file = b.path("vendor/picohttpparser.c"),
         .flags = &.{"-std=c99"},
     });
-    compile.addIncludePath(b.path("vendor"));
-    compile.linkLibC();
-    compile.linkSystemLibrary("ssl");
-    compile.linkSystemLibrary("crypto");
+    compile.root_module.addIncludePath(b.path("vendor"));
+    compile.root_module.link_libc = true;
+    compile.root_module.linkSystemLibrary("ssl", .{});
+    compile.root_module.linkSystemLibrary("crypto", .{});
 
     // GCC 15's crt1.o has .sframe sections with R_X86_64_PC64 relocations that
     // Zig's bundled lld can't handle. --gc-sections discards unreferenced .sframe.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,25 +1,25 @@
 .{
     .name = .keyway,
     .version = "0.1.0",
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0x9095a4ba39ca44a8,
 
     .dependencies = .{
         .libxev = .{
-            .url = "https://github.com/mitchellh/libxev/archive/refs/heads/main.tar.gz",
-            .hash = "libxev-0.0.0-86vtc689EwAjQWysidPm9NKkAwwUNByiE3kZTg_xu0Hp",
+            .url = "https://github.com/mitchellh/libxev/archive/9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf.tar.gz",
+            .hash = "libxev-0.0.0-86vtcwIRFADbH4hk-EjROXxlrKIRPQdA41XiTSytYO-F",
         },
         .luajit = .{
-            .url = "https://github.com/sackosoft/zig-luajit/archive/refs/heads/main.tar.gz",
-            .hash = "luajit-2.1.0-nMGF0kPDAwCHuZVz5A5rFIuxewhLyhCBaar1YJbtICyi",
+            .url = "https://github.com/sackosoft/zig-luajit/archive/11887ffa5b03788c05d23e64f2aafb20b645570a.tar.gz",
+            .hash = "luajit-3.0.0-nMGF0vfCAwBfUsknnnrxFWEDZ4G6sOgppH6DGzWgn7fV",
         },
         .metrics = .{
-            .url = "https://github.com/karlseguin/metrics.zig/archive/28cf547974144d827b5f85c07af7f9ec72c302dc.tar.gz",
-            .hash = "metrics-0.0.0-W7G4ePy_AQBozb1s8-avLxHOd4thMO92zKXDW84tmAhf",
+            .url = "https://github.com/karlseguin/metrics.zig/archive/1621f82e7ecf2b3dddf5730bf52761af354a7080.tar.gz",
+            .hash = "metrics-0.0.0-W7G4eJOgAQDBacPAeqGCaY8gV7zuddUQyikGNq7nDPds",
         },
         .logz = .{
-            .url = "https://github.com/karlseguin/log.zig/archive/b4a0b6b38d8fad1b94649046a967a700df5ce576.tar.gz",
-            .hash = "logz-0.0.0-O9YWXraFAgBQxWV4eh_4wp9axpoLhrzTIpYws4oxMLYh",
+            .url = "https://github.com/karlseguin/log.zig/archive/7fa8de39ad4d4adc54fce4d9bb0b6bc6c0076592.tar.gz",
+            .hash = "logz-0.0.0-O9YWXsllAgBq-S0z6q8AInWjei8h7polkVVRzJIGE-jW",
         },
     },
 

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -28,6 +28,7 @@ const config = @import("../util/config.zig");
 const params = @import("../http/params.zig");
 const conn_tls = @import("../tls/conn_tls.zig");
 const castUserdata = @import("../util/helpers.zig").castUserdata;
+const helpers = @import("../util/helpers.zig");
 const conn_sse = @import("../protocol/conn_sse.zig");
 const conn_ws = @import("../protocol/conn_ws.zig");
 const conn_stream = @import("../protocol/conn_stream.zig");
@@ -68,7 +69,7 @@ const LARGE_RESPONSE_THRESHOLD = config.LARGE_RESPONSE_THRESHOLD;
 
 /// Per-request HTTP state — reset between keep-alive requests.
 pub const HttpState = struct {
-    request_start_ns: i128 = 0,
+    request_start_ns: i64 = 0,
     request_method: []const u8 = "",
     request_path: []const u8 = "",
     request_raw_len: usize = 0, // total bytes consumed by current request (headers + body)
@@ -292,7 +293,7 @@ pub const Connection = struct {
                 self.lua_state.lua.unref(Lua.PseudoIndex.Registry, s.coroutine_ref);
             }
             // Close leaked outbound fd
-            if (s.outbound_fd != -1) std.posix.close(s.outbound_fd);
+            if (s.outbound_fd != -1) helpers.closeFd(s.outbound_fd);
             // Free outbound TLS state if mid-handshake (#21)
             s.cleanupTls(self.base_allocator);
         }
@@ -310,7 +311,7 @@ pub const Connection = struct {
         if (self.static_state) |*ss| ss.deinit(self.base_allocator);
         // Clean up TLS resources
         self.tls_state.deinit(self.base_allocator);
-        std.posix.close(self.socket);
+        helpers.closeFd(self.socket);
         self.arena.deinit();
         // param_cache/query_cache are inline structs, no deinit needed
         self.base_allocator.free(self.read_buffer.data);
@@ -545,7 +546,7 @@ pub const Connection = struct {
     }
 
     pub fn logAccess(self: *Connection, status: u16) void {
-        const dur_us: i64 = @intCast(@divTrunc(std.time.nanoTimestamp() - self.http_state.request_start_ns, 1000));
+        const dur_us: i64 = @intCast(@divTrunc(helpers.monotonicNanos() - self.http_state.request_start_ns, 1000));
         log.accessLog(self.http_state.request_method, self.http_state.request_path, status, dur_us);
         // Record metrics (latency + error tracking)
         const latency_us: u64 = @intCast(@max(0, dur_us));
@@ -669,7 +670,7 @@ pub const Connection = struct {
     /// error response is already in flight).
     pub fn handleRequest(self: *Connection) void {
         self.state = .processing;
-        self.http_state.request_start_ns = std.time.nanoTimestamp();
+        self.http_state.request_start_ns = helpers.monotonicNanos();
 
         const request = self.parseRequest() catch return;
         // Headers received successfully — cancel header timeout
@@ -759,14 +760,15 @@ pub const Connection = struct {
         prom.recordResponseBodySize(response.body.len);
         // Pre-size to avoid repeated ArrayList growth in arena (old buffers can't be freed)
         const estimated = response.body.len + 512;
-        var response_buf = try std.ArrayList(u8).initCapacity(alloc, estimated);
-        try response.serialize(response_buf.writer(alloc));
+        var response_buf: std.Io.Writer.Allocating = try .initCapacity(alloc, estimated);
+        try response.serialize(&response_buf.writer);
+        const response_bytes = response_buf.writer.buffered();
 
         if (self.ws_state != null) {
-            log.debug().string("msg", "ws response buf").int("len", response_buf.items.len).string("content", response_buf.items).log();
+            log.debug().string("msg", "ws response buf").int("len", response_bytes.len).string("content", response_bytes).log();
         }
 
-        self.submitSend(response_buf.items, onWrite, false);
+        self.submitSend(response_bytes, onWrite, false);
     }
 
     /// Submit a send on this connection's socket.
@@ -908,20 +910,39 @@ pub const Connection = struct {
         else
             raw_path;
 
-        // Connect to upstream
-        const stream = std.net.tcpConnectToHost(alloc, proxy_match.route.upstream_host, proxy_match.route.upstream_port) catch {
-            error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
-            return;
+        // Connect to upstream. std.net is gone in 0.16; this blocking client
+        // uses std.Io.net via a throwaway Threaded io. NOTE: this whole proxy
+        // path blocks the worker thread and should move to async libxev (#29).
+        var proxy_io: std.Io.Threaded = .init(alloc, .{});
+        defer proxy_io.deinit();
+        const pio = proxy_io.io();
+
+        const stream = blk: {
+            if (std.Io.net.IpAddress.parse(proxy_match.route.upstream_host, proxy_match.route.upstream_port)) |ipaddr| {
+                break :blk ipaddr.connect(pio, .{ .mode = .stream }) catch {
+                    error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
+                    return;
+                };
+            } else |_| {
+                const hostname = std.Io.net.HostName.init(proxy_match.route.upstream_host) catch {
+                    error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
+                    return;
+                };
+                break :blk hostname.connect(pio, proxy_match.route.upstream_port, .{ .mode = .stream }) catch {
+                    error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
+                    return;
+                };
+            }
         };
-        defer stream.close();
+        defer stream.close(pio);
 
         // Build upstream HTTP request
-        var req_buf = std.ArrayList(u8).initCapacity(alloc, 1024) catch {
+        var req_buf: std.Io.Writer.Allocating = std.Io.Writer.Allocating.initCapacity(alloc, 1024) catch {
             error_response.sendErrorStatus(self, 502, "proxy request alloc failed");
             return;
         };
-        const req_writer = req_buf.writer(alloc);
-        std.fmt.format(req_writer, "{s} {s} HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n", .{
+        const req_writer = &req_buf.writer;
+        req_writer.print("{s} {s} HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n", .{
             request.method,
             upstream_path,
             proxy_match.route.upstream_host,
@@ -933,7 +954,7 @@ pub const Connection = struct {
         for (request.headers) |h| {
             if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
             if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
-            std.fmt.format(req_writer, "{s}: {s}\r\n", .{ h.name, h.value }) catch {
+            req_writer.print("{s}: {s}\r\n", .{ h.name, h.value }) catch {
                 error_response.sendErrorStatus(self, 502, "proxy header build failed");
                 return;
             };
@@ -944,36 +965,30 @@ pub const Connection = struct {
         };
 
         // Send request + body
-        stream.writeAll(req_buf.items) catch {
+        var send_buf: [8192]u8 = undefined;
+        var upstream_writer = stream.writer(pio, &send_buf);
+        upstream_writer.interface.writeAll(req_buf.writer.buffered()) catch {
             error_response.sendErrorStatus(self, 502, "proxy upstream write failed");
             return;
         };
         if (request.body.len > 0) {
-            stream.writeAll(request.body) catch {
+            upstream_writer.interface.writeAll(request.body) catch {
                 error_response.sendErrorStatus(self, 502, "proxy upstream body write failed");
                 return;
             };
         }
-
-        // Read entire upstream response
-        var resp_buf = std.ArrayList(u8).initCapacity(alloc, 4096) catch {
-            error_response.sendErrorStatus(self, 502, "proxy response alloc failed");
+        upstream_writer.interface.flush() catch {
+            error_response.sendErrorStatus(self, 502, "proxy upstream write failed");
             return;
         };
-        var read_buf: [8192]u8 = undefined;
-        while (true) {
-            const n = stream.read(&read_buf) catch {
-                error_response.sendErrorStatus(self, 502, "proxy upstream read failed");
-                return;
-            };
-            if (n == 0) break;
-            resp_buf.appendSlice(alloc, read_buf[0..n]) catch {
-                error_response.sendErrorStatus(self, 502, "proxy response buffer failed");
-                return;
-            };
-        }
 
-        const upstream_response = resp_buf.items;
+        // Read entire upstream response (blocks until upstream closes)
+        var recv_buf: [8192]u8 = undefined;
+        var upstream_reader = stream.reader(pio, &recv_buf);
+        const upstream_response = upstream_reader.interface.allocRemaining(alloc, .unlimited) catch {
+            error_response.sendErrorStatus(self, 502, "proxy upstream read failed");
+            return;
+        };
         if (upstream_response.len == 0) {
             error_response.sendErrorStatus(self, 502, "proxy upstream empty response");
             return;

--- a/src/core/server.zig
+++ b/src/core/server.zig
@@ -7,6 +7,7 @@ const LuaState = @import("../lua/lua_state.zig").LuaState;
 const bpf_reuseport = @import("../io/bpf_reuseport.zig");
 const TlsContext = @import("../tls/tls.zig").TlsContext;
 const castUserdata = @import("../util/helpers.zig").castUserdata;
+const helpers = @import("../util/helpers.zig");
 const sse = @import("../protocol/sse.zig");
 const SseRegistry = sse.SseRegistry;
 const SseBroadcastBus = sse.SseBroadcastBus;
@@ -24,7 +25,7 @@ pub const Server = struct {
     allocator: std.mem.Allocator,
     loop: *xev.Loop,
     socket: std.posix.socket_t,
-    address: std.net.Address,
+    address: std.Io.net.IpAddress,
     accept_completion: xev.Completion,
     accept_cancel_completion: xev.Completion = .{},
     pool_sweep_completion: xev.Completion = undefined,
@@ -63,15 +64,16 @@ pub const Server = struct {
         metrics: *WorkerMetrics,
     ) !Server {
         // Parse address
-        const addr = try std.net.Address.parseIp(config.host, config.port);
+        const addr = try std.Io.net.IpAddress.parse(config.host, config.port);
 
         // Create socket
-        const socket = try std.posix.socket(
-            addr.any.family,
-            std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
-            std.posix.IPPROTO.TCP,
-        );
-        errdefer std.posix.close(socket);
+        // std.net + std.posix.socket are gone in 0.16; let libxev create the
+        // socket (STREAM|CLOEXEC, blocking on io_uring — same flags as before)
+        // and convert IpAddress -> sockaddr for bind(). We keep the raw fd for
+        // SO_REUSEPORT/BPF and the raw io_uring accept.
+        const tcp = try xev.TCP.init(addr);
+        const socket = tcp.fd;
+        errdefer helpers.closeFd(socket);
 
         // Set socket options
         try std.posix.setsockopt(
@@ -102,8 +104,8 @@ pub const Server = struct {
                 };
                 log.info().string("msg", "BPF connection affinity enabled").int("workers", num_workers).log();
 
-                try std.posix.bind(socket, &addr.any, addr.getOsSockLen());
-                try std.posix.listen(socket, DEFAULT_BACKLOG);
+                try tcp.bind(addr);
+                try tcp.listen(DEFAULT_BACKLOG);
 
                 if (bpf_ready) |ready| {
                     ready.store(true, .release);
@@ -115,13 +117,13 @@ pub const Server = struct {
                         std.atomic.spinLoopHint();
                     }
                 }
-                try std.posix.bind(socket, &addr.any, addr.getOsSockLen());
-                try std.posix.listen(socket, DEFAULT_BACKLOG);
+                try tcp.bind(addr);
+                try tcp.listen(DEFAULT_BACKLOG);
             }
         } else {
             // No BPF: all workers bind+listen independently (SO_REUSEPORT handles distribution)
-            try std.posix.bind(socket, &addr.any, addr.getOsSockLen());
-            try std.posix.listen(socket, DEFAULT_BACKLOG);
+            try tcp.bind(addr);
+            try tcp.listen(DEFAULT_BACKLOG);
         }
 
         // Initialize TLS context if cert+key are configured
@@ -207,13 +209,13 @@ pub const Server = struct {
 
         // If draining, reject new connections
         if (self.draining) {
-            std.posix.close(client_socket);
+            helpers.closeFd(client_socket);
             return .disarm;
         }
 
         // Connection limit: reject when over MAX_CONNECTIONS_PER_WORKER
         if (self.metrics.active_connections.load(.monotonic) >= tuning.MAX_CONNECTIONS_PER_WORKER) {
-            std.posix.close(client_socket);
+            helpers.closeFd(client_socket);
             self.metrics.incrementRejectedConnections();
             prom.connectionRejected();
             self.acceptNext();
@@ -245,7 +247,7 @@ pub const Server = struct {
             self,
         ) catch |err| {
             log.err().string("msg", "connection init failed").err(err).log();
-            std.posix.close(client_socket);
+            helpers.closeFd(client_socket);
             self.acceptNext();
             return .disarm;
         };
@@ -298,7 +300,7 @@ pub const Server = struct {
                 coord.getAsync(self.worker_id).notify() catch {};
             }
 
-            std.posix.close(self.socket);
+            helpers.closeFd(self.socket);
             self.socket = -1;
         }
         // Force-close every tracked connection.
@@ -320,7 +322,7 @@ pub const Server = struct {
         while (it) |node| {
             it = node.next;
             const conn: *Connection = @alignCast(@fieldParentPtr("link", node));
-            std.posix.shutdown(conn.socket, .both) catch {};
+            helpers.shutdownBoth(conn.socket);
         }
     }
 
@@ -331,7 +333,7 @@ pub const Server = struct {
     /// Clean up server resources
     pub fn deinit(self: *Server) void {
         if (self.tls_ctx) |*tc| tc.deinit();
-        if (self.socket != -1) std.posix.close(self.socket);
+        if (self.socket != -1) helpers.closeFd(self.socket);
     }
 };
 

--- a/src/core/shutdown.zig
+++ b/src/core/shutdown.zig
@@ -113,7 +113,7 @@ pub fn registerSignalHandlers(coordinator: *ShutdownCoordinator) void {
     std.posix.sigaction(std.posix.SIG.INT, &act, null);
 }
 
-fn signalHandler(_: c_int) callconv(.c) void {
+fn signalHandler(_: std.posix.SIG) callconv(.c) void {
     if (global_coordinator) |coord| {
         coord.signalReceived();
     }

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -298,13 +298,13 @@ test "response serialization" {
     response.status = 200;
     response.body = "Hello, World!";
 
-    var buf = std.ArrayList(u8).initCapacity(allocator, 0) catch unreachable;
-    defer buf.deinit(allocator);
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
 
-    try response.serialize(buf.writer(allocator));
+    try response.serialize(&buf.writer);
 
     const expected = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
-    try std.testing.expectEqualStrings(expected, buf.items);
+    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
 }
 
 test "http parser - simple GET request" {
@@ -342,12 +342,12 @@ test "101 switching protocols serialization" {
     try resp.addHeader("Connection", "Upgrade");
     try resp.addHeader("Sec-WebSocket-Accept", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
 
-    var buf = std.ArrayList(u8).initCapacity(allocator, 0) catch unreachable;
-    defer buf.deinit(allocator);
-    try resp.serialize(buf.writer(allocator));
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
+    try resp.serialize(&buf.writer);
 
     const expected = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n";
-    try std.testing.expectEqualStrings(expected, buf.items);
+    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
 }
 
 test "picohttpparser websocket upgrade headers" {
@@ -382,11 +382,10 @@ pub fn encodeChunk(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
     const hex_len = std.fmt.count("{x}", .{data.len});
     const total = hex_len + 2 + data.len + 2;
     const buf = try allocator.alloc(u8, total);
-    var fbs = std.io.fixedBufferStream(buf);
-    const writer = fbs.writer();
-    writer.print("{x}\r\n", .{data.len}) catch unreachable;
-    writer.writeAll(data) catch unreachable;
-    writer.writeAll("\r\n") catch unreachable;
+    var w = std.Io.Writer.fixed(buf);
+    w.print("{x}\r\n", .{data.len}) catch unreachable;
+    w.writeAll(data) catch unreachable;
+    w.writeAll("\r\n") catch unreachable;
     return buf;
 }
 
@@ -403,7 +402,7 @@ const ChunkedResult = struct {
 /// Returns the reassembled body (arena-allocated) and total bytes consumed.
 /// Returns error.Incomplete if the terminal chunk hasn't been received yet.
 fn decodeChunkedBody(data: []const u8, allocator: std.mem.Allocator) !ChunkedResult {
-    var body_buf = std.ArrayListUnmanaged(u8){};
+    var body_buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer body_buf.deinit(allocator);
     var pos: usize = 0;
 
@@ -552,11 +551,11 @@ test "serializeChunkedHeaders omits Content-Length" {
     response.status = 200;
     try response.addHeader("Content-Type", "application/x-ndjson");
 
-    var buf = std.ArrayList(u8).initCapacity(allocator, 0) catch unreachable;
-    defer buf.deinit(allocator);
-    try response.serializeChunkedHeaders(buf.writer(allocator));
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
+    try response.serializeChunkedHeaders(&buf.writer);
 
-    const result = buf.items;
+    const result = buf.writer.buffered();
     try std.testing.expect(std.mem.startsWith(u8, result, "HTTP/1.1 200 OK\r\n"));
     try std.testing.expect(std.mem.indexOf(u8, result, "Content-Type: application/x-ndjson") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "Transfer-Encoding: chunked") != null);

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -99,8 +99,8 @@ pub const ProxyRoute = struct {
 pub const Router = struct {
     allocator: std.mem.Allocator,
     root: *Node,
-    static_routes: std.ArrayListUnmanaged(StaticRoute) = .{},
-    proxy_routes: std.ArrayListUnmanaged(ProxyRoute) = .{},
+    static_routes: std.ArrayListUnmanaged(StaticRoute) = .empty,
+    proxy_routes: std.ArrayListUnmanaged(ProxyRoute) = .empty,
 
     /// Initialize radix router
     pub fn init(allocator: std.mem.Allocator) !Router {
@@ -116,7 +116,13 @@ pub const Router = struct {
     pub fn addStaticRoute(self: *Router, prefix: []const u8, root_dir: []const u8, index: []const u8) !void {
         const prefix_copy = try self.allocator.dupe(u8, prefix);
         const root_copy = try self.allocator.dupe(u8, root_dir);
-        const real_root = try std.fs.cwd().realpathAlloc(self.allocator, root_dir);
+        var route_io: std.Io.Threaded = .init(self.allocator, .{});
+        defer route_io.deinit();
+        var root_handle = try std.Io.Dir.cwd().openDir(route_io.io(), root_dir, .{});
+        defer root_handle.close(route_io.io());
+        var real_root_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const real_root_len = try root_handle.realPath(route_io.io(), &real_root_buf);
+        const real_root = try self.allocator.dupe(u8, real_root_buf[0..real_root_len]);
         const index_copy = try self.allocator.dupe(u8, index);
         try self.static_routes.append(self.allocator, .{
             .prefix = prefix_copy,
@@ -533,7 +539,7 @@ test "collectLuaRefs gathers all refs" {
     try router.addRoute("POST", "/a", 20);
     try router.addRoute("GET", "/b/{id}", 30);
 
-    var refs: std.ArrayListUnmanaged(i32) = .{};
+    var refs: std.ArrayListUnmanaged(i32) = .empty;
     defer refs.deinit(allocator);
     try router.collectLuaRefs(allocator, &refs);
 

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -13,6 +13,7 @@ const Connection = handler_mod.Connection;
 const http = @import("http.zig");
 const config = @import("../util/config.zig");
 const castUserdata = @import("../util/helpers.zig").castUserdata;
+const helpers = @import("../util/helpers.zig");
 const error_response = @import("error_response.zig");
 const router_mod = @import("router.zig");
 
@@ -24,7 +25,7 @@ pub const StaticState = struct {
     read_buf: []u8,
 
     pub fn deinit(self: *StaticState, allocator: std.mem.Allocator) void {
-        std.posix.close(self.fd);
+        helpers.closeFd(self.fd);
         allocator.free(self.read_buf);
     }
 };
@@ -142,10 +143,26 @@ pub fn serveStaticFile(
 
     // Resolve symlinks and verify the real path is still within root.
     // real_root was resolved once at route registration (avoids per-request realpathAlloc).
-    const real_resolved = std.fs.cwd().realpathAlloc(alloc, resolved) catch {
-        self.logAccess(404);
-        self.send404NotFound();
-        return;
+    var resolve_io: std.Io.Threaded = .init(alloc, .{});
+    defer resolve_io.deinit();
+    const real_resolved = blk: {
+        var rh = std.Io.Dir.cwd().openDir(resolve_io.io(), resolved, .{}) catch {
+            self.logAccess(404);
+            self.send404NotFound();
+            return;
+        };
+        defer rh.close(resolve_io.io());
+        var pbuf: [std.fs.max_path_bytes]u8 = undefined;
+        const n = rh.realPath(resolve_io.io(), &pbuf) catch {
+            self.logAccess(404);
+            self.send404NotFound();
+            return;
+        };
+        break :blk alloc.dupe(u8, pbuf[0..n]) catch {
+            self.logAccess(500);
+            self.send500InternalError();
+            return;
+        };
     };
     if (!std.mem.startsWith(u8, real_resolved, route.real_root)) {
         self.logAccess(403);
@@ -159,7 +176,9 @@ pub fn serveStaticFile(
         self.send500InternalError();
         return;
     };
-    const file = std.fs.openFileAbsoluteZ(resolved_z, .{}) catch {
+    var open_io: std.Io.Threaded = .init(alloc, .{});
+    defer open_io.deinit();
+    const file = std.Io.Dir.openFileAbsolute(open_io.io(), resolved_z, .{}) catch {
         self.logAccess(404);
         self.send404NotFound();
         return;
@@ -167,44 +186,45 @@ pub fn serveStaticFile(
     const fd = file.handle;
 
     // Stat for size + mtime
-    const stat = std.posix.fstat(fd) catch {
-        std.posix.close(fd);
+    const stat = file.stat(open_io.io()) catch {
+        helpers.closeFd(fd);
         self.logAccess(500);
         self.send500InternalError();
         return;
     };
 
     // Reject directories
-    if (stat.mode & std.posix.S.IFMT == std.posix.S.IFDIR) {
-        std.posix.close(fd);
+    if (stat.kind == .directory) {
+        helpers.closeFd(fd);
         self.logAccess(403);
         error_response.sendErrorStatus(self, 403, "is a directory");
         return;
     }
 
-    const file_size: u64 = @intCast(@max(0, stat.size));
+    const file_size: u64 = stat.size;
 
     // Size limit check
     if (file_size > config.STATIC_MAX_SIZE) {
-        std.posix.close(fd);
+        helpers.closeFd(fd);
         self.logAccess(413);
         error_response.sendErrorStatus(self, 413, "file too large");
         return;
     }
 
     // ETag: use inode + mtime + size
-    const mtime_sec = stat.mtim.sec;
+    const mtime_ns: i96 = stat.mtime.nanoseconds;
+    const mtime_sec: i64 = @intCast(@divFloor(mtime_ns, std.time.ns_per_s));
     var etag_buf: [64]u8 = undefined;
     const etag = std.fmt.bufPrint(&etag_buf, "\"{x}-{x}-{x}\"", .{
-        @as(u64, @bitCast(stat.ino)),
-        @as(u64, @bitCast(mtime_sec)),
+        stat.inode,
+        mtime_ns,
         file_size,
     }) catch "";
 
     // Check If-None-Match (use already-parsed headers, not raw buffer)
     if (http.Parser.getHeader(request, "If-None-Match")) |inm| {
         if (std.mem.eql(u8, inm, etag)) {
-            std.posix.close(fd);
+            helpers.closeFd(fd);
             self.logAccess(304);
             self.sendRawResponse("HTTP/1.1 304 Not Modified\r\nContent-Length: 0\r\n\r\n");
             return;
@@ -223,7 +243,7 @@ pub fn serveStaticFile(
         etag,
         &last_modified_buf,
     }) catch {
-        std.posix.close(fd);
+        helpers.closeFd(fd);
         self.logAccess(500);
         self.send500InternalError();
         return;
@@ -233,7 +253,7 @@ pub fn serveStaticFile(
 
     if (file_size == 0) {
         // Empty file — just send headers
-        std.posix.close(fd);
+        helpers.closeFd(fd);
         self.sendRawResponse(headers_text);
         return;
     }
@@ -241,24 +261,24 @@ pub fn serveStaticFile(
     // Small file fast path: single allocation, pread directly into combined buffer
     if (file_size <= config.STATIC_READ_SIZE) {
         const combined = alloc.alloc(u8, headers_text.len + @as(usize, @intCast(file_size))) catch {
-            std.posix.close(fd);
+            helpers.closeFd(fd);
             self.send500InternalError();
             return;
         };
         @memcpy(combined[0..headers_text.len], headers_text);
-        const bytes_read = std.posix.pread(fd, combined[headers_text.len..], 0) catch {
-            std.posix.close(fd);
+        const bytes_read = helpers.pread(fd, combined[headers_text.len..], 0) catch {
+            helpers.closeFd(fd);
             self.send500InternalError();
             return;
         };
-        std.posix.close(fd);
+        helpers.closeFd(fd);
         self.sendRawResponse(combined[0 .. headers_text.len + bytes_read]);
         return;
     }
 
     // Large file: send headers first, then pread+send loop
     const read_buf = self.base_allocator.alloc(u8, config.STATIC_READ_SIZE) catch {
-        std.posix.close(fd);
+        helpers.closeFd(fd);
         self.send500InternalError();
         return;
     };
@@ -301,7 +321,7 @@ fn sendNextChunk(self: *Connection) void {
     const remaining = ss.file_size - ss.bytes_sent;
     const to_read = @min(remaining, ss.read_buf.len);
 
-    const bytes_read = std.posix.pread(ss.fd, ss.read_buf[0..to_read], ss.bytes_sent) catch {
+    const bytes_read = helpers.pread(ss.fd, ss.read_buf[0..to_read], ss.bytes_sent) catch {
         self.close();
         return;
     };

--- a/src/io/connection_pool.zig
+++ b/src/io/connection_pool.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const helpers = @import("../util/helpers.zig");
 
 /// Per-worker connection pool for cosocket connections.
 /// Keyed by destination string (e.g. "127.0.0.1:6379"), LIFO retrieval,
@@ -38,7 +39,7 @@ pub const ConnectionPool = struct {
         while (it.next()) |entry| {
             // Close all pooled fds
             for (entry.value_ptr.entries.items) |pool_entry| {
-                std.posix.close(pool_entry.fd);
+                helpers.closeFd(pool_entry.fd);
             }
             entry.value_ptr.entries.deinit(self.allocator);
             // Free duped key
@@ -51,7 +52,7 @@ pub const ConnectionPool = struct {
     /// Returns null if no live connection available.
     pub fn get(self: *ConnectionPool, key: []const u8) ?PoolEntry {
         const pool = self.pools.getPtr(key) orelse return null;
-        const now = std.time.milliTimestamp();
+        const now = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_ms);
 
         // Pop from back (LIFO) — most recently returned connection reused first
         while (pool.entries.items.len > 0) {
@@ -60,7 +61,7 @@ pub const ConnectionPool = struct {
             pool.entries.items.len = len - 1;
             if (@max(0, now - entry.inserted_at_ms) > @as(i64, pool.max_idle_ms)) {
                 // Expired — close and continue
-                std.posix.close(entry.fd);
+                helpers.closeFd(entry.fd);
                 continue;
             }
             return entry;
@@ -70,7 +71,7 @@ pub const ConnectionPool = struct {
 
     /// Sweep all pools, closing expired entries. Called periodically by the worker timer.
     pub fn sweep(self: *ConnectionPool) void {
-        const now = std.time.milliTimestamp();
+        const now = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_ms);
         var it = self.pools.iterator();
         while (it.next()) |entry| {
             const pool = entry.value_ptr;
@@ -80,7 +81,7 @@ pub const ConnectionPool = struct {
                 i -= 1;
                 const pe = pool.entries.items[i];
                 if (@max(0, now - pe.inserted_at_ms) > @as(i64, pool.max_idle_ms)) {
-                    std.posix.close(pe.fd);
+                    helpers.closeFd(pe.fd);
                     _ = pool.entries.swapRemove(i);
                 }
             }
@@ -106,7 +107,7 @@ pub const ConnectionPool = struct {
             // First insertion — dupe the key, initialize the pool
             gop.key_ptr.* = try self.allocator.dupe(u8, key);
             gop.value_ptr.* = .{
-                .entries = .{},
+                .entries = .empty,
                 .max_size = effective_size,
                 .max_idle_ms = effective_timeout,
             };
@@ -116,14 +117,14 @@ pub const ConnectionPool = struct {
 
         // Enforce max size
         if (pool.entries.items.len >= pool.max_size) {
-            std.posix.close(fd);
+            helpers.closeFd(fd);
             return;
         }
 
         try pool.entries.append(self.allocator, .{
             .fd = fd,
             .reuse_count = reuse_count,
-            .inserted_at_ms = std.time.milliTimestamp(),
+            .inserted_at_ms = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_ms),
         });
     }
 };
@@ -148,8 +149,8 @@ test "connection pool put and get roundtrip" {
     defer pool.deinit();
 
     // Use a pipe fd as a stand-in for a real socket (safe to close)
-    const pipes = try std.posix.pipe();
-    std.posix.close(pipes[0]); // close read end, keep write end as our "fd"
+    const pipes = try helpers.pipe();
+    helpers.closeFd(pipes[0]); // close read end, keep write end as our "fd"
     const fake_fd = pipes[1];
 
     try pool.put("127.0.0.1:6379", fake_fd, 0, 0, 0);
@@ -164,7 +165,7 @@ test "connection pool put and get roundtrip" {
     try std.testing.expect(entry2 == null);
 
     // Close the fd we got back
-    std.posix.close(fake_fd);
+    helpers.closeFd(fake_fd);
 }
 
 test "connection pool LIFO order" {
@@ -172,12 +173,12 @@ test "connection pool LIFO order" {
     defer pool.deinit();
 
     // Create two pipe fds
-    const pipes1 = try std.posix.pipe();
-    std.posix.close(pipes1[0]);
+    const pipes1 = try helpers.pipe();
+    helpers.closeFd(pipes1[0]);
     const fd1 = pipes1[1];
 
-    const pipes2 = try std.posix.pipe();
-    std.posix.close(pipes2[0]);
+    const pipes2 = try helpers.pipe();
+    helpers.closeFd(pipes2[0]);
     const fd2 = pipes2[1];
 
     try pool.put("host:1234", fd1, 0, 0, 0);
@@ -192,8 +193,8 @@ test "connection pool LIFO order" {
     try std.testing.expect(second != null);
     try std.testing.expectEqual(fd1, second.?.fd);
 
-    std.posix.close(fd1);
-    std.posix.close(fd2);
+    helpers.closeFd(fd1);
+    helpers.closeFd(fd2);
 }
 
 test "connection pool max size enforcement" {
@@ -201,12 +202,12 @@ test "connection pool max size enforcement" {
     defer pool.deinit();
 
     // Put with max_size=1
-    const pipes1 = try std.posix.pipe();
-    std.posix.close(pipes1[0]);
+    const pipes1 = try helpers.pipe();
+    helpers.closeFd(pipes1[0]);
     const fd1 = pipes1[1];
 
-    const pipes2 = try std.posix.pipe();
-    std.posix.close(pipes2[0]);
+    const pipes2 = try helpers.pipe();
+    helpers.closeFd(pipes2[0]);
     const fd2 = pipes2[1];
 
     try pool.put("host:80", fd1, 0, 0, 1); // max_size=1
@@ -220,7 +221,7 @@ test "connection pool max size enforcement" {
     const entry2 = pool.get("host:80");
     try std.testing.expect(entry2 == null);
 
-    std.posix.close(fd1);
+    helpers.closeFd(fd1);
     // fd2 was closed by put() — do not close again
 }
 
@@ -228,8 +229,8 @@ test "connection pool default values for zero args" {
     var pool = ConnectionPool.init(std.testing.allocator);
     defer pool.deinit();
 
-    const pipes = try std.posix.pipe();
-    std.posix.close(pipes[0]);
+    const pipes = try helpers.pipe();
+    helpers.closeFd(pipes[0]);
     const fd = pipes[1];
 
     // Put with 0,0 — should use defaults
@@ -241,5 +242,5 @@ test "connection pool default values for zero args" {
 
     // Clean up
     const entry = pool.get("host:80");
-    if (entry) |e| std.posix.close(e.fd);
+    if (entry) |e| helpers.closeFd(e.fd);
 }

--- a/src/io/cosocket.zig
+++ b/src/io/cosocket.zig
@@ -32,6 +32,7 @@ const Lua = @import("luajit").Lua;
 const error_response = @import("../http/error_response.zig");
 const ErrorCategory = error_response.ErrorCategory;
 const castUserdata = @import("../util/helpers.zig").castUserdata;
+const helpers = @import("../util/helpers.zig");
 
 const cosocket_ops = @import("cosocket_ops.zig");
 const cosocket_tls = @import("../tls/cosocket_tls.zig");
@@ -314,7 +315,7 @@ pub fn onBatchComplete(
 
     if (op == .connect) {
         _ = result.connect catch {
-            std.posix.close(completion.op.connect.socket);
+            helpers.closeFd(completion.op.connect.socket);
             const classified = classifyOpError(op);
             self.cs.cq.push(.{ .result = -1, .err_msg = classified.msg, .err_category = classified.category });
             batchCompletionCheck(self);
@@ -391,7 +392,7 @@ fn batchCompletionCheck(self: *Connection) void {
                     s.coroutine_ref = 0;
                 }
                 if (s.outbound_fd != -1) {
-                    std.posix.close(s.outbound_fd);
+                    helpers.closeFd(s.outbound_fd);
                     s.outbound_fd = -1;
                 }
                 s.recv_buf = null;

--- a/src/io/cosocket_ops.zig
+++ b/src/io/cosocket_ops.zig
@@ -11,6 +11,7 @@
 //! After kTLS: send/recv are plaintext — the kernel handles crypto transparently.
 
 const std = @import("std");
+const helpers = @import("../util/helpers.zig");
 const xev = @import("xev");
 const Lua = @import("luajit").Lua;
 
@@ -29,6 +30,11 @@ const TlsMode = io_request_mod.TlsMode;
 const LuaState = @import("../lua/lua_state.zig").LuaState;
 
 const cosocket = @import("cosocket.zig");
+
+/// libxev's connect-op address type (its internal sockaddr union) isn't exported
+/// at the `xev` root; pull it off the Completion op so we can convert an
+/// `std.Io.net.IpAddress` into what the raw connect op expects.
+const XevConnectAddr = @FieldType(@FieldType(@FieldType(xev.Completion, "op"), "connect"), "addr");
 
 const error_response = @import("../http/error_response.zig");
 const ErrorCategory = error_response.ErrorCategory;
@@ -68,7 +74,7 @@ pub fn selectClientTlsCtx(lua_state: *LuaState, mode: TlsMode) @TypeOf(lua_state
     return switch (mode) {
         .verify => lua_state.tls_manager.client_tls_ctx.ctx,
         .insecure => blk: {
-            if (std.posix.getenv("KEYWAY_ALLOW_INSECURE_TLS")) |v| {
+            if (helpers.getenv("KEYWAY_ALLOW_INSECURE_TLS")) |v| {
                 if (std.mem.eql(u8, v, "1")) break :blk lua_state.tls_manager.insecure_tls_ctx.ctx;
             }
             const log = @import("../observability/log.zig");
@@ -85,7 +91,7 @@ pub fn selectClientTlsCtx(lua_state: *LuaState, mode: TlsMode) @TypeOf(lua_state
 
 /// Helper: create TCP socket and submit connect for batched I/O
 pub fn submitBatchConnect(self: *Connection, host: []const u8, port: u16, io_index: u8, _: IoEntry.Op) void {
-    const sock = std.posix.socket(
+    const sock = helpers.socket(
         std.posix.AF.INET,
         std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
         0,
@@ -94,14 +100,14 @@ pub fn submitBatchConnect(self: *Connection, host: []const u8, port: u16, io_ind
         return;
     };
 
-    const addr = std.net.Address.parseIp4(host, port) catch {
-        std.posix.close(sock);
+    const addr = std.Io.net.IpAddress.parseIp4(host, port) catch {
+        helpers.closeFd(sock);
         self.cs.cq.push(.{ .result = -1, .err_msg = "connect: invalid address", .err_category = .upstream_error });
         return;
     };
 
     self.cs.batch_completions.?[io_index] = .{
-        .op = .{ .connect = .{ .socket = sock, .addr = addr } },
+        .op = .{ .connect = .{ .socket = sock, .addr = XevConnectAddr.fromIpAddress(addr) } },
         .userdata = self,
         .callback = cosocket.onBatchComplete,
     };
@@ -111,7 +117,7 @@ pub fn submitBatchConnect(self: *Connection, host: []const u8, port: u16, io_ind
 
 /// Helper: create UDP socket and submit connect for batched I/O
 pub fn submitBatchUdpConnect(self: *Connection, host: []const u8, port: u16, timeout_ms: u32, io_index: u8) void {
-    const sock = std.posix.socket(
+    const sock = helpers.socket(
         std.posix.AF.INET,
         std.posix.SOCK.DGRAM | std.posix.SOCK.CLOEXEC,
         0,
@@ -128,14 +134,14 @@ pub fn submitBatchUdpConnect(self: *Connection, host: []const u8, port: u16, tim
         _ = std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
     }
 
-    const addr = std.net.Address.parseIp4(host, port) catch {
-        std.posix.close(sock);
+    const addr = std.Io.net.IpAddress.parseIp4(host, port) catch {
+        helpers.closeFd(sock);
         self.cs.cq.push(.{ .result = -1, .err_msg = "udp_connect: invalid address", .err_category = .upstream_error });
         return;
     };
 
     self.cs.batch_completions.?[io_index] = .{
-        .op = .{ .connect = .{ .socket = sock, .addr = addr } },
+        .op = .{ .connect = .{ .socket = sock, .addr = XevConnectAddr.fromIpAddress(addr) } },
         .userdata = self,
         .callback = cosocket.onBatchComplete,
     };

--- a/src/io/file_watcher.zig
+++ b/src/io/file_watcher.zig
@@ -8,6 +8,7 @@
 //! The kernel delivers events to all watchers independently.
 
 const std = @import("std");
+const helpers = @import("../util/helpers.zig");
 const xev = @import("xev");
 const log = @import("../observability/log.zig");
 const LuaState = @import("../lua/lua_state.zig").LuaState;
@@ -48,8 +49,8 @@ pub const FileWatcher = struct {
         lua_state: *LuaState,
         router: *Router,
     ) !FileWatcher {
-        const fd = try std.posix.inotify_init1(std.os.linux.IN.NONBLOCK | std.os.linux.IN.CLOEXEC);
-        errdefer std.posix.close(fd);
+        const fd = try helpers.inotifyInit1(std.os.linux.IN.NONBLOCK | std.os.linux.IN.CLOEXEC);
+        errdefer helpers.closeFd(fd);
 
         var watcher = FileWatcher{
             .inotify_fd = fd,
@@ -73,7 +74,7 @@ pub const FileWatcher = struct {
             self.allocator.free(entry.value_ptr.*);
         }
         self.watch_dirs.deinit();
-        std.posix.close(self.inotify_fd);
+        helpers.closeFd(self.inotify_fd);
     }
 
     /// Add a watch on a directory and recurse into subdirectories.
@@ -81,7 +82,7 @@ pub const FileWatcher = struct {
         const dir_path_z = try self.allocator.dupeZ(u8, dir_path);
         defer self.allocator.free(dir_path_z);
 
-        const wd = std.posix.inotify_add_watch(self.inotify_fd, dir_path_z, WATCH_MASK) catch |err| {
+        const wd = helpers.inotifyAddWatch(self.inotify_fd, dir_path_z, WATCH_MASK) catch |err| {
             log.warn().string("msg", "inotify_add_watch failed").string("path", dir_path).err(err).log();
             return;
         };
@@ -90,10 +91,13 @@ pub const FileWatcher = struct {
         try self.watch_dirs.put(wd, owned_path);
 
         // Recurse into subdirectories
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return;
-        defer dir.close();
+        var walk_io: std.Io.Threaded = .init(self.allocator, .{});
+        defer walk_io.deinit();
+        const io = walk_io.io();
+        var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
+        defer dir.close(io);
         var iter = dir.iterate();
-        while (try iter.next()) |entry| {
+        while (try iter.next(io)) |entry| {
             if (entry.kind == .directory) {
                 const sub_path = try std.fs.path.join(self.allocator, &.{ dir_path, entry.name });
                 defer self.allocator.free(sub_path);

--- a/src/lua/json.zig
+++ b/src/lua/json.zig
@@ -25,7 +25,7 @@ pub fn jsonEncode(lua: *Lua) callconv(.c) c_int {
         lua.pushString("JSON encode: argument required");
         lua.raiseError();
     }
-    var buf: Buf = .{};
+    var buf: Buf = .empty;
 
     encodeValue(lua, 1, &buf, 0) catch |err| {
         buf.deinit(alloc);

--- a/src/lua/lua_state.zig
+++ b/src/lua/lua_state.zig
@@ -21,6 +21,7 @@ const ConnectionPool = @import("../io/connection_pool.zig").ConnectionPool;
 const Connection = @import("../core/handler.zig").Connection;
 const tls = @import("../tls/tls.zig");
 const castUserdata = @import("../util/helpers.zig").castUserdata;
+const helpers = @import("../util/helpers.zig");
 const TlsManager = tls.TlsManager;
 const SseRegistry = @import("../protocol/sse.zig").SseRegistry;
 const prom = @import("../observability/prom.zig");
@@ -259,7 +260,7 @@ pub const LuaState = struct {
 
         // Resume the coroutine: thread stack has [handler_fn, userdata]
         prom.luaCoroutineStarted();
-        self.coroutine_start_us = std.time.microTimestamp();
+        self.coroutine_start_us = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us);
         // Capture route for duration labeling from Connection's http_state
         if (self.current_connection) |conn_ptr| {
             const conn: *Connection = @ptrCast(@alignCast(conn_ptr));
@@ -381,7 +382,7 @@ pub const LuaState = struct {
     /// Record coroutine execution duration for Prometheus metrics.
     fn recordCoroutineDuration(self: *LuaState) void {
         if (self.coroutine_start_us) |start| {
-            const elapsed = std.time.microTimestamp() - start;
+            const elapsed = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us) - start;
             prom.luaScriptDuration(self.coroutine_route, elapsed);
             self.coroutine_start_us = null;
         }
@@ -423,10 +424,10 @@ pub const LuaState = struct {
         const path_c = lua.toString(1) catch return luaError(lua, "path argument required");
         const path = std.mem.span(path_c);
 
-        const file = std.fs.cwd().openFile(path, .{}) catch return luaError(lua, "file not found");
-        defer file.close();
+        var file_io: std.Io.Threaded = .init(state.allocator, .{});
+        defer file_io.deinit();
 
-        const content = file.readToEndAlloc(state.allocator, 10 * 1024 * 1024) catch return luaError(lua, "read error");
+        const content = std.Io.Dir.cwd().readFileAlloc(file_io.io(), path, state.allocator, .limited(10 * 1024 * 1024)) catch return luaError(lua, "file not found");
         defer state.allocator.free(content);
 
         lua.pushLString(content);
@@ -444,22 +445,27 @@ pub const LuaState = struct {
         const state = getLuaState(lua) orelse return 0;
         const dir_path = std.fs.path.dirname(path) orelse ".";
 
+        var file_io: std.Io.Threaded = .init(state.allocator, .{});
+        defer file_io.deinit();
+        const io = file_io.io();
+        const cwd = std.Io.Dir.cwd();
+
         // Ensure parent directory exists
-        std.fs.cwd().makePath(dir_path) catch {};
+        cwd.createDirPath(io, dir_path) catch {};
 
         // Write tmp file and rename
         const tmp_path = std.fmt.allocPrint(state.allocator, "{s}.tmp", .{path}) catch return luaError(lua, "allocation failed");
         defer state.allocator.free(tmp_path);
 
-        const file = std.fs.cwd().createFile(tmp_path, .{}) catch return luaError(lua, "failed to create tmp file");
-        file.writeAll(content) catch {
-            file.close();
+        const file = cwd.createFile(io, tmp_path, .{}) catch return luaError(lua, "failed to create tmp file");
+        file.writeStreamingAll(io, content) catch {
+            file.close(io);
             return luaError(lua, "write error");
         };
-        file.close();
+        file.close(io);
 
         // Rename tmp -> target (atomic on same filesystem)
-        std.fs.cwd().rename(tmp_path, path) catch return luaError(lua, "rename failed");
+        cwd.rename(tmp_path, cwd, path, io) catch return luaError(lua, "rename failed");
 
         lua.pushBoolean(true);
         return 1;
@@ -467,10 +473,14 @@ pub const LuaState = struct {
 
     /// __keyway_file_delete(path) -> true or nil, error
     fn keyway_file_delete(lua: *Lua) callconv(.c) c_int {
+        const state = getLuaState(lua) orelse return 0;
         const path_c = lua.toString(1) catch return luaError(lua, "path argument required");
         const path = std.mem.span(path_c);
 
-        std.fs.cwd().deleteFile(path) catch return luaError(lua, "delete failed");
+        var file_io: std.Io.Threaded = .init(state.allocator, .{});
+        defer file_io.deinit();
+
+        std.Io.Dir.cwd().deleteFile(file_io.io(), path) catch return luaError(lua, "delete failed");
 
         lua.pushBoolean(true);
         return 1;
@@ -478,12 +488,17 @@ pub const LuaState = struct {
 
     /// __keyway_file_rename(old_path, new_path) -> true or nil, error
     fn keyway_file_rename(lua: *Lua) callconv(.c) c_int {
+        const state = getLuaState(lua) orelse return 0;
         const old_c = lua.toString(1) catch return luaError(lua, "old_path argument required");
         const new_c = lua.toString(2) catch return luaError(lua, "new_path argument required");
         const old_path = std.mem.span(old_c);
         const new_path = std.mem.span(new_c);
 
-        std.fs.cwd().rename(old_path, new_path) catch return luaError(lua, "rename failed");
+        var file_io: std.Io.Threaded = .init(state.allocator, .{});
+        defer file_io.deinit();
+        const cwd = std.Io.Dir.cwd();
+
+        cwd.rename(old_path, cwd, new_path, file_io.io()) catch return luaError(lua, "rename failed");
 
         lua.pushBoolean(true);
         return 1;
@@ -495,23 +510,26 @@ pub const LuaState = struct {
         const dir_c = lua.toString(1) catch return luaError(lua, "dir argument required");
         const dir_path = std.mem.span(dir_c);
 
+        var file_io: std.Io.Threaded = .init(state.allocator, .{});
+        defer file_io.deinit();
+
         lua.createTable(0, 0);
         var idx: i32 = 1;
 
-        listLuaFilesRecursive(lua, state.allocator, dir_path, dir_path, &idx);
+        listLuaFilesRecursive(lua, file_io.io(), state.allocator, dir_path, dir_path, &idx);
 
         return 1;
     }
 
-    fn listLuaFilesRecursive(lua: *Lua, alloc: std.mem.Allocator, base: []const u8, dir_path: []const u8, idx: *i32) void {
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return;
-        defer dir.close();
+    fn listLuaFilesRecursive(lua: *Lua, io: std.Io, alloc: std.mem.Allocator, base: []const u8, dir_path: []const u8, idx: *i32) void {
+        var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
+        defer dir.close(io);
         var iter = dir.iterate();
-        while (iter.next() catch null) |entry| {
+        while (iter.next(io) catch null) |entry| {
             if (entry.kind == .directory) {
                 const sub = std.fs.path.join(alloc, &.{ dir_path, entry.name }) catch continue;
                 defer alloc.free(sub);
-                listLuaFilesRecursive(lua, alloc, base, sub, idx);
+                listLuaFilesRecursive(lua, io, alloc, base, sub, idx);
             } else if (entry.kind == .file and (std.mem.endsWith(u8, entry.name, ".lua") or std.mem.endsWith(u8, entry.name, ".lua.disabled"))) {
                 const full = std.fs.path.join(alloc, &.{ dir_path, entry.name }) catch continue;
                 defer alloc.free(full);
@@ -639,7 +657,7 @@ pub const LuaState = struct {
     /// On script error: logs the error and leaves the router empty (all requests 404).
     pub fn reload(self: *LuaState, router: *Router, script_path: []const u8) void {
         // 1. Collect old lua_refs from router and unref each
-        var refs: std.ArrayListUnmanaged(i32) = .{};
+        var refs: std.ArrayListUnmanaged(i32) = .empty;
         defer refs.deinit(self.allocator);
         router.collectLuaRefs(self.allocator, &refs) catch {};
         for (refs.items) |ref| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,13 +15,13 @@ pub const std_options: std.Options = .{
     .logFn = log.logFn,
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+pub fn main(init: std.process.Init.Minimal) !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     // Parse CLI arguments (falls back to env vars, then defaults)
-    const cli_config = cli.parse(allocator) catch |err| {
+    const cli_config = cli.parse(allocator, init.args) catch |err| {
         cli.printHelp();
         std.log.err("CLI parse error: {}", .{err});
         std.process.exit(1);
@@ -33,10 +33,7 @@ pub fn main() !void {
     }
 
     if (cli_config.show_version) {
-        var buf: [64]u8 = undefined;
-        const stderr = std.debug.lockStderrWriter(&buf);
-        defer std.debug.unlockStderrWriter();
-        stderr.print("keyway {s}\n", .{version}) catch {};
+        std.debug.print("keyway {s}\n", .{version});
         return;
     }
 

--- a/src/observability/log.zig
+++ b/src/observability/log.zig
@@ -8,6 +8,11 @@ pub threadlocal var worker_id: u16 = 0;
 /// Track whether logz has been initialized (guards against pre-init logging in tests).
 var initialized = false;
 
+/// Backing I/O for the logz pool. The 0.16 logz dep drives its pool through a
+/// `std.Io` rather than managing threads itself; this owns that io for the
+/// process lifetime. logz was already a self-threaded subsystem pre-0.16.
+var log_io: std.Io.Threaded = undefined;
+
 /// Map std.log.Level to logz.Level.
 fn toLogzLevel(level: std.log.Level) logz.Level {
     return switch (level) {
@@ -24,7 +29,8 @@ pub fn init(allocator: std.mem.Allocator, level: std.log.Level, log_format: cli.
         .logfmt => .logfmt,
         .json => .json,
     };
-    try logz.setup(allocator, .{
+    log_io = .init(allocator, .{});
+    try logz.setup(log_io.io(), allocator, .{
         .level = toLogzLevel(level),
         .pool_size = @intCast(num_workers * 4),
         .output = .stderr,
@@ -37,6 +43,7 @@ pub fn init(allocator: std.mem.Allocator, level: std.log.Level, log_format: cli.
 pub fn deinit() void {
     if (initialized) {
         logz.deinit();
+        log_io.deinit();
         initialized = false;
     }
 }
@@ -77,7 +84,7 @@ pub fn accessLog(method: []const u8, path: []const u8, status: u16, dur_us: i64)
 /// Bridge: route std.log calls through logz so dependency/stdlib logging is consistent.
 pub fn logFn(
     comptime level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/src/observability/prom.zig
+++ b/src/observability/prom.zig
@@ -15,6 +15,12 @@ pub threadlocal var worker_id: u16 = 0;
 /// Global metrics instance. Starts as noop, activated by `init()`.
 pub var global: Metrics = m.initializeNoop(Metrics);
 
+/// Backing I/O for the metrics library's internal RwLocks. The 0.16 metrics dep
+/// guards its label maps with `std.Io` locks instead of raw atomics; we use this
+/// only as a mutex provider (never async), so no threads are ever spawned.
+/// Lives for the process lifetime alongside `global`.
+var metrics_io: std.Io.Threaded = undefined;
+
 pub const Metrics = struct {
     // -- Request flow --
     http_requests_total: HttpRequestsTotal,
@@ -57,11 +63,13 @@ pub const Metrics = struct {
 
 /// Initialize the global metrics instance. Call once at startup before spawning workers.
 pub fn init(allocator: Allocator) !void {
+    metrics_io = .init(allocator, .{});
+    const io = metrics_io.io();
     global = .{
-        .http_requests_total = try Metrics.HttpRequestsTotal.init(allocator, "keyway_http_requests_total", .{
+        .http_requests_total = try Metrics.HttpRequestsTotal.init(allocator, io, "keyway_http_requests_total", .{
             .help = "Total HTTP requests handled",
         }, .{}),
-        .http_request_duration_seconds = try Metrics.HttpRequestDuration.init(allocator, "keyway_http_request_duration_seconds", .{
+        .http_request_duration_seconds = try Metrics.HttpRequestDuration.init(allocator, io, "keyway_http_request_duration_seconds", .{
             .help = "Request latency in seconds",
         }, .{}),
         .http_request_body_bytes = Metrics.BodySizeHist.init("keyway_http_request_body_bytes", .{
@@ -70,28 +78,28 @@ pub fn init(allocator: Allocator) !void {
         .http_response_body_bytes = Metrics.BodySizeHist.init("keyway_http_response_body_bytes", .{
             .help = "Response body size in bytes",
         }, .{}),
-        .connections_accepted_total = try Metrics.ConnectionCounter.init(allocator, "keyway_connections_accepted_total", .{
+        .connections_accepted_total = try Metrics.ConnectionCounter.init(allocator, io, "keyway_connections_accepted_total", .{
             .help = "Total accepted connections",
         }, .{}),
-        .connections_active = try Metrics.ConnectionGauge.init(allocator, "keyway_connections_active", .{
+        .connections_active = try Metrics.ConnectionGauge.init(allocator, io, "keyway_connections_active", .{
             .help = "Current active connections",
         }, .{}),
-        .connections_rejected_total = try Metrics.ConnectionCounter.init(allocator, "keyway_connections_rejected_total", .{
+        .connections_rejected_total = try Metrics.ConnectionCounter.init(allocator, io, "keyway_connections_rejected_total", .{
             .help = "Total rejected connections",
         }, .{}),
-        .ring_submissions_total = try Metrics.ConnectionCounter.init(allocator, "keyway_ring_submissions_total", .{
+        .ring_submissions_total = try Metrics.ConnectionCounter.init(allocator, io, "keyway_ring_submissions_total", .{
             .help = "Total ring buffer submissions",
         }, .{}),
-        .ring_completions_total = try Metrics.ConnectionCounter.init(allocator, "keyway_ring_completions_total", .{
+        .ring_completions_total = try Metrics.ConnectionCounter.init(allocator, io, "keyway_ring_completions_total", .{
             .help = "Total ring buffer completions",
         }, .{}),
-        .ring_batch_size = try Metrics.RingBatchSizeHist.init(allocator, "keyway_ring_batch_size", .{
+        .ring_batch_size = try Metrics.RingBatchSizeHist.init(allocator, io, "keyway_ring_batch_size", .{
             .help = "Submissions per batch drain",
         }, .{}),
-        .lua_coroutines_active = try Metrics.ConnectionGauge.init(allocator, "keyway_lua_coroutines_active", .{
+        .lua_coroutines_active = try Metrics.ConnectionGauge.init(allocator, io, "keyway_lua_coroutines_active", .{
             .help = "Active Lua coroutines",
         }, .{}),
-        .lua_script_duration_seconds = try Metrics.LuaScriptDuration.init(allocator, "keyway_lua_script_duration_seconds", .{
+        .lua_script_duration_seconds = try Metrics.LuaScriptDuration.init(allocator, io, "keyway_lua_script_duration_seconds", .{
             .help = "Lua script execution time in seconds",
         }, .{}),
     };
@@ -108,6 +116,7 @@ pub fn deinit() void {
     global.ring_batch_size.deinit();
     global.lua_coroutines_active.deinit();
     global.lua_script_duration_seconds.deinit();
+    metrics_io.deinit();
 }
 
 /// Write all metrics in Prometheus text exposition format.

--- a/src/protocol/conn_sse.zig
+++ b/src/protocol/conn_sse.zig
@@ -46,7 +46,7 @@ pub fn handleSseUpgrade(self: *Connection, exchange: *HttpExchange) void {
     self.sse_state = .{
         .room = room_dupe,
         .registry = self.sse_registry,
-        .send_queue = .{},
+        .send_queue = .empty,
         .drain_index = 0,
         .writing = false,
         .disconnect_completion = undefined,

--- a/src/protocol/conn_stream.zig
+++ b/src/protocol/conn_stream.zig
@@ -36,11 +36,11 @@ pub fn handleStreamUpgrade(self: *Connection, exchange: *HttpExchange) void {
 
     const alloc = self.arena.allocator();
     const estimated: usize = 512;
-    var header_buf = std.ArrayList(u8).initCapacity(alloc, estimated) catch {
+    var header_buf: std.Io.Writer.Allocating = std.Io.Writer.Allocating.initCapacity(alloc, estimated) catch {
         self.send500InternalError();
         return;
     };
-    response.serializeChunkedHeaders(header_buf.writer(alloc)) catch {
+    response.serializeChunkedHeaders(&header_buf.writer) catch {
         self.send500InternalError();
         return;
     };
@@ -62,13 +62,13 @@ pub fn handleStreamUpgrade(self: *Connection, exchange: *HttpExchange) void {
             self.send500InternalError();
             return;
         };
-        header_buf.appendSlice(alloc, chunk) catch {
+        header_buf.writer.writeAll(chunk) catch {
             self.send500InternalError();
             return;
         };
     }
 
-    self.submitSend(header_buf.items, onStreamWrite, false);
+    self.submitSend(header_buf.writer.buffered(), onStreamWrite, false);
 }
 
 /// Callback after a stream write completes — resume coroutine for next chunk.

--- a/src/protocol/conn_ws.zig
+++ b/src/protocol/conn_ws.zig
@@ -215,7 +215,7 @@ pub fn processWsFrames(conn: *Connection) void {
                     }
                     wss.fragment_opcode = f.frame.opcode;
                     const alloc = conn.arena.allocator();
-                    var buf = std.ArrayListUnmanaged(u8){};
+                    var buf: std.ArrayListUnmanaged(u8) = .empty;
                     buf.appendSlice(alloc, f.frame.payload) catch {
                         sendWsClose(conn, 1011);
                         return;

--- a/src/protocol/sse.zig
+++ b/src/protocol/sse.zig
@@ -34,7 +34,7 @@ pub const SseRegistry = struct {
         const gop = try self.rooms.getOrPut(self.allocator, room);
         if (!gop.found_existing) {
             gop.key_ptr.* = try self.allocator.dupe(u8, room);
-            gop.value_ptr.* = .{};
+            gop.value_ptr.* = .empty;
         }
         try gop.value_ptr.append(self.allocator, conn);
     }
@@ -97,8 +97,8 @@ pub const SseBroadcastBus = struct {
     };
 
     const WorkerSlot = struct {
-        inbox: std.ArrayListUnmanaged(Message) = .{},
-        mutex: std.Thread.Mutex = .{},
+        inbox: std.ArrayListUnmanaged(Message) = .empty,
+        mutex: std.Io.Mutex = .init,
         notifier: xev.Async = undefined,
         completion: xev.Completion = undefined,
         registry: ?*SseRegistry = null,
@@ -110,6 +110,10 @@ pub const SseBroadcastBus = struct {
     slots: []WorkerSlot,
     num_workers: usize,
     allocator: std.mem.Allocator,
+    /// Sync provider for per-slot `std.Io.Mutex` (0.16 removed io-free mutexes).
+    /// Used only as a mutex provider — no async work, so no threads are spawned.
+    threaded: std.Io.Threaded,
+    io: std.Io,
 
     pub fn init(allocator: std.mem.Allocator, num_workers: usize) !*SseBroadcastBus {
         const bus = try allocator.create(SseBroadcastBus);
@@ -125,22 +129,26 @@ pub const SseBroadcastBus = struct {
             .slots = slots,
             .num_workers = num_workers,
             .allocator = allocator,
+            .threaded = .init(allocator, .{}),
+            .io = undefined,
         };
+        bus.io = bus.threaded.io();
         return bus;
     }
 
     pub fn deinit(self: *SseBroadcastBus) void {
         for (self.slots) |*slot| {
-            slot.mutex.lock();
+            slot.mutex.lockUncancelable(self.io);
             for (slot.inbox.items) |msg| {
                 self.allocator.free(msg.room);
                 self.allocator.free(msg.data);
             }
             slot.inbox.deinit(self.allocator);
-            slot.mutex.unlock();
+            slot.mutex.unlock(self.io);
             slot.notifier.deinit();
         }
         self.allocator.free(self.slots);
+        self.threaded.deinit();
         self.allocator.destroy(self);
     }
 
@@ -178,14 +186,14 @@ pub const SseBroadcastBus = struct {
                 continue;
             };
 
-            slot.mutex.lock();
+            slot.mutex.lockUncancelable(self.io);
             slot.inbox.append(self.allocator, .{ .room = room_dupe, .data = data_dupe }) catch {
                 self.allocator.free(room_dupe);
                 self.allocator.free(data_dupe);
-                slot.mutex.unlock();
+                slot.mutex.unlock(self.io);
                 continue;
             };
-            slot.mutex.unlock();
+            slot.mutex.unlock(self.io);
 
             slot.notifier.notify() catch {};
         }
@@ -213,11 +221,11 @@ pub const SseBroadcastBus = struct {
                 const registry = slot.registry orelse continue;
 
                 // Drain inbox under lock
-                slot.mutex.lock();
+                slot.mutex.lockUncancelable(self.io);
                 // Swap out the inbox for a fresh one so we can release the lock quickly
                 var messages = slot.inbox;
-                slot.inbox = .{};
-                slot.mutex.unlock();
+                slot.inbox = .empty;
+                slot.mutex.unlock(self.io);
 
                 for (messages.items) |msg| {
                     registry.broadcastLocal(msg.room, msg.data);

--- a/src/tls/tls.zig
+++ b/src/tls/tls.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const log = @import("../observability/log.zig");
 const config = @import("../util/config.zig");
+const helpers = @import("../util/helpers.zig");
 const c = @cImport({
     @cInclude("openssl/ssl.h");
     @cInclude("openssl/err.h");
@@ -813,9 +814,9 @@ pub const TlsManager = struct {
 
         // Custom mTLS context from env vars (for any mTLS target)
         const custom_tls_ctx: ?ClientTlsContext = blk: {
-            const ca = std.posix.getenv("KEYWAY_MTLS_CA") orelse break :blk null;
-            const cert = std.posix.getenv("KEYWAY_MTLS_CERT") orelse break :blk null;
-            const key = std.posix.getenv("KEYWAY_MTLS_KEY") orelse break :blk null;
+            const ca = helpers.getenv("KEYWAY_MTLS_CA") orelse break :blk null;
+            const cert = helpers.getenv("KEYWAY_MTLS_CERT") orelse break :blk null;
+            const key = helpers.getenv("KEYWAY_MTLS_KEY") orelse break :blk null;
             const ctx = ClientTlsContext.init(.{
                 .verify = true,
                 .ca_path = @ptrCast(ca.ptr),

--- a/src/util/cli.zig
+++ b/src/util/cli.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const helpers = @import("helpers.zig");
 
 /// CLI configuration for the Keyway server.
 /// Resolution order: CLI argument > environment variable > default value.
@@ -31,7 +32,7 @@ const ParseError = error{
 /// Parse CLI arguments with environment variable fallback.
 /// Caller owns no memory — all returned slices point into argv or env storage
 /// (both managed by the OS, valid for the process lifetime).
-pub fn parse(allocator: std.mem.Allocator) (ParseError || std.process.ArgIterator.InitError)!Config {
+pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseError || std.process.Args.Iterator.InitError)!Config {
     var config = Config{};
 
     // Track which fields were set by CLI args (env vars only apply to unset fields)
@@ -47,7 +48,7 @@ pub fn parse(allocator: std.mem.Allocator) (ParseError || std.process.ArgIterato
     var cli_watch = false;
 
     // Parse CLI arguments
-    var args = try std.process.argsWithAllocator(allocator);
+    var args = try args_ctx.iterateAllocator(allocator);
     defer args.deinit();
 
     _ = args.skip(); // skip program name
@@ -100,44 +101,44 @@ pub fn parse(allocator: std.mem.Allocator) (ParseError || std.process.ArgIterato
 
     // Apply environment variable fallbacks for fields not set by CLI
     if (!cli_host) {
-        if (std.posix.getenv("KEYWAY_HOST")) |val| config.host = val;
+        if (helpers.getenv("KEYWAY_HOST")) |val| config.host = val;
     }
     if (!cli_port) {
-        if (std.posix.getenv("KEYWAY_PORT")) |val| {
+        if (helpers.getenv("KEYWAY_PORT")) |val| {
             config.port = std.fmt.parseInt(u16, val, 10) catch return ParseError.InvalidPort;
         }
     }
     if (!cli_workers) {
-        if (std.posix.getenv("KEYWAY_WORKERS")) |val| {
+        if (helpers.getenv("KEYWAY_WORKERS")) |val| {
             config.workers = std.fmt.parseInt(u16, val, 10) catch return ParseError.InvalidWorkers;
         }
     }
     if (!cli_script) {
-        if (std.posix.getenv("KEYWAY_SCRIPT")) |val| config.script = val;
+        if (helpers.getenv("KEYWAY_SCRIPT")) |val| config.script = val;
     }
     if (!cli_tls_cert) {
-        if (std.posix.getenv("KEYWAY_TLS_CERT")) |val| config.tls_cert_path = val;
+        if (helpers.getenv("KEYWAY_TLS_CERT")) |val| config.tls_cert_path = val;
     }
     if (!cli_tls_key) {
-        if (std.posix.getenv("KEYWAY_TLS_KEY")) |val| config.tls_key_path = val;
+        if (helpers.getenv("KEYWAY_TLS_KEY")) |val| config.tls_key_path = val;
     }
     if (!cli_log_level) {
-        if (std.posix.getenv("KEYWAY_LOG_LEVEL")) |val| {
+        if (helpers.getenv("KEYWAY_LOG_LEVEL")) |val| {
             config.log_level = parseLogLevel(val) orelse return ParseError.InvalidLogLevel;
         }
     }
     if (!cli_log_format) {
-        if (std.posix.getenv("KEYWAY_LOG_FORMAT")) |val| {
+        if (helpers.getenv("KEYWAY_LOG_FORMAT")) |val| {
             config.log_format = parseLogFormat(val) orelse return ParseError.InvalidLogFormat;
         }
     }
     if (!cli_enable_bpf) {
-        if (std.posix.getenv("KEYWAY_ENABLE_BPF")) |val| {
+        if (helpers.getenv("KEYWAY_ENABLE_BPF")) |val| {
             config.enable_bpf = std.mem.eql(u8, val, "1") or std.mem.eql(u8, val, "true");
         }
     }
     if (!cli_watch) {
-        if (std.posix.getenv("KEYWAY_WATCH")) |val| {
+        if (helpers.getenv("KEYWAY_WATCH")) |val| {
             config.watch = std.mem.eql(u8, val, "1") or std.mem.eql(u8, val, "true");
         }
     }
@@ -181,10 +182,7 @@ pub fn printHelp() void {
         \\  -v, --version       Show version information
         \\
     ;
-    var buf: [64]u8 = undefined;
-    const stderr = std.debug.lockStderrWriter(&buf);
-    defer std.debug.unlockStderrWriter();
-    stderr.writeAll(usage) catch {};
+    std.debug.print("{s}", .{usage});
 }
 
 // ---------------------------------------------------------------------------
@@ -229,7 +227,7 @@ test "parse returns defaults when no args or env vars" {
 
 test "env var fallback for KEYWAY_PORT" {
     // Verify the default port when KEYWAY_PORT is not set.
-    if (std.posix.getenv("KEYWAY_PORT") == null) {
+    if (helpers.getenv("KEYWAY_PORT") == null) {
         const c = Config{};
         try std.testing.expectEqual(@as(u16, 8080), c.port);
     }

--- a/src/util/helpers.zig
+++ b/src/util/helpers.zig
@@ -4,7 +4,81 @@ pub fn castUserdata(comptime T: type, ud: ?*anyopaque) *T {
     return @as(*T, @ptrCast(@alignCast(ud.?)));
 }
 
-const testing = @import("std").testing;
+/// Look up an environment variable via libc. `std.posix.getenv` was removed in
+/// Zig 0.16; libc is always linked (see build.zig addSharedDeps). The returned
+/// slice is valid for the process lifetime.
+pub fn getenv(name: [*:0]const u8) ?[]const u8 {
+    return if (std.c.getenv(name)) |v| std.mem.span(v) else null;
+}
+
+/// Close a raw file descriptor. `std.posix.close` was removed in Zig 0.16;
+/// libc is always linked (see build.zig addSharedDeps).
+pub fn closeFd(fd: std.posix.fd_t) void {
+    _ = std.c.close(fd);
+}
+
+/// Monotonic clock in nanoseconds. `std.time.*Timestamp` were removed in Zig
+/// 0.16; this reads CLOCK_MONOTONIC via the vDSO (no syscall). keyway only ever
+/// measures durations, so a monotonic (not wall-clock) source is correct.
+pub fn monotonicNanos() i64 {
+    var ts: std.os.linux.timespec = undefined;
+    _ = std.os.linux.clock_gettime(.MONOTONIC, &ts);
+    return @as(i64, @intCast(ts.sec)) * std.time.ns_per_s + @as(i64, @intCast(ts.nsec));
+}
+
+// -- Raw syscall wrappers ---------------------------------------------------
+// Zig 0.16 removed most `std.posix.*` syscall wrappers. These reimplement the
+// few keyway needs via raw `std.os.linux` / libc calls. Errno decode mirrors
+// the manual decoder in src/tls/tls.zig (raw syscalls return -errno as usize).
+
+fn syscallErrno(rc: usize) std.posix.E {
+    const signed: isize = @bitCast(rc);
+    if (signed < 0 and signed > -4096) return @enumFromInt(@as(u16, @intCast(-signed)));
+    return .SUCCESS;
+}
+
+/// `std.posix.pread` replacement (removed in 0.16).
+pub fn pread(fd: std.posix.fd_t, buf: []u8, offset: u64) !usize {
+    const rc = std.os.linux.pread(fd, buf.ptr, buf.len, @intCast(offset));
+    if (syscallErrno(rc) != .SUCCESS) return error.PReadFailed;
+    return rc;
+}
+
+/// `std.posix.pipe` replacement (removed in 0.16).
+pub fn pipe() ![2]std.posix.fd_t {
+    var fds: [2]std.posix.fd_t = undefined;
+    if (syscallErrno(std.os.linux.pipe(&fds)) != .SUCCESS) return error.PipeFailed;
+    return fds;
+}
+
+/// Best-effort SHUT_RDWR; `std.posix.shutdown` was removed in 0.16.
+pub fn shutdownBoth(fd: std.posix.fd_t) void {
+    _ = std.os.linux.shutdown(fd, 2); // 2 = SHUT_RDWR
+}
+
+/// `std.posix.inotify_init1` replacement (removed in 0.16).
+pub fn inotifyInit1(flags: u32) !std.posix.fd_t {
+    const rc = std.os.linux.inotify_init1(flags);
+    if (syscallErrno(rc) != .SUCCESS) return error.InotifyInitFailed;
+    return @intCast(rc);
+}
+
+/// `std.posix.inotify_add_watch` replacement (removed in 0.16).
+pub fn inotifyAddWatch(fd: std.posix.fd_t, path: [*:0]const u8, mask: u32) !i32 {
+    const rc = std.os.linux.inotify_add_watch(fd, path, mask);
+    if (syscallErrno(rc) != .SUCCESS) return error.InotifyAddWatchFailed;
+    return @intCast(rc);
+}
+
+/// `std.posix.socket` replacement (removed in 0.16).
+pub fn socket(domain: u32, sock_type: u32, protocol: u32) !std.posix.fd_t {
+    const rc = std.os.linux.socket(domain, sock_type, protocol);
+    if (syscallErrno(rc) != .SUCCESS) return error.SocketCreationFailed;
+    return @intCast(rc);
+}
+
+const std = @import("std");
+const testing = std.testing;
 
 test "castUserdata round-trips a struct pointer" {
     const Point = struct { x: i32, y: i32 };


### PR DESCRIPTION
Migrates keyway from Zig 0.15.0 to 0.16.0. `zig build` and `zig build test` are green.

## Highlights
- **deps (#77):** libxev + zig-luajit pinned to immutable commit SHAs; metrics/logz bumped 0.16-compatible
- **args (#79):** `main(std.process.Init.Minimal)` + `Args.iterateAllocator`
- **Writergate (#80):** `Writer.fixed` / `Writer.Allocating`; `std.debug.print` for stderr
- **clock (#81):** `clock_gettime(MONOTONIC)` via vDSO (no syscall)
- **metrics/logz (#82):** new io-param API, each backed by a `std.Io.Threaded`
- **sockets (#37):** `std.net` → `std.Io.net.IpAddress`; `xev.TCP` listen socket; `std.Io.Mutex` for SSE
- **file I/O (#78):** `std.fs` → `std.Io.Dir`/`File` with a per-call Threaded io
- **posix removals + ArrayList (#36):** close/socket/pipe/shutdown/fstat/pread/inotify centralized in `util/helpers.zig`; `.{}` → `.empty`
- **toolchain (#39):** `minimum_zig_version` + CI + Dockerfiles → 0.16.0

## Caveats
- The blocking reverse proxy was migrated off `std.net` (now `std.Io.net`) but **still blocks the worker thread** — async rework remains tracked in **#29**.
- Bun integration suite not run here (needs a live server); verified `zig build test` only.
- **#38** (OpenSSL `@cImport` → `addTranslateC`) left open — optional refactor, not required for the migration.

Closes #35
Closes #36
Closes #37
Closes #39
Closes #77
Closes #78
Closes #79
Closes #80
Closes #81
Closes #82
