### PR TITLE
docs(manifest): make Lua-never-does-I/O absolute post-cosocket-removal

### DIFF
--- a/.claude/rules/zig-gotchas.md
+++ b/.claude/rules/zig-gotchas.md
@@ -10,7 +10,7 @@ paths:
 Read this before editing any `.zig` file. (Zig version + deps live in `build.zig.zon`; in-flight language migrations live in the issue tracker, not here.)
 
 - **LuaJIT, not Lua 5.4.** Semantics are Lua 5.1 + a few 5.2 extensions. No 5.3/5.4 features: no `//` integer division, no `<close>` to-be-closed vars, no integer subtype. Bit ops come from the `bit` library.
-- **Cosocket coroutine hack — keep it.** zig-luajit marks `resumeCoroutine`/`yieldCoroutine` private. We declare `extern "c" fn lua_yield` (in `src/io/ring_api.zig`, `src/io/io_request.zig`) and export `lua_resume` (in `src/lua/lua_state.zig`), calling them via `@ptrCast(lua)` because `*Lua` maps 1:1 to `lua_State*`. Don't route this through the wrapper API.
+- **Async-yield coroutine hack (WS/SSE/stream) — keep it.** zig-luajit marks `resumeCoroutine`/`yieldCoroutine` private. We declare `extern "c" fn lua_yield` (in `src/io/io_request.zig`) and export `lua_resume` (in `src/lua/lua_state.zig`), calling them via `@ptrCast(lua)` because `*Lua` maps 1:1 to `lua_State*`. Don't route this through the wrapper API.
 - **GCC 15 linker workaround — don't remove.** `link_gc_sections = true` in `build.zig`: GCC 15's `crt1.o` has `.sframe` sections with `R_X86_64_PC64` relocations that Zig's bundled lld can't handle; `--gc-sections` discards the unreferenced ones.
 - **`rdynamic` on the exe** (`build.zig`) exports symbols so Lua `.so` modules (LuaRocks) resolve at runtime. Don't drop it.
 - **OpenSSL is a system lib** — `linkSystemLibrary("ssl")` / `("crypto")` + inline `@cImport` in `src/tls/tls.zig`.

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -13,11 +13,11 @@ Zig: reads ctx → serializes response → submits async send via libxev
 
 - All I/O is initiated by Zig, completed asynchronously by the kernel.
 - libxev callbacks **dispatch** to the next stage; they hold no business logic.
-- Lua coroutines yield on cosocket ops; Zig resumes them when I/O completes.
+- Lua issues no outbound I/O calls. Coroutines only yield for WS/SSE/stream flow control (send a frame, flush a chunk); Zig resumes them when the operation completes.
 
 ## 2. Per-Core Isolation
 
-One worker thread per CPU core, pinned for cache locality. Each worker exclusively owns its `xev.Loop`, `LuaState`, `Router`, server socket (`SO_REUSEPORT`, kernel distributes), `SseRegistry`, `ConnectionPool`. `TlsContext` is shared read-only (immutable after init).
+One worker thread per CPU core, pinned for cache locality. Each worker exclusively owns its `xev.Loop`, `LuaState`, `Router`, server socket (`SO_REUSEPORT`, kernel distributes), `SseRegistry`. `TlsContext` is shared read-only (immutable after init).
 
 **No Lua state is shared. No cross-thread access. No mutexes on the hot path.** The only cross-worker mechanism is `SseBroadcastBus` (per-worker mutex-protected inboxes + `xev.Async` notifiers). eBPF can optionally pin a client to the same worker.
 
@@ -31,7 +31,7 @@ Accept → Read → Parse → Route → Execute → Respond → Reuse
 2. **Read** — libxev recv fills the `LinearBuffer`; TLS ciphertext is decrypted through `conn_tls`.
 3. **Parse** — picohttpparser (C FFI) yields a zero-copy `Request` — method/path/headers/body are slices into the buffer, no allocations.
 4. **Route** — `Router.match` does an O(path-length) trie lookup into inline `ParamArray`/`QueryArray` (zero heap).
-5. **Execute** — `LuaState.callLuaHandler` runs a Lua coroutine with the `HttpExchange` userdata; cosocket calls yield → Zig does the I/O → Zig resumes.
+5. **Execute** — `LuaState.callLuaHandler` runs a Lua coroutine with the `HttpExchange` userdata. WS/SSE/stream handlers yield for flow control; Zig resumes them. All other handlers run to completion without yielding.
 6. **Respond** — `HttpExchange.toResponse` → `Response.serialize` → async send. Special paths: SSE (`conn_sse`), WebSocket (`conn_ws`), chunked (`conn_stream`). Static routes short-circuit before Lua (`static.zig`, ETag/Last-Modified).
 7. **Reuse** — arena + buffer reset for keep-alive; if the response exceeded `LARGE_RESPONSE_THRESHOLD`, arena backing memory is freed to bound growth.
 
