### PR TITLE
fix(core): shrink per-request arena by capacity watermark (#25)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -63,7 +63,7 @@ pub const SuspendedState = struct {
 };
 
 const READ_BUFFER_SIZE = config.READ_BUFFER_SIZE;
-const LARGE_RESPONSE_THRESHOLD = config.LARGE_RESPONSE_THRESHOLD;
+const ARENA_RETAIN_LIMIT = config.ARENA_RETAIN_LIMIT;
 
 /// Per-request HTTP state — reset between keep-alive requests.
 pub const HttpState = struct {
@@ -996,7 +996,7 @@ pub const Connection = struct {
             .websocket => self.handleWsPostWrite(bytes_written),
             .sse => self.handleSsePostWrite(),
             .streaming => conn_stream.handleStreamPostWrite(self),
-            else => self.handleHttpPostWrite(bytes_written),
+            else => self.handleHttpPostWrite(),
         }
         return .disarm;
     }
@@ -1031,7 +1031,7 @@ pub const Connection = struct {
 
     /// Post-write handler for HTTP responses: reset state for keep-alive,
     /// handle pipelining.
-    pub fn handleHttpPostWrite(self: *Connection, bytes_written: usize) void {
+    pub fn handleHttpPostWrite(self: *Connection) void {
         // Cancel the per-request deadline timer on successful response completion
         self.cancelRequestTimer();
         self.cs.suspended = null;
@@ -1039,9 +1039,12 @@ pub const Connection = struct {
         self.cs.cq.reset();
         self.cs.pending_completions = 0;
         self.cs.single_shot_mode = false;
-        // Shrink arena if response was large to prevent unbounded growth
-        // on keep-alive connections that occasionally serve large responses.
-        if (bytes_written > LARGE_RESPONSE_THRESHOLD) {
+        // Free the arena if its retained capacity grew large; otherwise keep it
+        // for reuse. Watermark on the arena's actual capacity, not the response
+        // size — large intermediate allocations (and the static/streaming paths,
+        // which report zero bytes here) would otherwise leave the arena inflated
+        // for the connection's lifetime.
+        if (self.arena.queryCapacity() > ARENA_RETAIN_LIMIT) {
             _ = self.arena.reset(.free_all);
         } else {
             _ = self.arena.reset(.retain_capacity);

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -371,7 +371,7 @@ fn finishStaticFile(self: *Connection) void {
     }
     self.state = .writing;
     // Reuse handleHttpPostWrite for keep-alive/pipelining reset
-    self.handleHttpPostWrite(0);
+    self.handleHttpPostWrite();
 }
 
 // =============================================================================

--- a/src/protocol/conn_stream.zig
+++ b/src/protocol/conn_stream.zig
@@ -169,6 +169,6 @@ fn onTerminalWrite(
     const self = castUserdata(Connection, userdata);
     _ = self.handleSendCompletion(result) orelse return .disarm;
     // Reuse handleHttpPostWrite for keep-alive/pipelining reset
-    self.handleHttpPostWrite(0);
+    self.handleHttpPostWrite();
     return .disarm;
 }

--- a/src/util/config.zig
+++ b/src/util/config.zig
@@ -10,8 +10,10 @@ pub const WRITE_BUFFER_SIZE = 8192;
 /// Ciphertext receive buffer for inbound TLS connections.
 pub const CIPHERTEXT_BUFFER_SIZE = 8192;
 
-/// Free arena if response exceeds this size (prevents unbounded growth on keep-alive).
-pub const LARGE_RESPONSE_THRESHOLD = 1024 * 1024;
+/// Free the per-request arena between requests if its retained capacity exceeds
+/// this size; otherwise keep the capacity for reuse. Prevents unbounded growth on
+/// keep-alive connections that occasionally serve a large response.
+pub const ARENA_RETAIN_LIMIT = 1024 * 1024;
 
 /// Maximum route parameters per request (e.g., /users/{id}/posts/{post_id}).
 pub const MAX_ROUTE_PARAMS = 4;


### PR DESCRIPTION
## What

Switch the keep-alive arena shrink decision from `bytes_written` to the arena's actual retained capacity (`ArenaAllocator.queryCapacity()`).

## Why

`handleHttpPostWrite` shrank the arena only when `bytes_written > LARGE_RESPONSE_THRESHOLD`. That proxy is wrong for two reasons:

- Large *intermediate* allocations inflate the arena even when the response body is small, so the arena stays inflated but the check never fires.
- The static-file and streaming completion paths call `handleHttpPostWrite(0)` — the two paths that serve the largest responses (static files up to 100 MB, streamed bodies) passed a literal `0`, so `0 < threshold` always retained capacity and the arena never shrank for the connection's lifetime.

Watermarking on `queryCapacity()` measures what we actually care about (retained arena bytes) and fixes every caller uniformly, since they all route through this one shared function. Freed when capacity exceeds `ARENA_RETAIN_LIMIT` (1 MB, unchanged value), retained otherwise.

Also drops the now-unused `bytes_written` argument from `handleHttpPostWrite` (and the misleading `0` at its static/streaming call sites) and renames `LARGE_RESPONSE_THRESHOLD` -> `ARENA_RETAIN_LIMIT` to match the new semantics.

## Verify

- `zig build test`: green — 115/115 tests passed.
- Bun integration suite not run here (needs a live server).

Closes #25