### PR TITLE
docs(http): document addResponseHeader ownership contract (#65)

### DIFF
--- a/src/http/http_exchange.zig
+++ b/src/http/http_exchange.zig
@@ -58,7 +58,12 @@ pub const HttpExchange = struct {
         };
     }
 
-    /// Add a response header
+    /// Add a response header.
+    ///
+    /// Ownership: `name` and `value` are copied into the exchange allocator, so
+    /// the caller keeps ownership of its input buffers and may free or reuse
+    /// them immediately after this returns. The copies live for the exchange's
+    /// lifetime (freed via `toResponse` transfer or `deinit`).
     pub fn addResponseHeader(self: *HttpExchange, name: []const u8, value: []const u8) !void {
         // Copy strings from Lua memory into arena (Lua strings are temporary)
         const name_copy = try self.allocator.dupe(u8, name);


### PR DESCRIPTION
## What
Make the ownership contract of `HttpExchange.addResponseHeader` explicit in its doc comment.

## Why
Finding #65: `addResponseHeader` silently `dupe`s `name`/`value` into the exchange allocator, but the doc comment only said "Add a response header". Callers couldn't tell whether ownership of their input buffers was transferred or whether the copies would outlive the call. The behavior is correct (the sole caller passes temporary LuaJIT strings that *must* be copied) — only the contract was hidden. This documents that callers keep ownership of their inputs and the copies live for the exchange lifetime (freed via `toResponse` transfer or `deinit`).

Doc-comment only; no behavioral change.

## Verify
- `zig build test`: green (exit 0).
- Bun integration suite: not run here (needs a live server).

Closes #65