### PR TITLE
fix(sse): remove dead SseBroadcastBus.subscriberCount

### DIFF
--- a/src/protocol/sse.zig
+++ b/src/protocol/sse.zig
@@ -199,12 +199,6 @@ pub const SseBroadcastBus = struct {
         }
     }
 
-    /// Return subscriber count for a room (used in tests).
-    pub fn subscriberCount(self: *SseRegistry, room: []const u8) usize {
-        const list = self.rooms.getPtr(room) orelse return 0;
-        return list.items.len;
-    }
-
     /// xev.Async callback — fires on the worker's event loop thread.
     fn onNotify(
         self_opt: ?*SseBroadcastBus,


### PR DESCRIPTION
`subscriberCount` was declared inside `SseBroadcastBus` but typed `self: *SseRegistry` and reads `self.rooms` — a field that only exists on `SseRegistry`. It has no callers (all tests use `SseRegistry.subscriberCount`), so it's unreachable and would fail to compile against a real bus instance anyway. Deleted.

Closes #34