@@ -41,7 +41,6 @@ Accept → Read → Parse → Route → Execute → Respond → Reuse
 - **Arena-per-request** — every per-request allocation uses the `Connection`'s arena; reset after send.
 - **Pointer-in-userdata** — Lua gets a userdata holding a pointer to the arena-allocated `HttpExchange`, so coroutines can't touch another request's state.
 - **Inline params** — `ParamArray`/`QueryArray` are fixed-size inline arrays (caps in `config.zig`), no heap.
-- **Connection pooling** — cosocket connections pooled per-worker by `host:port`, LIFO, lazy expiry.
 
 ## 5. Module Map
 
@@ -51,10 +50,10 @@ Source lives under `src/`, grouped by responsibility. Read the directory, not a 
 |---|---|
 | `core/` | Per-core lifecycle: `main`→`ThreadPool`→`worker` (CPU-pinned, owns loop+LuaState+Router+Server), `server` (accept, SO_REUSEPORT, BPF, TLS init), `handler` (`Connection`: socket lifecycle, read/write completions, arena, coroutine suspend/resume), `shutdown`, `reload`. |
 | `http/` | HTTP path: `http` (Request/Response/parser bindings/serialize), `router` (zero-alloc trie), `route_loader`, `http_exchange` (the Lua-visible `ctx`), `params`, `static`, `error_response`. |
-| `io/` | Outbound I/O + rings: `cosocket`(+`_ops`), `ring`/`ring_api` (IoEntry rings), `io_request`, `connection_pool`, `file_watcher`, `bpf_reuseport`. |
+| `io/` | Async-yield engine driving WS/SSE/stream: `cosocket` (yield/resume bridge to libxev), `ring` (IoEntry submission/completion rings), `io_request`, `file_watcher`, `bpf_reuseport`. |
 | `lua/` | LuaJIT: `lua_state` (state, handler dispatch, coroutine lifecycle), `lua_api` (ctx/headers/params metatables, cosocket registration), `json`. |
 | `protocol/` | Upgraded protocols: `ws`/`conn_ws`, `sse`/`conn_sse` (SseRegistry + SseBroadcastBus), `conn_stream`. |
-| `tls/` | `tls` (TlsContext/TlsConn/kTLS), `conn_tls` (inbound), `cosocket_tls` (outbound client). |
+| `tls/` | `tls` (TlsContext/TlsConn/kTLS), `conn_tls` (inbound handshake). |
 | `observability/` | `metrics` (per-worker atomics), `prom` (Prometheus export), `log`. |
 | `util/` | `buffer` (LinearBuffer), `config` (tunable constants), `cli`, `helpers` (`castUserdata`), `clock`. |
 
@@ -62,7 +61,7 @@ Source lives under `src/`, grouped by responsibility. Read the directory, not a 
 
 Lua touches only `ctx` through metatables. **Read:** `ctx.method/.path/.body`, `ctx.params.id`, `ctx.headers["Key"]`, `ctx.query.name`. **Write:** `ctx.status`, `ctx.body`, `ctx.headers["Key"]`. No verbs (`send()`/`write()`) — state assignment only. Routes register via the declarative `keyway.routes` table; middleware chains at global and per-route levels.
 
