### PR TITLE
fix(static): canonicalize files with realPathFile, not openDir (#84)

### DIFF
--- a/.claude/rules/zig-gotchas.md
+++ b/.claude/rules/zig-gotchas.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "src/**/*.zig"
+  - "build.zig"
+  - "build.zig.zon"
+---
+
+# Zig Gotchas (keyway — LuaJIT via zig-luajit, libxev)
+
+Read this before editing any `.zig` file. (Zig version + deps live in `build.zig.zon`; in-flight language migrations live in the issue tracker, not here.)
+
+- **LuaJIT, not Lua 5.4.** Semantics are Lua 5.1 + a few 5.2 extensions. No 5.3/5.4 features: no `//` integer division, no `<close>` to-be-closed vars, no integer subtype. Bit ops come from the `bit` library.
+- **Cosocket coroutine hack — keep it.** zig-luajit marks `resumeCoroutine`/`yieldCoroutine` private. We declare `extern "c" fn lua_yield` (in `src/io/ring_api.zig`, `src/io/io_request.zig`) and export `lua_resume` (in `src/lua/lua_state.zig`), calling them via `@ptrCast(lua)` because `*Lua` maps 1:1 to `lua_State*`. Don't route this through the wrapper API.
+- **GCC 15 linker workaround — don't remove.** `link_gc_sections = true` in `build.zig`: GCC 15's `crt1.o` has `.sframe` sections with `R_X86_64_PC64` relocations that Zig's bundled lld can't handle; `--gc-sections` discards the unreferenced ones.
+- **`rdynamic` on the exe** (`build.zig`) exports symbols so Lua `.so` modules (LuaRocks) resolve at runtime. Don't drop it.
+- **OpenSSL is a system lib** — `linkSystemLibrary("ssl")` / `("crypto")` + inline `@cImport` in `src/tls/tls.zig`.
+- **`std.debug.assert` is stripped in release builds.** Never use it as a runtime guard for conditions that can actually occur (bad input, ring overflow, null state) — use real error returns.
+- **Proactor rule (it bites here):** no blocking syscalls on the worker thread — no `std.net.tcpConnectToHost`, no blocking `read`/`pread`/`writeAll`. All I/O goes through libxev/io_uring. See MANIFEST.md.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "enabledPlugins": {
     "impeccable@impeccable": true
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null || exit 0; if git diff --name-only HEAD 2>/dev/null | grep -q '^src/.*\\.zig$'; then if zig build test >/dev/null 2>&1; then echo 'Verify gate: zig build test PASSED.' >&2; else echo 'Verify gate: zig build test FAILED (advisory, not blocking) - run zig build test to see errors. Verify before done.' >&2; fi; fi; exit 0"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,38 @@
-# CLAUDE.md
+# Keyway
 
-## Build Commands
+A programmable HTTP engine: **Zig owns the execution engine** (memory, io_uring via libxev, LuaJIT); **Lua expresses routing/policy** as declarative state on `ctx` — it never performs I/O. Stack: Zig, LuaJIT, libxev, picohttpparser, eBPF.
+
+**What it's for:** a programmable reverse proxy / API gateway (peers: OpenResty, Kong, Envoy) — Lua expresses routing, auth, rate-limiting, transforms, and TLS as *policy*, not app logic. Craft-first, aspiring open-source; the dashboard is the end-to-end test client, not the product. Fuller rationale: README / MANIFEST.md.
+
+## Build & test
 
 ```bash
-zig build          # Build the keyway binary
-zig build run      # Build and run the server (listens on 0.0.0.0:8080)
-zig build test     # Run all unit tests (tests are embedded in source files)
+zig build                     # build the keyway binary
+zig build run                 # run the server (0.0.0.0:8080)
+zig build test                # unit tests (embedded in source files)
+cd tests && bun run test:ci   # bun integration suite (needs a running server)
 ```
 
-Requires Zig 0.15.0+. Dependencies (libxev, zig-luajit) are fetched via `build.zig.zon`.
+Zig version and deps: see `build.zig.zon` — the source of truth, so this file can't go stale on a bump.
 
-## What Keyway Is
+## The contracts — read these
 
-Keyway is a programmable HTTP engine where Zig owns the execution engine (memory, I/O, event loop) and Lua expresses routing policy through a declarative interface. Tech stack: Zig, LuaJIT, libxev (io_uring), picohttpparser, eBPF.
+- **MANIFEST.md** — *architecture* contract: proactor model, per-core isolation, zero-copy, request lifecycle, the Lua contract, module map. Authoritative: code conforms or the deviation is justified.
+- **.claude/rules/zig-gotchas.md** — read before editing any `.zig`.
 
-## Architecture
+## Working conventions
 
-Read **MANIFEST.md** — it is the authoritative design contract. Key rules:
+Work is tracked as **GitHub Issues** (the backlog, hand-driven via `gh`). Branch `kw/<issue#>-<slug>`; PR body contains `Closes #<issue#>`. **No AI/Claude attribution in commits or PRs.**
 
-- **Proactor model**: Lua never performs I/O. Lua sets fields on `ctx`, Zig submits all I/O via io_uring/libxev.
-- **Per-core isolation**: One worker thread per CPU core. Each owns its own xev loop, LuaJIT state, router, and server socket (`SO_REUSEPORT`). No sharing, no locking.
-- **Lua contract**: Lua interacts only with `ctx` (HttpExchange userdata) through metatables. State assignment, not method calls. Routes registered via `keyway.routes`.
-- **Zero-copy default**: Headers/path/body are slices into `LinearBuffer`. Copying is a failure mode.
+## Non-negotiables
 
-### Cosocket Key Constraint
+- **Proactor:** Lua never does I/O or syscalls — it sets fields on `ctx`; Zig submits all I/O via libxev/io_uring.
+- **Per-core isolation:** one thread / one xev loop / one LuaState / one Router per core, `SO_REUSEPORT`. No sharing, no hot-path locks.
+- **Zero-copy default:** headers/path/body are slices into the read buffer. Copying is a failure mode.
+- **Surgical & minimal:** touch only what the task needs; simplest change that works; no speculative abstractions. Spot something incoherent? File an issue — don't fix it inline.
+- **Verify before done:** `zig build test` + the bun integration suite must pass.
 
-zig-luajit marks `resumeCoroutine`/`yieldCoroutine` as private. We declare `extern "c" fn lua_resume` and `@ptrCast` the `*Lua` to call it directly.
+## Testing & tone
 
-## Principles
-
-- **Simplicity, not timidity**: Default to the simplest change — but when something architecturally incoherent is spotted (bad abstraction, misplaced responsibility, structural bug), **stop, note it, and surface it to the user**. Don't silently fix it or silently ignore it. The user decides whether to re-plan now or finish current work and address it later.
-- **Root causes, not patches**: Find the real problem. No temporary fixes.
-- **Verify before done**: Run `zig build test`, check compilation, demonstrate the fix.
-
-## Testing Philosophy
-
-**Integration-first, DDD/TDD red-green cycle.** Don't think in small unit tests. Think in integration tests that prove the architecture works end-to-end.
-
-The **dashboard is the integration test client** — a real consumer of the Zig server that exercises the architecture (HTTP, WebSocket, SSE, cosocket, routing). Bugs found through the dashboard are categorized, isolated, and fixed against the real server.
-
-### Bug Triage by Layer
-
-Each layer (JS, Lua, Zig) is well-understood in isolation. JS and Lua have rich ecosystems, stdlib, and tooling — if something breaks at those layers using standard, well-known patterns, **the bug is below them**. Use this to triage:
-
-1. **JS layer issue** → likely surfaces a Lua-layer limitation or mismatch
-2. **Lua layer issue** → likely surfaces a Zig-layer implementation bug or missing capability
-3. Each layer is encapsulated — if it's coherent on its own level, the flaw comes from the layer below
-
-This layered debugging model is how we pinpoint Zig implementation issues efficiently. Problems at higher layers are symptoms; the Zig engine is where root causes live.
-
-### Test Stack
-
-- **Zig side**: `zig build test` for internal correctness (embedded tests in source files)
-- **Integration side**: `bun test` against a running keyway server
-  - Native `fetch`, `WebSocket`, `EventSource` — no mock libraries
-  - `Bun.spawn()` manages server lifecycle (start in `beforeAll`, kill in `afterAll`)
-  - `--preload` for global server setup across suites
-  - `CLAUDECODE=1 bun test --bail --timeout 10000` for agentic workflows (failures only)
-- **Later**: Playwright for browser-based dashboard UI testing
+- **Integration-first.** The dashboard is the integration test client. Triage by layer: if JS/Lua breaks using standard patterns, the real bug is usually in the layer below — the Zig engine is where root causes live.
+- **Skeptical mentor.** Default stance is challenge, not agreement: decompose from first principles (what *genus*? essential vs. accidental?), research current (2025–2026) practice, critique the tradeoffs — *then* recommend. If an idea is genuinely good, say why. Terse, direct — a senior engineer who's seen too many rewrites.

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,42 +1,25 @@
 # MANIFEST.md — Keyway Architectural Contract
 
-This document is the authoritative design contract for Keyway, a programmable HTTP engine. All code must conform to these rules. Deviations require explicit justification and approval.
+The authoritative design contract. Code conforms to these rules; deviations require explicit justification and approval.
 
 ## 1. Execution Model: Proactor
 
-Lua **never** performs I/O. Lua **never** calls syscalls. Lua **never** manages lifetimes.
-
-Lua describes intent by setting fields on `ctx` (the HttpExchange userdata). Zig reads that intent and submits all I/O via io_uring through libxev. This separation is the foundational rule of the system.
+Lua **never** performs I/O, calls syscalls, or manages lifetimes. Lua describes intent by setting fields on `ctx` (the HttpExchange userdata); Zig reads that intent and submits all I/O via io_uring through libxev.
 
 ```
 Lua: ctx.status = 200; ctx.body = "hello"   -- state assignment only
-Zig: reads ctx fields → serializes response → submits async send via libxev
+Zig: reads ctx → serializes response → submits async send via libxev
 ```
 
-The proactor model means:
-- All I/O is initiated by Zig, completed asynchronously by the kernel
-- libxev callbacks dispatch to the next stage; they do not contain business logic
-- Lua coroutines yield on cosocket operations; Zig resumes them when I/O completes
+- All I/O is initiated by Zig, completed asynchronously by the kernel.
+- libxev callbacks **dispatch** to the next stage; they hold no business logic.
+- Lua coroutines yield on cosocket ops; Zig resumes them when I/O completes.
 
 ## 2. Per-Core Isolation
 
-Each CPU core runs exactly one worker thread. Each worker owns:
+One worker thread per CPU core, pinned for cache locality. Each worker exclusively owns its `xev.Loop`, `LuaState`, `Router`, server socket (`SO_REUSEPORT`, kernel distributes), `SseRegistry`, `ConnectionPool`. `TlsContext` is shared read-only (immutable after init).
 
-| Resource | Type | Sharing |
-|---|---|---|
-| Event loop | `xev.Loop` | None |
-| Lua state | `LuaState` | None |
-| Router | `Router` | None (loaded independently) |
-| Server socket | TCP listener | `SO_REUSEPORT` (kernel distributes) |
-| SSE registry | `SseRegistry` | None (cross-worker via `SseBroadcastBus`) |
-| Connection pool | `ConnectionPool` | None |
-| TLS context | `TlsContext` | Shared read-only (immutable after init) |
-
-**No Lua state is shared. No cross-thread access. No mutexes on the hot path.**
-
-Workers are pinned to CPU cores for cache locality. eBPF can optionally provide connection affinity so the same client always hits the same worker.
-
-The only cross-worker mechanism is `SseBroadcastBus`, which uses per-worker mutex-protected inboxes and `xev.Async` notifiers to wake target event loops.
+**No Lua state is shared. No cross-thread access. No mutexes on the hot path.** The only cross-worker mechanism is `SseBroadcastBus` (per-worker mutex-protected inboxes + `xev.Async` notifiers). eBPF can optionally pin a client to the same worker.
 
 ## 3. Request Lifecycle
 
@@ -44,108 +27,49 @@ The only cross-worker mechanism is `SseBroadcastBus`, which uses per-worker mute
 Accept → Read → Parse → Route → Execute → Respond → Reuse
 ```
 
-1. **Accept** — `Server.onAccept` creates a `Connection` with an arena allocator. If TLS is configured, `conn_tls.initTls` starts the handshake state machine.
-
-2. **Read** — libxev async recv fills the `LinearBuffer`. Callback: `Connection.onRead`. For TLS connections, ciphertext is fed through `conn_tls` which decrypts into the plaintext buffer.
-
-3. **Parse** — `http.Parser` (picohttpparser via C FFI) produces a zero-copy `Request`. All header names, values, path, and method are slices into the `LinearBuffer`. No allocations.
-
-4. **Route** — `Router.match` performs O(path-length) trie lookup, populating a `ParamArray` (inline array, max 4 params, zero heap allocation). Query string is parsed into `QueryArray` via `parseQueryString`.
-
-5. **Execute** — `LuaState.callLuaHandler` creates a Lua coroutine (`lua_newthread` + `lua_resume`), passes `HttpExchange` userdata. The handler reads request data and sets response fields on `ctx`. If the handler calls cosocket APIs, the coroutine yields and Zig submits the I/O; on completion, Zig resumes the coroutine.
-
-6. **Respond** — `HttpExchange.toResponse` builds the `Response`, `Response.serialize` writes headers + body into the send buffer, libxev async send transmits it. Special paths: SSE upgrade (`conn_sse`), WebSocket upgrade (`conn_ws`), chunked streaming (`conn_stream`). Static file routes (`static.zig`) short-circuit before Lua dispatch — served entirely in Zig with ETag/Last-Modified caching.
-
-7. **Reuse** — Arena reset + buffer reset for HTTP/1.1 keep-alive. The `Connection` is ready for the next request on the same socket.
+1. **Accept** — `Server.onAccept` makes a `Connection` with an arena allocator; TLS starts `conn_tls` handshake.
+2. **Read** — libxev recv fills the `LinearBuffer`; TLS ciphertext is decrypted through `conn_tls`.
+3. **Parse** — picohttpparser (C FFI) yields a zero-copy `Request` — method/path/headers/body are slices into the buffer, no allocations.
+4. **Route** — `Router.match` does an O(path-length) trie lookup into inline `ParamArray`/`QueryArray` (zero heap).
+5. **Execute** — `LuaState.callLuaHandler` runs a Lua coroutine with the `HttpExchange` userdata; cosocket calls yield → Zig does the I/O → Zig resumes.
+6. **Respond** — `HttpExchange.toResponse` → `Response.serialize` → async send. Special paths: SSE (`conn_sse`), WebSocket (`conn_ws`), chunked (`conn_stream`). Static routes short-circuit before Lua (`static.zig`, ETag/Last-Modified).
+7. **Reuse** — arena + buffer reset for keep-alive; if the response exceeded `LARGE_RESPONSE_THRESHOLD`, arena backing memory is freed to bound growth.
 
 ## 4. Memory Model
 
-### Zero-Copy Default
+- **Zero-copy default** — request data stays in `LinearBuffer`; slices, never copies. Copying is a failure mode.
+- **Arena-per-request** — every per-request allocation uses the `Connection`'s arena; reset after send.
+- **Pointer-in-userdata** — Lua gets a userdata holding a pointer to the arena-allocated `HttpExchange`, so coroutines can't touch another request's state.
+- **Inline params** — `ParamArray`/`QueryArray` are fixed-size inline arrays (caps in `config.zig`), no heap.
+- **Connection pooling** — cosocket connections pooled per-worker by `host:port`, LIFO, lazy expiry.
 
-Request data lives in `LinearBuffer`. Headers, path, method, and body are slices into this buffer — never copied. Copying data is a failure mode that must be justified.
+## 5. Module Map
 
-### Arena Per-Request
+Source lives under `src/`, grouped by responsibility. Read the directory, not a per-file list (which rots):
 
-Each `Connection` owns an arena allocator. All per-request allocations (HttpExchange userdata, formatted strings, response bodies) use this arena. After the response is sent, the arena is reset. If the response exceeded `LARGE_RESPONSE_THRESHOLD`, the arena backing memory is freed entirely to prevent unbounded growth on keep-alive connections.
-
-### Pointer-in-Userdata
-
-`HttpExchange` is a Zig struct allocated in the arena. Lua receives a userdata containing a pointer to this struct. This avoids the singleton-sharing problem: each request has its own userdata, and coroutines cannot accidentally access another request's state.
-
-### Inline Parameter Storage
-
-`ParamArray` (route params) and `QueryArray` (query params) are fixed-size inline arrays on the `Connection` struct. No heap allocation for parameter storage. Maximum counts are configured in `config.zig`.
-
-### Connection Pooling
-
-Cosocket connections are pooled per-worker in `ConnectionPool`, keyed by destination (host:port), using LIFO ordering with lazy expiry. Pooled connections avoid repeated TCP handshakes and TLS negotiations.
-
-## 5. Module Architecture
-
-| Module | Role |
+| Dir | Owns |
 |---|---|
-| `main.zig` | Entry point, creates `ThreadPool` |
-| `worker.zig` | Per-core thread with CPU pinning, owns xev.Loop + LuaState + Router + Server |
-| `server.zig` | TCP listener, accept loop, SO_REUSEPORT, BPF attachment, TLS context init |
-| `handler.zig` | `Connection` struct — socket lifecycle, read/write completions, arena, buffers, `SuspendedState` for coroutine yield/resume |
-| `lua_state.zig` | LuaJIT state management, handler dispatch, coroutine lifecycle |
-| `lua_api.zig` | Lua metatables for `ctx` (HttpExchange), headers proxy, params table, cosocket API registration |
-| `route_loader.zig` | Route table processing from Lua `keyway.routes` declarations |
-| `http_exchange.zig` | `HttpExchange` — the single Lua-visible object binding request/response |
-| `http.zig` | HTTP types (`Request`, `Response`, `Header`), picohttpparser C bindings, response serialization |
-| `router.zig` | Segment-level trie router with `{param}` support, zero-alloc matching |
-| `params.zig` | `ParamArray`, `QueryArray`, `parseQueryString` — inline parameter storage |
-| `buffer.zig` | `LinearBuffer` for single-request I/O |
-| `config.zig` | Centralized tunable constants (buffer sizes, limits, capacities) |
-| `ring.zig` | `IoEntry` tagged union, `SubmissionRing`, `CompletionRing` for batched cosocket I/O |
-| `ring_api.zig` | Lua C API for ring push/submit/result |
-| `cosocket.zig` | Outbound I/O engine: submission ring drain, batch ops, coroutine resume |
-| `io_request.zig` | `IoRequest` — typed outbound I/O descriptor passed from Lua cosocket API to Zig |
-| `connection_pool.zig` | Per-worker cosocket connection pool, keyed by destination, LIFO, lazy expiry |
-| `tls.zig` | `TlsConn`, `TlsContext`, `ClientTlsContext`, `TlsManager` — TLS primitives |
-| `conn_tls.zig` | Inbound TLS handshake/decrypt state machine for accepted connections |
-| `conn_ws.zig` | WebSocket upgrade, frame encoding/decoding, send/recv |
-| `ws.zig` | WebSocket frame parsing (low-level) |
-| `conn_sse.zig` | SSE upgrade, per-connection send, disconnect watch |
-| `sse.zig` | `SseRegistry` (per-worker room→subscribers), `SseBroadcastBus` (cross-worker pub/sub) |
-| `conn_stream.zig` | Chunked transfer encoding streaming — yield-to-flush abstraction |
-| `static.zig` | Static file serving — pread+send with ETag/Last-Modified caching |
-| `shutdown.zig` | Graceful shutdown coordination (running → draining → force_shutdown) |
-| `cli.zig` | CLI argument parsing with environment variable fallback |
-| `error_response.zig` | Unified error response model — ErrorCategory → status/body/log-level |
-| `cosocket_tls.zig` | Outbound cosocket TLS handshake state machine (client-side) |
-| `cosocket_ops.zig` | Interpret functions for cosocket completion results |
-| `helpers.zig` | Shared utility: `castUserdata` for xev callback pointer casts |
-| `metrics.zig` | Per-worker atomic metrics for health monitoring |
-| `bpf_reuseport.zig` | Classic BPF program generation for SO_REUSEPORT worker affinity |
-| `log.zig` | Custom log formatting |
+| `core/` | Per-core lifecycle: `main`→`ThreadPool`→`worker` (CPU-pinned, owns loop+LuaState+Router+Server), `server` (accept, SO_REUSEPORT, BPF, TLS init), `handler` (`Connection`: socket lifecycle, read/write completions, arena, coroutine suspend/resume), `shutdown`, `reload`. |
+| `http/` | HTTP path: `http` (Request/Response/parser bindings/serialize), `router` (zero-alloc trie), `route_loader`, `http_exchange` (the Lua-visible `ctx`), `params`, `static`, `error_response`. |
+| `io/` | Outbound I/O + rings: `cosocket`(+`_ops`), `ring`/`ring_api` (IoEntry rings), `io_request`, `connection_pool`, `file_watcher`, `bpf_reuseport`. |
+| `lua/` | LuaJIT: `lua_state` (state, handler dispatch, coroutine lifecycle), `lua_api` (ctx/headers/params metatables, cosocket registration), `json`. |
+| `protocol/` | Upgraded protocols: `ws`/`conn_ws`, `sse`/`conn_sse` (SseRegistry + SseBroadcastBus), `conn_stream`. |
+| `tls/` | `tls` (TlsContext/TlsConn/kTLS), `conn_tls` (inbound), `cosocket_tls` (outbound client). |
+| `observability/` | `metrics` (per-worker atomics), `prom` (Prometheus export), `log`. |
+| `util/` | `buffer` (LinearBuffer), `config` (tunable constants), `cli`, `helpers` (`castUserdata`), `clock`. |
 
 ## 6. The Lua Contract
 
-Lua interacts only with `ctx` (HttpExchange userdata) through metatables:
+Lua touches only `ctx` through metatables. **Read:** `ctx.method/.path/.body`, `ctx.params.id`, `ctx.headers["Key"]`, `ctx.query.name`. **Write:** `ctx.status`, `ctx.body`, `ctx.headers["Key"]`. No verbs (`send()`/`write()`) — state assignment only. Routes register via the declarative `keyway.routes` table; middleware chains at global and per-route levels.
 
-**Read:** `ctx.method`, `ctx.path`, `ctx.body`, `ctx.params.id`, `ctx.headers["Key"]`, `ctx.query.name`
+Cosocket ops (`keyway.tcp_connect`, socket methods) are the one exception: function calls that **yield** the coroutine — but Lua still performs no I/O; it yields, Zig does the I/O and resumes with the result.
 
-**Write:** `ctx.status = 200`, `ctx.body = "..."`, `ctx.headers["Key"] = "value"`
+## 7. Design Rules (non-negotiable)
 
-No verbs (`send()`, `write()`). Only state assignment. Routes are registered via the declarative `keyway.routes` table. Middleware chains are supported at global and per-route levels.
-
-Cosocket operations (`keyway.tcp_connect`, socket methods) are the exception: they are function calls that yield the Lua coroutine. But even here, Lua does not perform the I/O — it yields, Zig performs the I/O, and Zig resumes Lua with the result.
-
-## 7. Design Rules
-
-These rules are non-negotiable:
-
-1. **Lua never performs syscalls or manages lifetimes.** Lua expresses intent through state assignment. Zig owns all I/O and memory.
-
-2. **Zero-copy is the default.** Copying data is a failure mode. Request headers, path, and body are slices into the read buffer.
-
-3. **libxev callbacks dispatch, not decide.** Callbacks transition to the next state. Business logic lives in the handler or Lua.
-
-4. **Each layer has one job.** Modules do not compensate for failures in other modules. The router routes. The parser parses. The handler manages connection state.
-
-5. **One core, one thread, one Lua state.** No sharing, no locking on the hot path. Cross-worker communication uses explicit message passing (SseBroadcastBus).
-
-6. **Arena-per-request.** All per-request allocations use the connection's arena. Reset after response. No garbage accumulation.
-
-7. **Inline over heap.** Fixed-size arrays (ParamArray, IoEntry rings) are preferred over heap-allocated dynamic containers when bounds are known.
+1. **Lua never does syscalls or manages lifetimes** — intent via state assignment; Zig owns all I/O and memory.
+2. **Zero-copy is the default** — copying request data is a failure mode.
+3. **libxev callbacks dispatch, not decide** — business logic lives in the handler or Lua.
+4. **Each layer has one job** — modules don't compensate for other modules' failures.
+5. **One core, one thread, one Lua state** — no hot-path sharing/locking; cross-worker only via `SseBroadcastBus`.
+6. **Arena-per-request** — reset after response; no garbage accumulation.
+7. **Inline over heap** — fixed-size arrays when bounds are known.

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -95,6 +95,22 @@ fn formatHttpDate(buf: *[29]u8, epoch_secs: i64) void {
     }) catch {};
 }
 
+/// Map a static-file I/O error to an HTTP response.
+/// A missing entry is the client's problem (404); permissions, I/O, fd
+/// exhaustion, etc. are the server failing to read its own files (500).
+fn sendStaticError(self: *Connection, err: anyerror, server_msg: []const u8) void {
+    switch (err) {
+        error.FileNotFound, error.NotDir => {
+            self.logAccess(404);
+            error_response.sendErrorStatus(self, 404, "static file not found");
+        },
+        else => {
+            self.logAccess(500);
+            error_response.sendErrorStatus(self, 500, server_msg);
+        },
+    }
+}
+
 /// Serve a static file. Called from handler.zig routeRequest.
 pub fn serveStaticFile(
     self: *Connection,
@@ -146,16 +162,10 @@ pub fn serveStaticFile(
     var resolve_io: std.Io.Threaded = .init(alloc, .{});
     defer resolve_io.deinit();
     const real_resolved = blk: {
-        var rh = std.Io.Dir.cwd().openDir(resolve_io.io(), resolved, .{}) catch {
-            self.logAccess(404);
-            self.send404NotFound();
-            return;
-        };
-        defer rh.close(resolve_io.io());
+        // realPathFile canonicalizes a file path (openDir would fail with NotDir on a regular file).
         var pbuf: [std.fs.max_path_bytes]u8 = undefined;
-        const n = rh.realPath(resolve_io.io(), &pbuf) catch {
-            self.logAccess(404);
-            self.send404NotFound();
+        const n = std.Io.Dir.cwd().realPathFile(resolve_io.io(), resolved, &pbuf) catch |err| {
+            sendStaticError(self, err, "static realpath failed");
             return;
         };
         break :blk alloc.dupe(u8, pbuf[0..n]) catch {
@@ -178,9 +188,8 @@ pub fn serveStaticFile(
     };
     var open_io: std.Io.Threaded = .init(alloc, .{});
     defer open_io.deinit();
-    const file = std.Io.Dir.openFileAbsolute(open_io.io(), resolved_z, .{}) catch {
-        self.logAccess(404);
-        self.send404NotFound();
+    const file = std.Io.Dir.openFileAbsolute(open_io.io(), resolved_z, .{}) catch |err| {
+        sendStaticError(self, err, "static file open failed");
         return;
     };
     const fd = file.handle;


### PR DESCRIPTION
## Problem

Every static-file request 404'd; the dashboard was unreachable. `serveStaticFile` opened the resolved **file** path with `openDir`, which always fails with `NotDir` on a regular file, then fell through to a generic 404. Regression from the 0.15→0.16 `std.Io` migration — `openDir().realPath()` only works on directories.

## Fix

- Canonicalize with `std.Io.Dir.realPathFile` (the file-appropriate realpath) instead of `openDir().realPath()`. The symlink-traversal check against `real_root` is unchanged.
- Correct the not-found error semantics: `FileNotFound`/`NotDir` → **404** (client asked for a nonexistent resource), but the error union also carries `AccessDenied`, `InputOutput`, fd exhaustion, etc. — server failures that now correctly return **500** instead of masquerading as 404.
- Static misses log `"static file not found"` / server errors log a distinct message, instead of the router's `"route not found"`, so the two are distinguishable in logs (the secondary bug in the issue).

## Verification

- `zig build` + `zig build test` pass.
- `cd tests && bun run test:ci` — 15/15 pass, including the previously-failing `dashboard.test.ts`.
- Manual repro: `GET /__keyway/dashboard` → 200, `/__keyway/dashboard/main.js` → 200, a genuine miss → 404 with `msg="static file not found"`.

Closes #84