### PR TITLE
fix(lua): retype current_connection from anyopaque to *Connection

### DIFF
--- a/src/lua/lua_state.zig
+++ b/src/lua/lua_state.zig
@@ -64,7 +64,7 @@ pub const LuaState = struct {
 
     // Current connection being served (set during handler call/resume, cleared on completion)
     // Used by ring C bridge functions to access the Connection's SQ/CQ.
-    current_connection: ?*anyopaque = null,
+    current_connection: ?*Connection = null,
 
     // Lua script timing: start timestamp for duration histogram
     coroutine_start_us: ?i64 = null,
@@ -250,8 +250,7 @@ pub const LuaState = struct {
         prom.luaCoroutineStarted();
         self.coroutine_start_us = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us);
         // Capture route for duration labeling from Connection's http_state
-        if (self.current_connection) |conn_ptr| {
-            const conn: *Connection = @ptrCast(@alignCast(conn_ptr));
+        if (self.current_connection) |conn| {
             self.coroutine_route = conn.http_state.route_pattern;
         } else {
             self.coroutine_route = "";
@@ -572,12 +571,6 @@ pub const LuaState = struct {
 
         registry.broadcast(std.mem.span(room), std.mem.span(data));
         return 0;
-    }
-
-    /// Cast current_connection to *Connection. Internal helper.
-    inline fn currentConnection(self: *LuaState) ?*Connection {
-        const ptr = self.current_connection orelse return null;
-        return @ptrCast(@alignCast(ptr));
     }
 
     /// Register embedded stdlib modules as package.preload entries.


### PR DESCRIPTION
Closes #52

`current_connection` was `?*anyopaque` but every writer already stored a `*Connection` and every reader immediately `@ptrCast(@alignCast(...))`'d it back. #99 pruned the outbound cosocket engine but the field survives as the live yield/resume bridge for cosocket/WS/stream — this issue wasn't resolved by that merge, just narrowed to the retype the issue asked for.

- `current_connection: ?*anyopaque` -> `?*Connection` (`Connection` was already imported in `lua_state.zig`, no circular-import issue)
- Deleted the two read-site casts (`coroutine_route` capture, and an unused `currentConnection()` helper that existed only to perform the same cast — zero callers)
- No call-site changes needed: all assignments already passed a `*Connection` value directly (relied on implicit coercion to anyopaque)

`zig build` and `zig build test` pass.