### PR TITLE
fix(static): serve files with async pread, extract path/header concerns

### DIFF
--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -113,15 +113,25 @@ fn sendStaticError(self: *Connection, err: anyerror, server_msg: []const u8) voi
     }
 }
 
-/// Serve a static file. Called from handler.zig routeRequest.
-pub fn serveStaticFile(
+/// Result of resolving a requested suffix to a file on disk.
+const StaticPath = struct {
+    /// Route-root + suffix, traversal-checked, NOT symlink-resolved. Content-type
+    /// is derived from this — a symlink's target extension (e.g. a `.css` route
+    /// pointing at a `.txt` file) shouldn't override what the client requested.
+    requested: []const u8,
+    /// Symlink-resolved absolute path — used to open the file.
+    real: []const u8,
+};
+
+/// Resolve `suffix` against `route` to an absolute, symlink-resolved path
+/// verified to stay within the route root. Returns null after sending an
+/// error response (400/403/500) if resolution fails.
+fn resolveStaticPath(
     self: *Connection,
-    request: *const http.Request,
+    alloc: std.mem.Allocator,
     route: router_mod.StaticRoute,
     suffix: []const u8,
-) void {
-    const alloc = self.arena.allocator();
-
+) ?StaticPath {
     // Determine the file path within root
     const rel_path = if (suffix.len == 0 or std.mem.eql(u8, suffix, "/"))
         route.index
@@ -135,7 +145,7 @@ pub fn serveStaticFile(
         if (ch == 0) {
             self.logAccess(400);
             error_response.sendErrorStatus(self, 400, "null byte in path");
-            return;
+            return null;
         }
     }
 
@@ -144,19 +154,19 @@ pub fn serveStaticFile(
     const resolved = std.fs.path.resolve(alloc, &components) catch {
         self.logAccess(500);
         self.send500InternalError();
-        return;
+        return null;
     };
 
     // Verify resolved path starts with root (prevent traversal)
     const root_resolved = std.fs.path.resolve(alloc, &[_][]const u8{route.root}) catch {
         self.logAccess(500);
         self.send500InternalError();
-        return;
+        return null;
     };
     if (!std.mem.startsWith(u8, resolved, root_resolved)) {
         self.logAccess(403);
         error_response.sendErrorStatus(self, 403, "path traversal blocked");
-        return;
+        return null;
     }
 
     // Resolve symlinks and verify the real path is still within root.
@@ -168,22 +178,56 @@ pub fn serveStaticFile(
         var pbuf: [std.fs.max_path_bytes]u8 = undefined;
         const n = std.Io.Dir.cwd().realPathFile(resolve_io.io(), resolved, &pbuf) catch |err| {
             sendStaticError(self, err, "static realpath failed");
-            return;
+            return null;
         };
         break :blk alloc.dupe(u8, pbuf[0..n]) catch {
             self.logAccess(500);
             self.send500InternalError();
-            return;
+            return null;
         };
     };
     if (!std.mem.startsWith(u8, real_resolved, route.real_root)) {
         self.logAccess(403);
         error_response.sendErrorStatus(self, 403, "symlink traversal blocked");
-        return;
+        return null;
     }
 
-    // Open the file (use real_resolved — it's always absolute after realpathAlloc)
-    const resolved_z = alloc.dupeZ(u8, real_resolved) catch {
+    return .{ .requested = resolved, .real = real_resolved };
+}
+
+/// Build the response headers text: status line, content-type, length, ETag,
+/// Last-Modified, cache-control. Pure formatting — no I/O, no error response.
+fn buildStaticHeaders(
+    alloc: std.mem.Allocator,
+    content_type: []const u8,
+    file_size: u64,
+    etag: []const u8,
+    mtime_sec: i64,
+) ![]const u8 {
+    var last_modified_buf: [29]u8 = undefined;
+    formatHttpDate(&last_modified_buf, mtime_sec);
+
+    return std.fmt.allocPrint(alloc, "HTTP/1.1 200 OK\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nETag: {s}\r\nLast-Modified: {s}\r\nCache-Control: public, max-age=3600\r\n\r\n", .{
+        content_type,
+        file_size,
+        etag,
+        &last_modified_buf,
+    });
+}
+
+/// Serve a static file. Called from handler.zig routeRequest.
+pub fn serveStaticFile(
+    self: *Connection,
+    request: *const http.Request,
+    route: router_mod.StaticRoute,
+    suffix: []const u8,
+) void {
+    const alloc = self.arena.allocator();
+
+    const path = resolveStaticPath(self, alloc, route, suffix) orelse return;
+
+    // Open the file (use path.real — it's always absolute after realpathAlloc)
+    const resolved_z = alloc.dupeZ(u8, path.real) catch {
         self.logAccess(500);
         self.send500InternalError();
         return;
@@ -242,18 +286,8 @@ pub fn serveStaticFile(
         }
     }
 
-    const content_type = getContentType(resolved);
-
-    // Build response headers
-    var last_modified_buf: [29]u8 = undefined;
-    formatHttpDate(&last_modified_buf, mtime_sec);
-
-    const headers_text = std.fmt.allocPrint(alloc, "HTTP/1.1 200 OK\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nETag: {s}\r\nLast-Modified: {s}\r\nCache-Control: public, max-age=3600\r\n\r\n", .{
-        content_type,
-        file_size,
-        etag,
-        &last_modified_buf,
-    }) catch {
+    const content_type = getContentType(path.requested);
+    const headers_text = buildStaticHeaders(alloc, content_type, file_size, etag, mtime_sec) catch {
         helpers.closeFd(fd);
         self.logAccess(500);
         self.send500InternalError();
@@ -271,7 +305,9 @@ pub fn serveStaticFile(
 
     // Send headers first, then drive an async pread+send loop. Files up to
     // STATIC_READ_SIZE complete in a single chunk; larger files span several.
-    const read_buf = self.base_allocator.alloc(u8, config.STATIC_READ_SIZE) catch {
+    // read_buf is sized to the smaller of the two so small files don't pay
+    // for a full 64 KB allocation.
+    const read_buf = self.base_allocator.alloc(u8, @min(file_size, config.STATIC_READ_SIZE)) catch {
         helpers.closeFd(fd);
         self.send500InternalError();
         return;
@@ -414,4 +450,15 @@ test "formatHttpDate produces valid format" {
     // Unix epoch: Thu, 01 Jan 1970 00:00:00 GMT
     formatHttpDate(&buf, 0);
     try std.testing.expectEqualStrings("Thu, 01 Jan 1970 00:00:00 GMT", &buf);
+}
+
+test "buildStaticHeaders formats status line and cache headers" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const headers = try buildStaticHeaders(arena.allocator(), "text/plain; charset=utf-8", 42, "\"abc\"", 0);
+    try std.testing.expect(std.mem.startsWith(u8, headers, "HTTP/1.1 200 OK\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, headers, "Content-Type: text/plain; charset=utf-8\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, headers, "Content-Length: 42\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, headers, "ETag: \"abc\"\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, headers, "Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT\r\n") != null);
 }

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -1,8 +1,9 @@
-//! Static file serving — pread into arena + send, with ETag/Last-Modified caching.
+//! Static file serving — async pread + send, with ETag/Last-Modified caching.
 //!
 //! Zig-native, no Lua involvement. Route configuration via keyway.static.
-//! Small files (< STATIC_READ_SIZE) are served in a single read+send.
-//! Large files are served via pread+send loop using Content-Length (size known from stat).
+//! Headers are sent first, then the body is streamed via an async pread+send
+//! loop (one chunk per STATIC_READ_SIZE) using Content-Length (size from stat).
+//! pread runs on the worker's xev loop (io_uring), never blocking it.
 //!
 //! Path safety: std.fs.path.resolve + verify result starts with configured root.
 
@@ -23,6 +24,7 @@ pub const StaticState = struct {
     file_size: u64,
     bytes_sent: u64,
     read_buf: []u8,
+    pread_completion: xev.Completion = .{},
 
     pub fn deinit(self: *StaticState, allocator: std.mem.Allocator) void {
         helpers.closeFd(self.fd);
@@ -267,25 +269,8 @@ pub fn serveStaticFile(
         return;
     }
 
-    // Small file fast path: single allocation, pread directly into combined buffer
-    if (file_size <= config.STATIC_READ_SIZE) {
-        const combined = alloc.alloc(u8, headers_text.len + @as(usize, @intCast(file_size))) catch {
-            helpers.closeFd(fd);
-            self.send500InternalError();
-            return;
-        };
-        @memcpy(combined[0..headers_text.len], headers_text);
-        const bytes_read = helpers.pread(fd, combined[headers_text.len..], 0) catch {
-            helpers.closeFd(fd);
-            self.send500InternalError();
-            return;
-        };
-        helpers.closeFd(fd);
-        self.sendRawResponse(combined[0 .. headers_text.len + bytes_read]);
-        return;
-    }
-
-    // Large file: send headers first, then pread+send loop
+    // Send headers first, then drive an async pread+send loop. Files up to
+    // STATIC_READ_SIZE complete in a single chunk; larger files span several.
     const read_buf = self.base_allocator.alloc(u8, config.STATIC_READ_SIZE) catch {
         helpers.closeFd(fd);
         self.send500InternalError();
@@ -317,7 +302,7 @@ fn onStaticHeadersSent(
     return .disarm;
 }
 
-/// Read the next chunk from file and send it.
+/// Submit an async pread for the next chunk from the file.
 fn sendNextChunk(self: *Connection) void {
     const ss = &self.static_state.?;
 
@@ -330,22 +315,55 @@ fn sendNextChunk(self: *Connection) void {
     const remaining = ss.file_size - ss.bytes_sent;
     const to_read = @min(remaining, ss.read_buf.len);
 
-    const bytes_read = helpers.pread(ss.fd, ss.read_buf[0..to_read], ss.bytes_sent) catch {
-        self.close();
-        return;
+    // Async pread on the worker's xev loop (io_uring) — never blocks. The
+    // completion lives in StaticState (stable address until the read fires).
+    ss.pread_completion = .{
+        .op = .{ .pread = .{
+            .fd = ss.fd,
+            .buffer = .{ .slice = ss.read_buf[0..to_read] },
+            .offset = ss.bytes_sent,
+        } },
+        .userdata = self,
+        .callback = onStaticPreadComplete,
     };
+    self.pending_io_ops += 1;
+    self.loop.add(&ss.pread_completion);
+}
 
-    if (bytes_read == 0) {
-        // EOF before expected — file truncated
-        finishStaticFile(self);
-        return;
+/// Callback after an async pread completes — send the chunk we just read.
+fn onStaticPreadComplete(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    const self = castUserdata(Connection, userdata);
+    self.pending_io_ops -= 1;
+
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
     }
 
+    const bytes_read = result.pread catch |err| {
+        if (err == error.EOF) {
+            // File truncated under us — stop, send what was already delivered.
+            finishStaticFile(self);
+        } else {
+            self.close();
+        }
+        return .disarm;
+    };
+
+    const ss = &self.static_state.?;
     ss.bytes_sent += bytes_read;
 
-    // read_buf is stable during async send — pread overwrites it only in sendNextChunk,
-    // which runs after onStaticChunkSent fires. No dupe needed.
+    // read_buf is stable during the async send — it is overwritten only by the
+    // next pread, which is submitted from onStaticChunkSent after the send fires.
     self.submitSend(ss.read_buf[0..bytes_read], onStaticChunkSent, false);
+    return .disarm;
 }
 
 /// Callback after a static file chunk is sent — continue or finish.

--- a/src/util/helpers.zig
+++ b/src/util/helpers.zig
@@ -37,13 +37,6 @@ fn syscallErrno(rc: usize) std.posix.E {
     return .SUCCESS;
 }
 
-/// `std.posix.pread` replacement (removed in 0.16).
-pub fn pread(fd: std.posix.fd_t, buf: []u8, offset: u64) !usize {
-    const rc = std.os.linux.pread(fd, buf.ptr, buf.len, @intCast(offset));
-    if (syscallErrno(rc) != .SUCCESS) return error.PReadFailed;
-    return rc;
-}
-
 /// `std.posix.pipe` replacement (removed in 0.16).
 pub fn pipe() ![2]std.posix.fd_t {
     var fds: [2]std.posix.fd_t = undefined;

--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -1,0 +1,86 @@
+// Static file serving — exercises the async pread+send path (issue #53).
+//
+// The dashboard route (dashboard/keyway.lua) serves dashboard/public at
+// /__keyway/dashboard, so we read those assets back over HTTP and compare
+// them byte-for-byte against disk. Files larger than STATIC_READ_SIZE (64 KB)
+// span multiple async pread chunks — the case where a blocking/truncating
+// read would corrupt the body.
+
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const base = () => globalThis.__KEYWAY_BASE;
+const PUBLIC = resolve(import.meta.dir, "../../dashboard/public");
+
+async function diskBytes(name: string): Promise<Uint8Array> {
+  return new Uint8Array(await Bun.file(resolve(PUBLIC, name)).arrayBuffer());
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+describe("static file serving", () => {
+  // Small file: served in a single pread chunk.
+  test("serves a small file intact (single chunk)", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/index.html`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+
+    const got = new Uint8Array(await res.arrayBuffer());
+    const want = await diskBytes("index.html");
+    expect(got.length).toBe(want.length);
+    expect(bytesEqual(got, want)).toBe(true);
+  });
+
+  // Large file (~470 KB): spans ~8 async pread chunks. This is the regression
+  // target for #53 — a blocking/truncating read would corrupt or short the body.
+  test("serves a large file intact across multiple chunks", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/main.js`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/javascript");
+
+    const got = new Uint8Array(await res.arrayBuffer());
+    const want = await diskBytes("main.js");
+    expect(got.length).toBe(want.length);
+    expect(Number(res.headers.get("content-length"))).toBe(want.length);
+    expect(bytesEqual(got, want)).toBe(true);
+  });
+
+  // Chunk-boundary case: ~90 KB file straddles the 64 KB chunk size.
+  test("serves a file that straddles the chunk boundary", async () => {
+    const res = await fetch(
+      `${base()}/__keyway/dashboard/fonts/JetBrainsMono-Regular.woff2`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("font/woff2");
+
+    const got = new Uint8Array(await res.arrayBuffer());
+    const want = await diskBytes("fonts/JetBrainsMono-Regular.woff2");
+    expect(got.length).toBe(want.length);
+    expect(bytesEqual(got, want)).toBe(true);
+  });
+
+  // Missing file: 404, not a hang or 500.
+  test("returns 404 for a missing file", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/does-not-exist.txt`);
+    expect(res.status).toBe(404);
+  });
+
+  // ETag round-trip: a matching If-None-Match yields 304 with no body.
+  test("returns 304 for a matching ETag", async () => {
+    const first = await fetch(`${base()}/__keyway/dashboard/main.js`);
+    expect(first.status).toBe(200);
+    await first.arrayBuffer();
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
+
+    const second = await fetch(`${base()}/__keyway/dashboard/main.js`, {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+    expect((await second.text()).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #53
Closes #62

## What

Two commits, fix then refactor:

**`fix(static)` — #53 (P-high, proactor):** both blocking `pread` sites (small-file fast path and large-file chunk loop) stalled the worker's xev loop on slow storage. Replaced with one async chunk loop: `xev.Completion{.op = .pread}` (io_uring offset read) → completion → `submitSend` → next pread, 64 KB chunks until `file_size`. The pread completion lives in `StaticState` (stable address on the heap-allocated `Connection`); `read_buf` comes from `base_allocator` sized `@min(file_size, STATIC_READ_SIZE)`; `pending_io_ops` accounting defers deinit while a read is in flight, so client-abort mid-transfer cannot use-after-free. 0-byte pread surfaces as xev `error.EOF` (file truncated mid-transfer) and finishes gracefully. `helpers.pread` deleted — zero callers remain.

**`refactor(static)` — #62:** extracted the two concerns still mixed after the async rework already separated the I/O loop: `resolveStaticPath` (suffix → traversal-checked, symlink-resolved `StaticPath{requested, real}`) and `buildStaticHeaders` (stat values → header text, now unit-testable). Content-type derives from the *requested* path (`StaticPath.requested`), preserving pre-refactor behavior for symlinked assets with mismatched extensions. Deliberately not a 4-way split: open/stat/ETag branches share fd ownership; splitting them adds indirection without readability gain. `serveStaticFile`: ~172 → ~104 lines.

## Verification

- `zig build test` / `zig build` — pass (after each commit and post-amend)
- Integration: 20 pass / 0 fail (15 existing + new `static.test.ts`: small file single-chunk, 473 KB multi-chunk, 92 KB boundary-straddling, 404, ETag/304, content-type)
- `grep -rn "helpers.pread" src/` — empty
- Zero overlap with #29 (handler.zig untouched)

Known gaps kept out of scope (pre-existing, follow-up issues to come): request-time `open`/`stat`/`realpath` remain synchronous; mid-transfer truncation sends a short body on keep-alive; 403 traversal branches lack a dedicated regression test.