### PR TITLE
fix(core): exit promptly on SIGINT/SIGTERM instead of hanging

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -1087,6 +1087,16 @@ pub const Connection = struct {
         // Decrement active connection counter
         self.server.metrics.decrementActiveConnections();
         prom.connectionClosed();
+        // If this was the last connection during drain, finish shutdown now
+        // rather than waiting out the drain deadline.
+        self.server.maybeFinishDrain();
+        // Cancel any armed deadline timer so a force-closed connection doesn't
+        // linger until its header/request timeout fires (issue #90 force path;
+        // also the recv-error-mid-request path). Both are refcount-safe no-ops
+        // when their timer isn't armed, and bump pending_timer_ops for the
+        // in-flight timer_remove so maybeFinishClose can't free early.
+        self.cancelHeaderTimer();
+        self.cancelRequestTimer();
         // Deferred deinit: only free when all armed cosocket completions have fired.
         // Normal HTTP connections have pending_completions == 0 (no cosocket I/O),
         // so maybeFinishClose is equivalent to deinit() in the common case.

--- a/src/core/server.zig
+++ b/src/core/server.zig
@@ -12,6 +12,7 @@ const sse = @import("../protocol/sse.zig");
 const SseRegistry = sse.SseRegistry;
 const SseBroadcastBus = sse.SseBroadcastBus;
 const ShutdownCoordinator = @import("shutdown.zig").ShutdownCoordinator;
+const FileWatcher = @import("../io/file_watcher.zig").FileWatcher;
 const tuning = @import("../util/config.zig");
 const WorkerMetrics = @import("../observability/metrics.zig").WorkerMetrics;
 const prom = @import("../observability/prom.zig");
@@ -29,8 +30,12 @@ pub const Server = struct {
     accept_completion: xev.Completion,
     accept_cancel_completion: xev.Completion = .{},
     pool_sweep_completion: xev.Completion = undefined,
+    pool_sweep_cancel_completion: xev.Completion = .{},
+    drain_timer_completion: ?*xev.Completion = null,
+    drain_timer_cancel_completion: xev.Completion = .{},
     coordinator: ?*ShutdownCoordinator = null,
     reload_coordinator: ?*@import("reload.zig").ReloadCoordinator = null,
+    file_watcher: ?*FileWatcher = null,
     worker_id: usize = 0,
     router: *Router,
     lua_state: *LuaState,
@@ -273,6 +278,15 @@ pub const Server = struct {
         self.draining = true;
     }
 
+    /// Called after a connection closes. If we're draining and this was the
+    /// last connection, wake the shutdown async so the worker exits immediately
+    /// instead of waiting out the full drain deadline. Cheap no-op otherwise.
+    pub fn maybeFinishDrain(self: *Server) void {
+        if (!self.draining or self.socket == -1) return;
+        if (self.metrics.active_connections.load(.monotonic) != 0) return;
+        if (self.coordinator) |coord| coord.getAsync(self.worker_id).notify() catch {};
+    }
+
     /// Force-close the listen socket and every tracked client connection.
     /// Safe to call multiple times (guards against double-close).
     pub fn forceCloseAll(self: *Server) void {
@@ -296,6 +310,38 @@ pub const Server = struct {
             // Wake shutdown async so it can self-disarm (sees socket == -1)
             if (self.coordinator) |coord| {
                 coord.getAsync(self.worker_id).notify() catch {};
+            }
+
+            // Wake reload async so it can self-disarm (sees socket == -1).
+            // Its wait() always rearms, so without this the loop never drains.
+            if (self.reload_coordinator) |rc| {
+                rc.getAsync(self.worker_id).notify() catch {};
+            }
+
+            // Cancel the recurring pool-sweep timer. It self-disarms on drain,
+            // but only on its next fire (up to 60s away) — too slow to exit
+            // within the drain deadline, so remove it now.
+            self.pool_sweep_cancel_completion = .{
+                .op = .{ .timer_remove = .{ .timer = &self.pool_sweep_completion } },
+                .callback = onCancelComplete,
+            };
+            self.loop.add(&self.pool_sweep_cancel_completion);
+
+            // Stop the file watcher's recurring poll timer (--watch mode) so it
+            // stops rearming and the loop can reach active == 0.
+            if (self.file_watcher) |fw| fw.draining = true;
+
+            // Cancel the drain-deadline timer if it's still pending. On force
+            // shutdown (2nd signal) the deadline is moot; without this the loop
+            // lingers until the deadline fires instead of exiting immediately.
+            if (self.drain_timer_completion) |dt| {
+                if (dt.state() == .active) {
+                    self.drain_timer_cancel_completion = .{
+                        .op = .{ .timer_remove = .{ .timer = dt } },
+                        .callback = onCancelComplete,
+                    };
+                    self.loop.add(&self.drain_timer_cancel_completion);
+                }
             }
 
             helpers.closeFd(self.socket);

--- a/src/core/worker.zig
+++ b/src/core/worker.zig
@@ -201,6 +201,7 @@ pub const Worker = struct {
             async_watcher.wait(&loop, &shutdown_completion, ShutdownContext, shutdown_ctx, onShutdownSignal);
             server.coordinator = coord;
             server.worker_id = ctx.worker_id;
+            server.drain_timer_completion = &drain_timer_completion;
         }
         server.reload_coordinator = ctx.reload_coordinator;
 
@@ -213,6 +214,8 @@ pub const Worker = struct {
                 .lua_state = &lua_state,
                 .router = &router,
                 .script_path = ctx.script_path,
+                .server = &server,
+                .allocator = ctx.allocator,
             };
             reload_async.wait(&loop, &reload_completion, ReloadContext, reload_ctx, onReloadSignal);
         }
@@ -226,6 +229,7 @@ pub const Worker = struct {
             };
             if (file_watcher) |*fw| {
                 fw.start(&loop);
+                server.file_watcher = fw;
                 log.info().string("msg", "file watcher started").string("script", ctx.script_path).log();
             }
         }
@@ -275,7 +279,9 @@ fn onShutdownSignal(
         return .disarm;
     }
 
-    log.info().string("msg", "shutting down").log();
+    // stopAccepting sets draining; a second wake (last connection closed during
+    // drain) re-enters here to finish early — don't re-log the banner.
+    if (!ctx.server.draining) log.info().string("msg", "shutting down").log();
     ctx.server.stopAccepting();
 
     const active = ctx.server.metrics.active_connections.load(.monotonic);
@@ -321,6 +327,8 @@ const ReloadContext = struct {
     lua_state: *LuaState,
     router: *Router,
     script_path: []const u8,
+    server: *Server,
+    allocator: std.mem.Allocator,
 };
 
 /// xev.Async callback — fires on the worker's event loop when reload signal received.
@@ -332,6 +340,14 @@ fn onReloadSignal(
 ) xev.CallbackAction {
     _ = r catch return .disarm;
     const ctx = ctx_opt orelse return .disarm;
+
+    // Shutdown woke us to self-disarm (forceCloseAll set socket = -1). Without
+    // this the always-rearming wait keeps loop.active > 0 and the worker never
+    // exits — see issue #90.
+    if (ctx.server.socket == -1) {
+        ctx.allocator.destroy(ctx);
+        return .disarm;
+    }
 
     log.info().string("msg", "performing hot reload").log();
     ctx.lua_state.reload(ctx.router, ctx.script_path);

--- a/src/io/file_watcher.zig
+++ b/src/io/file_watcher.zig
@@ -35,6 +35,9 @@ pub const FileWatcher = struct {
     debounce_armed: bool = false,
     debounce_completion: xev.Completion = .{},
 
+    // Set on shutdown so the recurring poll timer stops rearming (issue #90).
+    draining: bool = false,
+
     // Reload target
     lua_state: *LuaState,
     router: *Router,
@@ -125,6 +128,9 @@ pub const FileWatcher = struct {
     ) xev.CallbackAction {
         const self: *FileWatcher = @ptrCast(@alignCast(userdata orelse return .disarm));
 
+        // Shutting down — stop rearming so the loop can drain (issue #90).
+        if (self.draining) return .disarm;
+
         // Read all pending inotify events
         var buf: [4096]u8 align(@alignOf(std.os.linux.inotify_event)) = undefined;
         var has_lua_change = false;
@@ -187,6 +193,7 @@ pub const FileWatcher = struct {
     ) xev.CallbackAction {
         const self: *FileWatcher = @ptrCast(@alignCast(userdata orelse return .disarm));
         self.debounce_armed = false;
+        if (self.draining) return .disarm;
 
         log.info().string("msg", "file change detected — reloading").log();
         self.lua_state.reload(self.router, self.script_path);


### PR DESCRIPTION
Closes #90

## Problem

Workers run `loop.run(.until_done)`, which returns only once **every armed xev completion has drained**. Several shutdown-time completions were never disarmed, so the loop never reached `active == 0`, the worker thread never exited, and `pool.joinAll()` blocked forever — silently accumulating rogue, port-holding processes across a test session (the issue observed 8 live instances, oldest 2h47m).

## Root causes (all in the shutdown path)

- **reload async watcher** — `onReloadSignal` always returned `.rearm`, keeping the eventfd wait armed forever. This is the primary *infinite* hang (reproduces with plain `--workers 1`, no `--watch`).
- **file watcher poll timer** (`--watch`) — rearmed every 500ms with no drain check.
- **pool-sweep timer** — self-disarms only on its next fire, up to 60s away → exceeds the 30s drain deadline (measured: a plain `kill -INT` took ~58s even after the reload fix).
- **drain-deadline timer** — never cancelled, so a 2nd (force) signal still lingered until the full 30s deadline.
- **drain never short-circuited** — `onShutdownSignal` armed the deadline timer but nothing re-checked `active == 0` as connections closed, so *any* graceful shutdown with ≥1 live connection waited the full 30s (this is what left the integration-suite server lingering ~30s per run).
- **per-connection timers** — `close()` didn't cancel the header/request deadline timers, so a force-closed connection lingered until its own timeout fired (~10s for a half-sent header).

## Fix

`forceCloseAll` now disarms the reload async, pool-sweep timer, file watcher, and drain-deadline timer alongside the existing accept/SSE/shutdown disarms. `Connection.close()` cancels its deadline timers (refcount-safe no-ops when unarmed) and, when it's the last connection during drain, wakes the shutdown async via `maybeFinishDrain` to finish immediately. The 30s deadline remains the backstop for timeout-exempt (SSE/websocket) connections.

## Verification

- `zig build test` ✅ · `tests` bun integration suite: 15 pass / 0 fail, **zero lingering processes** after teardown (previously left a hung server) ✅
- `kill -INT` / `kill -TERM`, default and `--watch`, 1/2/4 workers → exit in ~0.1s (`--watch` ~0.4s) ✅
- 2nd signal (force path), incl. a held half-header connection → immediate exit ✅
- graceful drain short-circuits when the last connection closes (idle keep-alive closed 1.5s post-signal → server exits at 1.6s) ✅
- 30s deadline backstop still honored for a held SSE connection ✅
- 10× rapid start/stop cycles → zero lingering processes ✅