### PR TITLE
refactor: remove hidden compaction side-effect from writeSlice (#66)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -474,6 +474,9 @@ pub const Connection = struct {
             }
             break :blk cb.writeSlice();
         } else blk: {
+            // Reclaim space consumed by a prior pipelined request before
+            // deciding the buffer is full (writeSlice no longer auto-compacts).
+            self.read_buffer.compact();
             if (self.read_buffer.availableWrite() == 0) {
                 self.send400BadRequest();
                 return;

--- a/src/util/buffer.zig
+++ b/src/util/buffer.zig
@@ -23,16 +23,10 @@ pub const LinearBuffer = struct {
         self.allocator.free(self.data);
     }
 
-    /// Get slice available for writing.
-    /// Auto-compacts when write space is low but consumed space is available,
-    /// preventing false "buffer full" on long-lived connections (WS, SSE).
+    /// Get slice available for writing (pure accessor, symmetric with readSlice).
+    /// Does not mutate: callers that need to reclaim consumed space must call
+    /// compact() explicitly before writing (see startRead / startWsRead).
     pub inline fn writeSlice(self: *LinearBuffer) []u8 {
-        // Proactive compaction: if less than 25% write space remains and
-        // at least 25% of the buffer has been consumed, compact to reclaim.
-        const quarter = self.data.len / 4;
-        if (self.availableWrite() <= quarter and self.read_pos >= quarter) {
-            self.compact();
-        }
         return self.data[self.write_pos..];
     }
 
@@ -173,26 +167,29 @@ test "linear buffer partial consume" {
     try std.testing.expectEqualStrings("World", buf.readSlice());
 }
 
-test "linear buffer auto-compaction on fragmentation" {
+test "linear buffer writeSlice is a pure accessor" {
     const allocator = std.testing.allocator;
 
     var buf = try LinearBuffer.init(allocator, 64);
     defer buf.deinit();
 
-    // Simulate fragmentation: write 48 bytes, consume 32, leaving
-    // read_pos=32 (50% consumed), write_pos=48, available_write=16 (25%).
+    // Fragment the buffer: write 48 bytes, consume 32, leaving
+    // read_pos=32, write_pos=48, available_write=16.
     const ws1 = buf.writeSlice();
     @memset(ws1[0..48], 'A');
     buf.commitWrite(48);
-    buf.consume(32); // read_pos=32, write_pos=48
+    buf.consume(32);
 
-    // Before writeSlice: available_write=16 (25%), read_pos=32 (50%)
-    // This should trigger auto-compaction.
-    try std.testing.expectEqual(@as(usize, 16), buf.availableWrite());
+    // writeSlice must not compact: positions stay put and it returns the
+    // tail from write_pos, never silently reclaiming consumed space.
     const ws2 = buf.writeSlice();
+    try std.testing.expectEqual(@as(usize, 32), buf.read_pos);
+    try std.testing.expectEqual(@as(usize, 48), buf.write_pos);
+    try std.testing.expectEqual(@as(usize, 16), ws2.len);
 
-    // After compaction: read_pos=0, write_pos=16, available_write=48
+    // Reclaiming is now an explicit, visible step.
+    buf.compact();
     try std.testing.expectEqual(@as(usize, 0), buf.read_pos);
     try std.testing.expectEqual(@as(usize, 16), buf.write_pos);
-    try std.testing.expectEqual(@as(usize, 48), ws2.len);
+    try std.testing.expectEqual(@as(usize, 48), buf.writeSlice().len);
 }


### PR DESCRIPTION
## What
`LinearBuffer.writeSlice()` read like a pure getter (mirrors `readSlice()`) but silently compacted the buffer when free write space dropped below 25%. Compaction runs `std.mem.copyForwards`, so a call that looks like a slice fetch could relocate buffered bytes and invalidate outstanding zero-copy slices — a hidden mutation behind a read-sounding name (finding 35, Naming).

## Change
- `writeSlice()` is now a pure accessor: `return self.data[self.write_pos..]`, symmetric with `readSlice()`.
- Hoisted the reclaim to the one path that relied on the implicit compaction: the HTTP pipelined-request continuation in `Connection.startRead` now calls `read_buffer.compact()` explicitly before checking capacity.
- Other recv-target call sites are unaffected: `startWsRead` already compacts before writing; the TLS ciphertext buffer is `reset()` on every feed (read_pos==0) and the SSE disconnect-watch always has read_pos==0, so neither ever triggered the old auto-compaction.
- Repurposed the `auto-compaction` unit test into a regression guard asserting `writeSlice()` does not mutate buffer positions.

Behavior is unchanged; compaction is just visible at the call site now.

## Verify
- `zig build test`: PASS (green)
- `zig build`: PASS
- Bun integration suite: not run here (needs a live server).

Closes #66