### PR TITLE
fix(io): replace debug-only guards with real runtime checks (#32, #57)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -1004,7 +1004,13 @@ pub const Connection = struct {
     /// Post-write handler for WebSocket upgrade: reset arena, consume HTTP bytes,
     /// enter WS frame read loop.
     fn handleWsPostWrite(self: *Connection, bytes_written: usize) void {
-        std.debug.assert(self.ws_state != null);
+        // state == .websocket must imply ws_state != null; if it doesn't (logic
+        // bug), close rather than let a downstream `.?` deref null in release.
+        if (self.ws_state == null) {
+            log.err().string("msg", "ws post-write with null ws_state, closing").log();
+            self.close();
+            return;
+        }
         log.debug().string("msg", "ws 101 sent, entering WS mode").int("bytes_written", bytes_written).int("raw_len", self.http_state.request_raw_len).int("buf_avail_read", self.read_buffer.availableRead()).int("buf_avail_write", self.read_buffer.availableWrite()).log();
         _ = self.arena.reset(.retain_capacity);
         if (self.http_state.request_raw_len > 0) {
@@ -1025,7 +1031,13 @@ pub const Connection = struct {
 
     /// Post-write handler for SSE upgrade: start watching for client disconnect.
     fn handleSsePostWrite(self: *Connection) void {
-        std.debug.assert(self.sse_state != null);
+        // state == .sse must imply sse_state != null; if it doesn't (logic bug),
+        // close rather than let startSseDisconnectWatch deref null in release.
+        if (self.sse_state == null) {
+            log.err().string("msg", "sse post-write with null sse_state, closing").log();
+            self.close();
+            return;
+        }
         conn_sse.startSseDisconnectWatch(self);
     }
 

--- a/src/io/cosocket.zig
+++ b/src/io/cosocket.zig
@@ -420,7 +420,13 @@ fn batchCompletionCheck(self: *Connection) void {
 /// single-shot cosocket API (connect/send/recv/close yield and resume with
 /// result values on the stack, not a CQ count).
 fn resumeSingleShot(self: *Connection, s: *SuspendedState, thread: *Lua) void {
-    const cqe = self.cs.cq.get(0);
+    const cqe = self.cs.cq.get(0) orelse {
+        // single_shot_mode was set without a completion queued — resume with an
+        // error rather than reading uninitialized ring memory.
+        cosocket_ops.pushErrorTable(thread, .server_error, "internal: missing completion");
+        dispatchResume(self, thread, 2, s.exchange);
+        return;
+    };
 
     if (cqe.err_msg) |err_msg| {
         // Error: push nil, {category=, message=}

--- a/src/io/ring.zig
+++ b/src/io/ring.zig
@@ -101,8 +101,11 @@ pub const CompletionRing = struct {
         self.tail += 1;
     }
 
-    pub inline fn get(self: *const CompletionRing, index: u8) CQEntry {
-        std.debug.assert(index < self.tail);
+    /// Returns the CQE at `index`, or null if out of bounds. Real check (not a
+    /// debug assert) so an invalid index can't read uninitialized/OOB memory in
+    /// release builds.
+    pub inline fn get(self: *const CompletionRing, index: u8) ?CQEntry {
+        if (index >= self.tail) return null;
         return self.entries[index];
     }
 
@@ -164,10 +167,11 @@ test "CompletionRing: push/get/reset" {
     cq.push(.{ .result = 5 }); // fd from connect
     cq.push(.{ .result = 6, .buf = "PONG\r\n" }); // recv result
 
-    try std.testing.expectEqual(@as(i32, 5), cq.get(0).result);
-    try std.testing.expectEqual(@as(i32, 6), cq.get(1).result);
-    try std.testing.expectEqualStrings("PONG\r\n", cq.get(1).buf.?);
-    try std.testing.expect(cq.get(0).buf == null);
+    try std.testing.expectEqual(@as(i32, 5), cq.get(0).?.result);
+    try std.testing.expectEqual(@as(i32, 6), cq.get(1).?.result);
+    try std.testing.expectEqualStrings("PONG\r\n", cq.get(1).?.buf.?);
+    try std.testing.expect(cq.get(0).?.buf == null);
+    try std.testing.expect(cq.get(2) == null); // out of bounds returns null
 
     cq.reset();
     try std.testing.expectEqual(@as(u8, 0), cq.tail);
@@ -181,15 +185,15 @@ test "CQEntry: err_category round-trips correctly" {
     cq.push(.{ .result = -1, .err_msg = "recv: alloc failed", .err_category = .server_error });
     cq.push(.{ .result = 5 }); // success entry, no category
 
-    const e0 = cq.get(0);
+    const e0 = cq.get(0).?;
     try std.testing.expectEqual(@as(i32, -1), e0.result);
     try std.testing.expectEqual(ErrorCategory.upstream_error, e0.err_category.?);
     try std.testing.expectEqualStrings("connection refused", std.mem.span(e0.err_msg.?));
 
-    const e1 = cq.get(1);
+    const e1 = cq.get(1).?;
     try std.testing.expectEqual(ErrorCategory.server_error, e1.err_category.?);
 
-    const e2 = cq.get(2);
+    const e2 = cq.get(2).?;
     try std.testing.expect(e2.err_category == null);
     try std.testing.expect(e2.err_msg == null);
 }


### PR DESCRIPTION
## What

Two related P0/P1 memory-safety fixes in the same class: `std.debug.assert` used as a runtime guard, which is stripped in `ReleaseFast`/`ReleaseSafe`.

### #32 — `CompletionRing.get()` OOB read in release
`get()` guarded its index with `std.debug.assert(index < self.tail)`. Stripped in release → an invalid CQE index read uninitialized/OOB ring memory. Now returns `?CQEntry` with a real bounds check; the sole caller (`resumeSingleShot`) resumes the coroutine with a server-error table instead of reading garbage.

### #57 — debug assertions as runtime guards in handler
`handleWsPostWrite` / `handleSsePostWrite` asserted `ws_state != null` / `sse_state != null`. In release those vanish and a downstream `.?` dereferences null (UB in ReleaseFast). Replaced with real null checks that log and close the connection.

## Scope
Surgical: only the two guard sites plus the one `get()` caller and the ring unit tests (updated for the `?CQEntry` return). No behavior change on the happy path; the invariants held by construction — this just makes the guards hold in release too.

## Verify
- `zig build test` — green
- `zig build` — green

Closes #32
Closes #57