### PR TITLE
refactor(lua): re-scope LuaState grab-bag after #99

### DIFF
--- a/src/lua/lua_state.zig
+++ b/src/lua/lua_state.zig
@@ -1,7 +1,8 @@
 //! Per-worker Lua state aggregation and initialization.
 //!
 //! Each worker thread owns one LuaState containing: the Lua VM, cached coroutine thread,
-//! cosocket pending I/O staging, connection pool, TLS manager, and SSE registry pointer.
+//! the async-yield bridge (pending I/O + suspended coroutine state, shared by cosocket/WS/
+//! SSE/stream), an outbound TLS manager, and an SSE registry pointer.
 //!
 //! Init order: Lua VM → std libs → keyway module → embedded stdlib → cached thread → package paths → TLS manager.
 //! After init: registerCosocketApi → setWorkerGlobals → loadScript → processRouteTable.
@@ -66,10 +67,12 @@ pub const LuaState = struct {
     // Used by ring C bridge functions to access the Connection's SQ/CQ.
     current_connection: ?*Connection = null,
 
-    // Lua script timing: start timestamp for duration histogram
-    coroutine_start_us: ?i64 = null,
-    // Route pattern for the current coroutine (for Prometheus labels)
-    coroutine_route: []const u8 = "",
+    // Lua script timing: duration + route label for the currently-running coroutine,
+    // consumed by recordCoroutineDuration() for the Prometheus histogram.
+    timing: struct {
+        start_us: ?i64 = null,
+        route: []const u8 = "",
+    } = .{},
 
     // SSE: per-worker registry for broadcast (set by worker.zig)
     sse_registry: ?*SseRegistry = null,
@@ -248,12 +251,12 @@ pub const LuaState = struct {
 
         // Resume the coroutine: thread stack has [handler_fn, userdata]
         prom.luaCoroutineStarted();
-        self.coroutine_start_us = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us);
+        self.timing.start_us = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us);
         // Capture route for duration labeling from Connection's http_state
         if (self.current_connection) |conn| {
-            self.coroutine_route = conn.http_state.route_pattern;
+            self.timing.route = conn.http_state.route_pattern;
         } else {
-            self.coroutine_route = "";
+            self.timing.route = "";
         }
         const status = lua_resume(@ptrCast(thread), 1);
 
@@ -368,10 +371,10 @@ pub const LuaState = struct {
 
     /// Record coroutine execution duration for Prometheus metrics.
     fn recordCoroutineDuration(self: *LuaState) void {
-        if (self.coroutine_start_us) |start| {
+        if (self.timing.start_us) |start| {
             const elapsed = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us) - start;
-            prom.luaScriptDuration(self.coroutine_route, elapsed);
-            self.coroutine_start_us = null;
+            prom.luaScriptDuration(self.timing.route, elapsed);
+            self.timing.start_us = null;
         }
     }
 


### PR DESCRIPTION
Closes #50

## Re-scoping after #99

#99 (PR #113) already removed the two biggest offenders the issue named: the connection pool and cosocket pending-I/O-into-pool staging. What's left in `LuaState` is 12 fields that already read as ~5 cohesive, comment-delineated groups: VM core (`lua`/`allocator`), thread cache (`cached_thread`/`cached_thread_ref`), the async-yield bridge (`pending_io`/`coroutine_ref`/`coroutine_thread`/`current_connection`), coroutine timing (`coroutine_start_us`/`coroutine_route`), SSE (`sse_registry`), and outbound TLS (`tls_manager`).

## What changed

- Nested `coroutine_start_us`/`coroutine_route` into a `timing` sub-struct. This is the one grouping that's both genuinely cohesive (set together at coroutine start, read together in `recordCoroutineDuration`) and has **zero external call sites** — both fields were only ever touched inside `lua_state.zig`, so the change is fully contained.
- Fixed the top-of-file doc comment, which still described the LuaState as containing a "connection pool" — dead language left over from before #99.

## What I deliberately did not touch

- `sse_registry` / `tls_manager` — single-field concerns; a one-field wrapper struct adds a name, not information.
- The thread-cache pair and the yield-bridge fields (`pending_io`, `coroutine_ref`, `coroutine_thread`, `current_connection`) — these are read/written across `cosocket.zig`, `conn_ws.zig`, `conn_stream.zig`, and `handler.zig`. Nesting them under a sub-struct would touch many hot-path call sites in the proactor's yield/resume path purely to rename `self.lua_state.coroutine_ref` to `self.lua_state.<something>.coroutine_ref` — no behavior changes, no reduction in what a caller needs to understand about the mechanism. That's indirection without insight, not a structural fix. If the real complaint is that the yield/resume mechanism is hard to follow, the fix is behavioral (e.g. a `suspend`/`resume` helper), which is #40's territory ("structural WS/SSE/stream engine coupling"), not a field-grouping change.

## Verification

- `zig build` — clean
- `zig build test` — all tests pass (exit 0)
- No behavior changes; every touched field access is a rename to a nested path, same file.