### PR TITLE
fix(sse): log dropped broadcasts instead of silently skipping workers (#54)

### DIFF
--- a/src/protocol/sse.zig
+++ b/src/protocol/sse.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const xev = @import("xev");
 const config = @import("../util/config.zig");
+const log = @import("../observability/log.zig");
 const handler_mod = @import("../core/handler.zig");
 const Connection = handler_mod.Connection;
 const conn_sse = @import("conn_sse.zig");
@@ -176,13 +177,17 @@ pub const SseBroadcastBus = struct {
 
     /// Publish a message to all workers' inboxes and wake their event loops.
     pub fn publish(self: *SseBroadcastBus, room: []const u8, data: []const u8) void {
-        for (self.slots[0..self.num_workers]) |*slot| {
+        for (self.slots[0..self.num_workers], 0..) |*slot, worker_idx| {
             if (!slot.ready) continue;
 
             // Dupe per-slot (each worker frees its own copy)
-            const room_dupe = self.allocator.dupe(u8, room) catch continue;
+            const room_dupe = self.allocator.dupe(u8, room) catch {
+                logDrop(room, worker_idx);
+                continue;
+            };
             const data_dupe = self.allocator.dupe(u8, data) catch {
                 self.allocator.free(room_dupe);
+                logDrop(room, worker_idx);
                 continue;
             };
 
@@ -191,12 +196,23 @@ pub const SseBroadcastBus = struct {
                 self.allocator.free(room_dupe);
                 self.allocator.free(data_dupe);
                 slot.mutex.unlock(self.io);
+                logDrop(room, worker_idx);
                 continue;
             };
             slot.mutex.unlock(self.io);
 
-            slot.notifier.notify() catch {};
+            // Enqueued, but if the wake fails the worker won't drain until the next notify.
+            slot.notifier.notify() catch |e| {
+                log.warn().string("msg", "SSE broadcast notify failed — worker not woken")
+                    .string("room", room).int("worker_slot", worker_idx).err(e).log();
+            };
         }
+    }
+
+    /// Warn that a broadcast was dropped for one worker (allocation failure).
+    fn logDrop(room: []const u8, worker_idx: usize) void {
+        log.warn().string("msg", "SSE broadcast dropped for worker (out of memory)")
+            .string("room", room).int("worker_slot", worker_idx).log();
     }
 
     /// xev.Async callback — fires on the worker's event loop thread.


### PR DESCRIPTION
## What
`SseBroadcastBus.publish` fanned messages into each worker's inbox, but allocation and notify failures were swallowed with bare `catch continue` / `catch {}`. A worker that lost a broadcast left no trace — the silent skip in the issue title.

## Change
Add a `warn` log at every drop site in the per-worker loop, tagging the room and worker slot:
- room dupe OOM
- data dupe OOM
- inbox append OOM
- `notifier.notify()` failure (message enqueued but worker not woken)

A small private `logDrop` helper keeps the three identical OOM warnings to one call site. No behavior change beyond observability — dropping on OOM is still the right move (retrying an allocation in-place won't help); the fix is that it's no longer silent.

## Verify
- `zig build test` — green.
- Bun integration suite not run here (needs a live server).

Closes #54