### PR TITLE
fix(lua): surface non-string keys/values in ctx metamethods (#56)

### DIFF
--- a/src/lua/lua_api.zig
+++ b/src/lua/lua_api.zig
@@ -39,14 +39,21 @@ inline fn getProxy(lua: *Lua, index: i32) ?*HeadersProxy {
     return castUserdata(HeadersProxy, @as(?*anyopaque, ud));
 }
 
+/// Helper: convert the value at `index` to a string span, or raise a Lua error.
+/// Metamethod keys/values must be string-convertible; a non-convertible value is
+/// a caller bug, so surface it instead of silently returning nil/0 (issue #56).
+fn checkString(lua: *Lua, index: i32, what: [*:0]const u8) [:0]const u8 {
+    const s = lua.toString(index) catch {
+        lua.pushString(what);
+        lua.raiseError();
+    };
+    return std.mem.span(s);
+}
+
 /// Lua metamethod: __index for reading ctx.field
 fn luaExchangeIndex(lua: *Lua) callconv(.c) c_int {
     const ex = getExchange(lua, 1);
-    const key = lua.toString(2) catch {
-        lua.pushNil();
-        return 1;
-    };
-    const key_str = std.mem.span(key);
+    const key_str = checkString(lua, 2, "ctx index: key must be a string");
 
     if (std.mem.eql(u8, key_str, "method")) {
         lua.pushLString(ex.method);
@@ -75,15 +82,13 @@ fn luaExchangeIndex(lua: *Lua) callconv(.c) c_int {
 /// Lua metamethod: __newindex for writing ctx.field = value
 fn luaExchangeNewIndex(lua: *Lua) callconv(.c) c_int {
     const ex = getExchange(lua, 1);
-    const key = lua.toString(2) catch return 0;
-    const key_str = std.mem.span(key);
+    const key_str = checkString(lua, 2, "ctx newindex: key must be a string");
 
     if (std.mem.eql(u8, key_str, "status")) {
         const status = lua.toInteger(3);
         ex.status = @intCast(status);
     } else if (std.mem.eql(u8, key_str, "body")) {
-        const body = lua.toString(3) catch return 0;
-        const body_span = std.mem.span(body);
+        const body_span = checkString(lua, 3, "ctx.body: value must be a string");
         // Arena-dupe immediately — Lua string lifetime is unpredictable across yields.
         // This eliminates the use-after-free class entirely.
         // Free previous body if any (no-op on arena allocator, needed for test allocator)
@@ -96,8 +101,7 @@ fn luaExchangeNewIndex(lua: *Lua) callconv(.c) c_int {
             return 0;
         };
     } else if (std.mem.eql(u8, key_str, "upgrade")) {
-        const val = lua.toString(3) catch return 0;
-        const val_str = std.mem.span(val);
+        const val_str = checkString(lua, 3, "ctx.upgrade: value must be a string");
         if (std.mem.eql(u8, val_str, "websocket")) {
             ex.upgrade_websocket = true;
         } else if (std.mem.eql(u8, val_str, "sse")) {
@@ -106,9 +110,11 @@ fn luaExchangeNewIndex(lua: *Lua) callconv(.c) c_int {
             ex.upgrade_stream = true;
         }
     } else if (std.mem.eql(u8, key_str, "sse_room")) {
-        const val = lua.toString(3) catch return 0;
-        const val_str = std.mem.span(val);
-        ex.sse_room = ex.allocator.dupe(u8, val_str) catch return 0;
+        const val_str = checkString(lua, 3, "ctx.sse_room: value must be a string");
+        ex.sse_room = ex.allocator.dupe(u8, val_str) catch {
+            lua.pushString("ctx.sse_room: arena alloc failed");
+            lua.raiseError();
+        };
     } else if (std.mem.eql(u8, key_str, "on_message")) {
         if (lua.isFunction(3)) {
             lua.pushValue(3);


### PR DESCRIPTION
## What
The `HttpExchange` `__index` / `__newindex` metamethods in `src/lua/lua_api.zig` swallowed `toString()` failures by returning `nil`/`0`. An operator indexing `ctx` with a non-string key, or assigning a non-string to `ctx.body` / `ctx.upgrade` / `ctx.sse_room`, got a silent no-op — indistinguishable from an internal failure. The `sse_room` arena-dup OOM was also silently dropped.

## Change
- Added a small `checkString` helper that converts a stack value to a string span or raises a Lua error (`pushString` + `raiseError`), mirroring the already-fixed `json.zig` half.
- Routed the four key/value conversions in `luaExchangeIndex` / `luaExchangeNewIndex` through it.
- `ctx.sse_room` arena-dup OOM now raises instead of returning `0`, matching the existing `ctx.body` OOM path.

Raised errors propagate to the middleware `pcall` wrapper (→ 500 + stderr), so failures are now visible instead of silent.

## Scope
Issue-scoped to the Exchange metamethods (lines 45–109). The sibling `luaHeadersIndex`/`luaHeadersNewIndex`/`luaWsContextIndex` metamethods use the same silent-`toString` pattern but were deliberately out of the issue's verified scope; missing-header lookups arguably want map-style `nil` semantics, so they are left untouched and noted here rather than changed inline.

## Verify
- `zig build test` — green.
- Bun integration suite not run here (needs a live server).

Closes #56