-Cosocket ops (`keyway.tcp_connect`, socket methods) are the one exception: function calls that **yield** the coroutine — but Lua still performs no I/O; it yields, Zig does the I/O and resumes with the result.
+No exceptions: Lua never issues outbound I/O. WS/SSE/stream handlers yield the coroutine for flow control only (send a frame, flush a chunk); Zig still owns the I/O and drives the resume. A declarative async-upstream primitive is tracked as future work (#96) — not built until a concrete need lands.
 
 ## 7. Design Rules (non-negotiable)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ No `send()`, no `write()`, no lifecycle calls — only state assignment. Zig com
 ## Features
 
 - **Per-core isolation** — one worker thread, one Lua state, one event loop per CPU core. No locks.
-- **Cosockets** — non-blocking outbound TCP (Redis, PostgreSQL, etc.) via coroutine yield/resume with per-worker connection pooling.
 - **WebSocket** — upgrade via `ctx.upgrade = "websocket"`, frame encoding/decoding handled by Zig.
 - **SSE** — upgrade via `ctx.upgrade = "sse"`, cross-worker broadcast via `SseBroadcastBus`.
 - **Chunked streaming** — `ctx.upgrade = "stream"` with `coroutine.yield()` to flush chunks.
@@ -93,13 +92,13 @@ src/
 ├── core/           # server, worker, handler, shutdown, reload
 ├── http/           # HTTP types, exchange, router, params, static
 ├── protocol/       # WebSocket, SSE, chunked streaming
-├── tls/            # TLS primitives, inbound/outbound handshake
-├── io/             # cosocket engine, ring, connection pool, BPF
+├── tls/            # TLS primitives, inbound handshake, kTLS offload
+├── io/             # async-yield engine (WS/SSE/stream), rings, file watcher, BPF
 ├── lua/            # LuaJIT state management, Lua API bindings
 ├── observability/  # logging, metrics, Prometheus
 └── util/           # buffer, helpers, config, CLI
 dashboard/          # Solid.js admin dashboard + keyway.lua entry script
-lua/                # Lua stdlib modules (keyway.socket, keyway.dns, etc.)
+lua/                # embedded Lua stdlib modules (keyway.form, keyway.response)
 tests/              # Integration tests (Bun)
 observability/      # Prometheus + Grafana config
 ```
@@ -138,7 +137,6 @@ Keyway ships a built-in Solid.js dashboard at `/__keyway/dashboard`. It provides
 - Real-time event stream via SSE
 - Route and middleware inspection
 - Lua file editor (read/write/delete)
-- HTTP probe tool and DNS lookup
 - Embedded Grafana view
 
 Access is restricted to localhost (`127.0.0.1` / `::1`). Manual reload: `POST /__keyway/reload`.
@@ -164,10 +162,6 @@ Access is restricted to localhost (`127.0.0.1` / `::1`). Manual reload: `POST /_
 | Module | Purpose |
 |---|---|
 | `keyway.response` | `json_response`, `get_header`, `broadcast_event`, `broadcast_html`, `now_us` |
-| `keyway.socket` | LuaSocket-compatible TCP — `connect`, `send`, `receive`, `setkeepalive` |
-| `keyway.ring` | Batched I/O ring — submit multiple ops, yield once |
-| `keyway.dns` | DNS A-record lookup, `resolve_host` via FFI getaddrinfo |
-| `keyway.http_client` | Outbound HTTP (`probe`, `post`) with SSRF protection |
 | `keyway.form` | Form data parsing |
 
 ## Observability


### PR DESCRIPTION
Closes #95

Doc-only cleanup. #99 (PR #113) pruned the outbound cosocket engine — this brings MANIFEST.md, README.md, and the zig-gotchas coroutine note in line with the code as it actually is now.

## Corrections (verified against `src/`)

- **MANIFEST.md §1** — "Lua coroutines yield on cosocket ops" → no outbound-I/O yield exists; only WS/SSE/stream yield for flow control (`registerCosocketApi` now registers only `__keyway_ws_send`/`__keyway_sse_broadcast`).
- **MANIFEST.md §2** — dropped `ConnectionPool` from the per-worker ownership list; no such type exists in `src/`.
- **MANIFEST.md §3 (Execute step)** — reworded to say only WS/SSE/stream handlers yield; everything else runs to completion.
- **MANIFEST.md §4** — deleted the "Connection pooling ... LIFO, lazy expiry" bullet; no pooling code remains.
- **MANIFEST.md §5 module map**
  - `io/` row: dropped `cosocket_ops`, `ring_api`, `connection_pool` — none of those files exist (`src/io/` is `bpf_reuseport.zig`, `cosocket.zig`, `file_watcher.zig`, `io_request.zig`, `ring.zig`).
  - `tls/` row: dropped `cosocket_tls (outbound client)` — file no longer exists (`src/tls/` is `tls.zig`, `conn_tls.zig`).
- **MANIFEST.md §6** — deleted the "Cosocket ops are the one exception" paragraph; contract is now absolute. Added a one-line pointer to #96 as the sanctioned future path for declarative async upstream.
- **.claude/rules/zig-gotchas.md** — reframed the coroutine-hack note from "cosocket" to "async-yield (WS/SSE/stream)"; also dropped the dead `src/io/ring_api.zig` path (file doesn't exist, only `io_request.zig` still declares `lua_yield`).
- **README.md**
  - Removed the "Cosockets" feature bullet (dead capability).
  - `io/` and `tls/` project-structure comments updated to match actual files.
  - Root `lua/` comment updated — only `keyway.form`/`keyway.response`/`keyway.json` are embedded now.
  - Stdlib modules table: removed `keyway.socket`, `keyway.ring`, `keyway.dns`, `keyway.http_client` rows — none of these modules exist in the repo anymore.
  - Dashboard feature list: removed "HTTP probe tool and DNS lookup" — no code anywhere (Zig or Lua) implements this; it depended on the now-deleted `keyway.http_client`/`keyway.dns`.

CLAUDE.md needed no changes — it already states the contract absolutely and has no cosocket references.

## Test plan
- [x] Docs-only change; no code touched.
- [x] Verified every removed/reworded claim against `src/` (grepped for `cosocket`, `ConnectionPool`, `ring_api`, `cosocket_tls`, `keyway.socket`/`dns`/`http_client`/`ring`, `probe`/`dns` in dashboard — all confirmed absent from code).