### PR TITLE
fix(cli): stop swallowing stderr diagnostic writes (#70)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -22,18 +22,18 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     // Parse CLI arguments (falls back to env vars, then defaults)
     const cli_config = cli.parse(allocator, init.args) catch |err| {
-        cli.printHelp();
-        std.log.err("CLI parse error: {}", .{err});
+        cli.printStderr("keyway: error parsing arguments: {}\n", .{err}) catch {};
+        cli.printHelp() catch {}; // best-effort: already exiting non-zero
         std.process.exit(1);
     };
 
     if (cli_config.show_help) {
-        cli.printHelp();
+        try cli.printHelp();
         return;
     }
 
     if (cli_config.show_version) {
-        std.debug.print("keyway {s}\n", .{version});
+        try cli.printStderr("keyway {s}\n", .{version});
         return;
     }
 

--- a/src/util/cli.zig
+++ b/src/util/cli.zig
@@ -160,8 +160,21 @@ fn parseLogLevel(val: []const u8) ?std.log.Level {
     return null;
 }
 
+/// Write formatted output to stderr, propagating write errors instead of
+/// silently discarding them the way `std.debug.print` does. Used for CLI
+/// diagnostics (help, version) that must not vanish. Bypasses the `Io`
+/// interface, which is not yet set up during argument parsing.
+pub fn printStderr(comptime fmt: []const u8, args: anytype) !void {
+    var buffer: [256]u8 = undefined;
+    const stderr = std.debug.lockStderr(&buffer);
+    defer std.debug.unlockStderr();
+    const w = &stderr.file_writer.interface;
+    try w.print(fmt, args);
+    try w.flush();
+}
+
 /// Print usage information to stderr.
-pub fn printHelp() void {
+pub fn printHelp() !void {
     const usage =
         \\Usage: keyway [OPTIONS]
         \\
@@ -182,7 +195,7 @@ pub fn printHelp() void {
         \\  -v, --version       Show version information
         \\
     ;
-    std.debug.print("{s}", .{usage});
+    try printStderr("{s}", .{usage});
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
`std.debug.print` (used for `--help`, `--version`, and the argument-parse error path) silently discards write errors, so CLI diagnostics could vanish. This routes those writes through a new `cli.printStderr` helper that propagates write/flush errors, and has `main` surface them via `try`.

`printStderr` uses `std.debug.lockStderr` — the low-level primitive that bypasses the `Io` interface, which is correct here since no `Io` is set up during argument parsing.

While in the parse-error branch, the existing `std.log.err("CLI parse error: ...")` was a no-op (logz isn't initialized yet at parse time), so the *reason* for a bad-args exit never printed. Replaced it with a direct `printStderr` write so the failure reason actually shows before the usage text.

## Why
Fixes finding #70: stderr write errors swallowed in the CLI path (`src/util/cli.zig`, `src/main.zig`), so diagnostics could silently fail to print.

## Verify
- `zig build test` — passing (green).
- `zig build` + smoke test: `--version`, `--help`, and an unknown flag all print correctly; unknown flag now emits `keyway: error parsing arguments: error.UnknownOption` to stderr before usage.
- Bun integration suite: not run here (needs a live server).

Closes #70