### PR TITLE
fix(proxy): make reverse proxy fully async, never blocking the event loop

### DIFF
--- a/dashboard/keyway.lua
+++ b/dashboard/keyway.lua
@@ -195,6 +195,11 @@ keyway.static = {
 
 keyway.proxy = {
     ["/__keyway/grafana"] = { host = "127.0.0.1", port = 3000, redirect = "/__keyway/dashboard/grafana.html", strip_prefix = false },
+    -- Integration-test upstreams (see tests/integration/proxy.test.ts).
+    -- The live upstream is spawned by the test on this fixed port; the dead
+    -- one points at a closed port to exercise the 502 connect-failure path.
+    ["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true },
+    ["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true },
 }
 
 -- ─── Routes ──────────────────────────────────────────────────────────

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -36,6 +36,7 @@ const ErrorCategory = error_response.ErrorCategory;
 const Server = @import("server.zig").Server;
 const prom = @import("../observability/prom.zig");
 const static_mod = @import("../http/static.zig");
+const proxy_mod = @import("../http/proxy.zig");
 
 const ParamArray = params.ParamArray;
 const QueryArray = params.QueryArray;
@@ -125,6 +126,9 @@ pub const Connection = struct {
 
     // Static file: non-null when serving a static file
     static_state: ?static_mod.StaticState = null,
+
+    // Reverse proxy: non-null while an upstream exchange is in flight
+    proxy_state: ?proxy_mod.ProxyState = null,
 
     // Per-request timeout: timer fires after REQUEST_TIMEOUT_MS, sending 504
     // Completions initialized to .{} per xev requirements (Pitfall 3: never undefined)
@@ -250,6 +254,10 @@ pub const Connection = struct {
         if (self.sse_state) |*ss| ss.deinit(self);
         // Clean up static file state
         if (self.static_state) |*ss| ss.deinit(self.base_allocator);
+        // Clean up reverse-proxy state (closes upstream fd, frees buffers).
+        // pending_io_ops gates maybeFinishClose, so any in-flight upstream op
+        // has already fired before deinit runs.
+        if (self.proxy_state) |*ps| ps.deinit(self.base_allocator);
         // Clean up TLS resources
         self.tls_state.deinit(self.base_allocator);
         helpers.closeFd(self.socket);
@@ -735,7 +743,7 @@ pub const Connection = struct {
 
         // Reverse proxy routes: forward matching prefixes to upstream servers
         if (self.router.matchProxy(clean_path)) |proxy_match| {
-            self.proxyRequest(request, proxy_match, self.arena.allocator());
+            proxy_mod.serveProxy(self, request, proxy_match);
             return null;
         }
 
@@ -891,122 +899,10 @@ pub const Connection = struct {
         }
     }
 
-    /// Reverse proxy: connect to upstream, forward request, relay response.
-    fn proxyRequest(self: *Connection, request: *const http.Request, proxy_match: Router.ProxyMatch, alloc: std.mem.Allocator) void {
-        const prefix = proxy_match.route.prefix;
-
-        // Bare prefix with a configured redirect → 302
-        if (proxy_match.route.redirect) |redirect| {
-            if (proxy_match.suffix.len == 0 or std.mem.eql(u8, proxy_match.suffix, "/")) {
-                const resp = std.fmt.allocPrint(alloc, "HTTP/1.1 302 Found\r\nLocation: {s}\r\nContent-Length: 0\r\n\r\n", .{redirect}) catch {
-                    error_response.sendError(self, .server_error, "proxy redirect failed");
-                    return;
-                };
-                self.logAccess(302);
-                self.sendRawResponse(resp);
-                return;
-            }
-        }
-
-        // Build upstream path
-        const raw_path = request.path;
-        const upstream_path: []const u8 = if (proxy_match.route.strip_prefix)
-            (if (raw_path.len >= prefix.len and std.mem.startsWith(u8, raw_path, prefix))
-                (if (raw_path[prefix.len..].len == 0) "/" else raw_path[prefix.len..])
-            else
-                "/")
-        else
-            raw_path;
-
-        // Connect to upstream. std.net is gone in 0.16; this blocking client
-        // uses std.Io.net via a throwaway Threaded io. NOTE: this whole proxy
-        // path blocks the worker thread and should move to async libxev (#29).
-        var proxy_io: std.Io.Threaded = .init(alloc, .{});
-        defer proxy_io.deinit();
-        const pio = proxy_io.io();
-
-        const stream = blk: {
-            if (std.Io.net.IpAddress.parse(proxy_match.route.upstream_host, proxy_match.route.upstream_port)) |ipaddr| {
-                break :blk ipaddr.connect(pio, .{ .mode = .stream }) catch {
-                    error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
-                    return;
-                };
-            } else |_| {
-                const hostname = std.Io.net.HostName.init(proxy_match.route.upstream_host) catch {
-                    error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
-                    return;
-                };
-                break :blk hostname.connect(pio, proxy_match.route.upstream_port, .{ .mode = .stream }) catch {
-                    error_response.sendErrorStatus(self, 502, "proxy upstream connect failed");
-                    return;
-                };
-            }
-        };
-        defer stream.close(pio);
-
-        // Build upstream HTTP request
-        var req_buf: std.Io.Writer.Allocating = std.Io.Writer.Allocating.initCapacity(alloc, 1024) catch {
-            error_response.sendErrorStatus(self, 502, "proxy request alloc failed");
-            return;
-        };
-        const req_writer = &req_buf.writer;
-        req_writer.print("{s} {s} HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n", .{
-            request.method,
-            upstream_path,
-            proxy_match.route.upstream_host,
-            proxy_match.route.upstream_port,
-        }) catch {
-            error_response.sendErrorStatus(self, 502, "proxy request build failed");
-            return;
-        };
-        for (request.headers) |h| {
-            if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
-            if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
-            req_writer.print("{s}: {s}\r\n", .{ h.name, h.value }) catch {
-                error_response.sendErrorStatus(self, 502, "proxy header build failed");
-                return;
-            };
-        }
-        req_writer.writeAll("\r\n") catch {
-            error_response.sendErrorStatus(self, 502, "proxy request build failed");
-            return;
-        };
-
-        // Send request + body
-        var send_buf: [8192]u8 = undefined;
-        var upstream_writer = stream.writer(pio, &send_buf);
-        upstream_writer.interface.writeAll(req_buf.writer.buffered()) catch {
-            error_response.sendErrorStatus(self, 502, "proxy upstream write failed");
-            return;
-        };
-        if (request.body.len > 0) {
-            upstream_writer.interface.writeAll(request.body) catch {
-                error_response.sendErrorStatus(self, 502, "proxy upstream body write failed");
-                return;
-            };
-        }
-        upstream_writer.interface.flush() catch {
-            error_response.sendErrorStatus(self, 502, "proxy upstream write failed");
-            return;
-        };
-
-        // Read entire upstream response (blocks until upstream closes)
-        var recv_buf: [8192]u8 = undefined;
-        var upstream_reader = stream.reader(pio, &recv_buf);
-        const upstream_response = upstream_reader.interface.allocRemaining(alloc, .unlimited) catch {
-            error_response.sendErrorStatus(self, 502, "proxy upstream read failed");
-            return;
-        };
-        if (upstream_response.len == 0) {
-            error_response.sendErrorStatus(self, 502, "proxy upstream empty response");
-            return;
-        }
-
-        self.logAccess(200);
-        self.sendRawResponse(upstream_response);
-    }
-
-    fn onWrite(
+    /// pub: proxy.zig passes this directly as the completion callback for the
+    /// final proxy response send (submitSend with arena_dupe=false), so the
+    /// upstream buffers stay alive until the send actually completes.
+    pub fn onWrite(
         userdata: ?*anyopaque,
         loop: *xev.Loop,
         completion: *xev.Completion,
@@ -1016,6 +912,13 @@ pub const Connection = struct {
         _ = completion;
         const self = castUserdata(Connection, userdata);
         const bytes_written = self.handleSendCompletion(result) orelse return .disarm;
+        // Tear down proxy_state now that its response buffer's send has
+        // completed (safe: handleSendCompletion already returned on error/
+        // closing, so this doesn't run on a send that failed mid-flight —
+        // that path is cleaned up once by Connection.deinit instead).
+        if (self.proxy_state != null) {
+            proxy_mod.cleanupProxy(self);
+        }
         // If this write was the 504 timeout response, close instead of recycling.
         // pending_timer_ops/pending_io_ops may still be non-zero (in-flight
         // completions), so close() -> maybeFinishClose() defers deinit until they drain.

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1,0 +1,287 @@
+//! Reverse proxy — async connect/send/recv to upstream, relay response to client.
+//!
+//! Zig-native, no Lua involvement. Route configuration via keyway.proxy.
+//! Proactor model: every upstream I/O step runs on the worker's xev loop
+//! (io_uring) and never blocks it.
+//!
+//! Response framing: we send `Connection: close` upstream and read until EOF,
+//! buffering the whole response before relaying it (no Content-Length/chunked
+//! parsing). Upstream hosts are pre-resolved to an address at route
+//! registration, so the data path never does DNS.
+//!
+//! Connect/send/recv go through xev.TCP rather than raw xev.Completion ops
+//! (the pattern the rest of this file's siblings use for the client socket):
+//! building a raw `.connect` op needs libxev's internal address type, which
+//! Zig 0.16's std.Io migration no longer exposes to callers. xev.TCP is the
+//! only public surface that can bridge std.Io.net.IpAddress into a connect op.
+//!
+//! Known gaps tracked as follow-ups: no upstream deadline (#72), access status
+//! always logged as 200 (#73).
+
+const std = @import("std");
+const xev = @import("xev");
+const handler_mod = @import("../core/handler.zig");
+const Connection = handler_mod.Connection;
+const http = @import("http.zig");
+const helpers = @import("../util/helpers.zig");
+const error_response = @import("error_response.zig");
+const router_mod = @import("router.zig");
+
+/// Size of each upstream recv chunk (bytes), appended to the response buffer.
+const RECV_CHUNK = 16384;
+
+/// State for an in-progress reverse-proxy exchange.
+///
+/// Embedded directly in Connection (stable address as long as Connection is
+/// heap-alive). Exactly one upstream completion is in flight at a time, so a
+/// single `completion` drives the connect → send → recv phases — never submit
+/// a new upstream op except from inside the previous op's callback.
+pub const ProxyState = struct {
+    tcp: xev.TCP,
+    completion: xev.Completion = .{},
+    request_buf: []const u8, // upstream request bytes (headers + body); outlives the send
+    sent: usize = 0, // bytes of request_buf already sent (short-send loop)
+    recv_buf: []u8, // fixed-size upstream recv chunk
+    response: std.ArrayListUnmanaged(u8) = .empty, // accumulated upstream response
+
+    pub fn deinit(self: *ProxyState, allocator: std.mem.Allocator) void {
+        helpers.closeFd(self.tcp.fd);
+        allocator.free(self.request_buf);
+        allocator.free(self.recv_buf);
+        self.response.deinit(allocator);
+    }
+};
+
+/// Reverse proxy a request to its upstream. Called from handler.zig routeRequest.
+pub fn serveProxy(self: *Connection, request: *const http.Request, proxy_match: router_mod.Router.ProxyMatch) void {
+    const route = proxy_match.route;
+    const prefix = route.prefix;
+
+    // Bare prefix with a configured redirect → 302 (synchronous, no upstream).
+    if (route.redirect) |redirect| {
+        if (proxy_match.suffix.len == 0 or std.mem.eql(u8, proxy_match.suffix, "/")) {
+            const resp = std.fmt.allocPrint(self.arena.allocator(), "HTTP/1.1 302 Found\r\nLocation: {s}\r\nContent-Length: 0\r\n\r\n", .{redirect}) catch {
+                error_response.sendError(self, .server_error, "proxy redirect failed");
+                return;
+            };
+            self.logAccess(302);
+            self.sendRawResponse(resp);
+            return;
+        }
+    }
+
+    // Compute the upstream request-target path.
+    const raw_path = request.path;
+    const upstream_path: []const u8 = if (route.strip_prefix)
+        (if (raw_path.len >= prefix.len and std.mem.startsWith(u8, raw_path, prefix))
+            (if (raw_path[prefix.len..].len == 0) "/" else raw_path[prefix.len..])
+        else
+            "/")
+    else
+        raw_path;
+
+    // Build the upstream request bytes on base_allocator: they must outlive the
+    // per-request arena and keep a stable address for the async send.
+    const request_buf = buildUpstreamRequest(self.base_allocator, request, route, upstream_path) catch {
+        error_response.sendErrorStatus(self, 502, "proxy request build failed");
+        return;
+    };
+
+    const tcp = xev.TCP.init(route.upstream_addr) catch {
+        self.base_allocator.free(request_buf);
+        error_response.sendErrorStatus(self, 502, "proxy socket creation failed");
+        return;
+    };
+
+    const recv_buf = self.base_allocator.alloc(u8, RECV_CHUNK) catch {
+        helpers.closeFd(tcp.fd);
+        self.base_allocator.free(request_buf);
+        error_response.sendErrorStatus(self, 502, "proxy buffer alloc failed");
+        return;
+    };
+
+    self.proxy_state = .{
+        .tcp = tcp,
+        .request_buf = request_buf,
+        .recv_buf = recv_buf,
+    };
+
+    // Async connect to the pre-resolved upstream address.
+    self.pending_io_ops += 1;
+    tcp.connect(self.loop, &self.proxy_state.?.completion, route.upstream_addr, Connection, self, onProxyConnect);
+}
+
+/// Build the HTTP/1.1 request to send upstream: request line, rewritten Host,
+/// forced `Connection: close`, forwarded client headers, then the body.
+fn buildUpstreamRequest(
+    allocator: std.mem.Allocator,
+    request: *const http.Request,
+    route: router_mod.ProxyRoute,
+    upstream_path: []const u8,
+) ![]const u8 {
+    var aw: std.Io.Writer.Allocating = try .initCapacity(allocator, 1024);
+    defer aw.deinit();
+    const w = &aw.writer;
+
+    try w.print("{s} {s} HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n", .{
+        request.method,
+        upstream_path,
+        route.upstream_host,
+        route.upstream_port,
+    });
+    for (request.headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
+        if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
+        try w.print("{s}: {s}\r\n", .{ h.name, h.value });
+    }
+    try w.writeAll("\r\n");
+    if (request.body.len > 0) try w.writeAll(request.body);
+
+    var list = aw.toArrayList();
+    return try list.toOwnedSlice(allocator);
+}
+
+/// Connect completed — start sending the upstream request.
+fn onProxyConnect(
+    ud: ?*Connection,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    tcp: xev.TCP,
+    result: xev.ConnectError!void,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    _ = tcp;
+    const self = ud.?;
+    self.pending_io_ops -= 1;
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    result catch {
+        proxyFail(self, 502, "proxy upstream connect failed");
+        return .disarm;
+    };
+    submitUpstreamSend(self);
+    return .disarm;
+}
+
+/// Submit a send of the not-yet-sent tail of the upstream request.
+fn submitUpstreamSend(self: *Connection) void {
+    const ps = &self.proxy_state.?;
+    self.pending_io_ops += 1;
+    ps.tcp.write(self.loop, &ps.completion, .{ .slice = ps.request_buf[ps.sent..] }, Connection, self, onProxyUpstreamSent);
+}
+
+/// A send completed — loop on short sends, then start reading the response.
+fn onProxyUpstreamSent(
+    ud: ?*Connection,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    tcp: xev.TCP,
+    buf: xev.WriteBuffer,
+    result: xev.WriteError!usize,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    _ = tcp;
+    _ = buf;
+    const self = ud.?;
+    self.pending_io_ops -= 1;
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    const n = result catch {
+        proxyFail(self, 502, "proxy upstream write failed");
+        return .disarm;
+    };
+    const ps = &self.proxy_state.?;
+    ps.sent += n;
+    if (ps.sent < ps.request_buf.len) {
+        submitUpstreamSend(self); // short send — send the remainder
+        return .disarm;
+    }
+    submitUpstreamRecv(self);
+    return .disarm;
+}
+
+/// Submit a recv of the next upstream response chunk.
+fn submitUpstreamRecv(self: *Connection) void {
+    const ps = &self.proxy_state.?;
+    self.pending_io_ops += 1;
+    ps.tcp.read(self.loop, &ps.completion, .{ .slice = ps.recv_buf }, Connection, self, onProxyUpstreamRecv);
+}
+
+/// A recv completed — accumulate the chunk and keep reading until EOF.
+fn onProxyUpstreamRecv(
+    ud: ?*Connection,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    tcp: xev.TCP,
+    buf: xev.ReadBuffer,
+    result: xev.ReadError!usize,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    _ = tcp;
+    _ = buf;
+    const self = ud.?;
+    self.pending_io_ops -= 1;
+    if (self.state == .closing) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    const n = result catch |err| {
+        // EOF (upstream honored Connection: close) means the response is complete.
+        if (err == error.EOF) {
+            forwardProxyResponse(self);
+        } else {
+            proxyFail(self, 502, "proxy upstream read failed");
+        }
+        return .disarm;
+    };
+    const ps = &self.proxy_state.?;
+    ps.response.appendSlice(self.base_allocator, ps.recv_buf[0..n]) catch {
+        proxyFail(self, 502, "proxy response buffer failed");
+        return .disarm;
+    };
+    submitUpstreamRecv(self);
+    return .disarm;
+}
+
+/// Relay the buffered upstream response to the client.
+fn forwardProxyResponse(self: *Connection) void {
+    const ps = &self.proxy_state.?;
+    if (ps.response.items.len == 0) {
+        proxyFail(self, 502, "proxy upstream empty response");
+        return;
+    }
+    self.logAccess(200);
+    // Send directly from proxy_state's base_allocator buffer (arena_dupe=false)
+    // rather than through sendRawResponse: that buffer must stay valid until
+    // the write completion actually fires (io_uring reads it asynchronously),
+    // so cleanupProxy runs from handler.zig's onWrite once the send is
+    // confirmed done — not here. Freeing it at submission time would race the
+    // in-flight send; also avoids a full copy of a possibly large response.
+    self.state = .writing;
+    self.submitSend(ps.response.items, handler_mod.Connection.onWrite, false);
+}
+
+/// Send an error to the client and tear down proxy state. Safe to call from any
+/// upstream callback: we are inside the only in-flight op (already decremented),
+/// so no upstream completion references the fd we close here.
+fn proxyFail(self: *Connection, status: u16, internal_msg: []const u8) void {
+    cleanupProxy(self);
+    error_response.sendErrorStatus(self, status, internal_msg);
+}
+
+/// Tear down proxy_state (closes the upstream fd, frees buffers). Called from
+/// any upstream-failure callback and from handler.zig's onWrite once the
+/// final response send has completed.
+pub fn cleanupProxy(self: *Connection) void {
+    if (self.proxy_state) |*ps| {
+        ps.deinit(self.base_allocator);
+        self.proxy_state = null;
+    }
+}

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -168,8 +168,9 @@ pub const StaticRoute = struct {
 /// Reverse proxy route configuration.
 pub const ProxyRoute = struct {
     prefix: []const u8, // e.g. "/__keyway/grafana"
-    upstream_host: []const u8, // e.g. "127.0.0.1"
+    upstream_host: []const u8, // e.g. "127.0.0.1" — kept for the upstream Host header
     upstream_port: u16, // e.g. 3000
+    upstream_addr: std.Io.net.IpAddress, // resolved once at registration (no per-request DNS)
     redirect: ?[]const u8 = null, // if set, bare prefix requests 302 to this URL
     strip_prefix: bool = true, // if false, forward the full path to upstream
 };
@@ -225,7 +226,12 @@ pub const Router = struct {
     }
 
     /// Register a reverse proxy route.
+    /// Resolves the upstream host to an address at registration time (blocking here
+    /// is fine — it's config load, not the request hot path) so the proactor data
+    /// path never blocks on DNS. Mirrors nginx's resolve-at-config default.
     pub fn addProxyRoute(self: *Router, prefix: []const u8, upstream_host: []const u8, upstream_port: u16, redirect: []const u8, strip_prefix: bool) !void {
+        const upstream_addr = try resolveUpstream(self.allocator, upstream_host, upstream_port);
+
         const prefix_copy = try self.allocator.dupe(u8, prefix);
         const host_copy = try self.allocator.dupe(u8, upstream_host);
         const redirect_copy: ?[]const u8 = if (redirect.len > 0) try self.allocator.dupe(u8, redirect) else null;
@@ -233,10 +239,38 @@ pub const Router = struct {
             .prefix = prefix_copy,
             .upstream_host = host_copy,
             .upstream_port = upstream_port,
+            .upstream_addr = upstream_addr,
             .redirect = redirect_copy,
             .strip_prefix = strip_prefix,
         });
         try self.proxy_trie.insert(prefix, self.proxy_routes.items.len - 1);
+    }
+
+    /// Resolve an upstream host:port to an address once, at route registration.
+    /// Literal IPs parse without I/O; hostnames fall back to a blocking DNS
+    /// lookup (registration-time only — the request hot path never resolves).
+    fn resolveUpstream(allocator: std.mem.Allocator, host: []const u8, port: u16) !std.Io.net.IpAddress {
+        if (std.Io.net.IpAddress.parse(host, port)) |addr| return addr else |_| {}
+
+        const hostname = try std.Io.net.HostName.init(host);
+        var threaded: std.Io.Threaded = .init(allocator, .{});
+        defer threaded.deinit();
+        const io = threaded.io();
+
+        var lookup_buf: [8]std.Io.net.HostName.LookupResult = undefined;
+        var queue: std.Io.Queue(std.Io.net.HostName.LookupResult) = .init(&lookup_buf);
+        var lookup_future = io.async(std.Io.net.HostName.lookup, .{ hostname, io, &queue, .{ .port = port } });
+        defer lookup_future.cancel(io) catch {};
+
+        while (queue.getOne(io)) |result| {
+            switch (result) {
+                .address => |addr| return addr,
+                .canonical_name => {},
+            }
+        } else |_| {}
+
+        log.err().string("msg", "proxy upstream has no address").string("host", host).log();
+        return error.UnknownHostName;
     }
 
     pub const ProxyMatch = PrefixMatch(ProxyRoute);

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,0 +1,93 @@
+// Reverse proxy — exercises the async connect/send/recv path (issue #29).
+//
+// The dashboard config (dashboard/keyway.lua) registers two proxy routes:
+//   /__keyway/test-proxy       -> 127.0.0.1:38291 (the upstream spawned below)
+//   /__keyway/test-proxy-dead  -> 127.0.0.1:1     (closed port -> 502)
+// strip_prefix=true, so /__keyway/test-proxy/small forwards as /small upstream.
+//
+// We spin up a tiny Bun upstream here so the proxy has something real to talk
+// to. The large-response case is the regression target: the upstream reply
+// spans many async recv chunks, where a blocking/truncating relay would
+// corrupt or short the body.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import type { Server } from "bun";
+
+const base = () => globalThis.__KEYWAY_BASE;
+const UPSTREAM_PORT = 38291;
+const LARGE_SIZE = 500_000; // ~32 chunks at a 16 KB recv buffer
+const LARGE_BODY = "x".repeat(LARGE_SIZE);
+
+let upstream: Server | null = null;
+
+beforeAll(() => {
+  upstream = Bun.serve({
+    port: UPSTREAM_PORT,
+    async fetch(req) {
+      const url = new URL(req.url);
+      switch (url.pathname) {
+        case "/small":
+          return new Response("hello from upstream", {
+            headers: { "X-Upstream": "yes" },
+          });
+        case "/large":
+          return new Response(LARGE_BODY);
+        case "/echo":
+          return new Response(await req.text());
+        case "/header":
+          // Reflect a forwarded request header back in the body.
+          return new Response(req.headers.get("X-Client-Header") ?? "(none)");
+        case "/status500":
+          return new Response("upstream error", { status: 500 });
+        default:
+          return new Response("not found", { status: 404 });
+      }
+    },
+  });
+});
+
+afterAll(() => {
+  upstream?.stop(true);
+  upstream = null;
+});
+
+describe("reverse proxy", () => {
+  test("forwards a small GET and relays the upstream body + headers", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/small`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello from upstream");
+    expect(res.headers.get("x-upstream")).toBe("yes");
+  });
+
+  // Regression target for #29: response spans many async recv chunks.
+  test("relays a large upstream response intact across many chunks", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/large`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body.length).toBe(LARGE_SIZE);
+    expect(body).toBe(LARGE_BODY);
+  });
+
+  test("forwards the request body to the upstream (POST)", async () => {
+    const payload = "the quick brown fox".repeat(1000);
+    const res = await fetch(`${base()}/__keyway/test-proxy/echo`, {
+      method: "POST",
+      body: payload,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(payload);
+  });
+
+  test("forwards request headers to the upstream", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/header`, {
+      headers: { "X-Client-Header": "keyway-rocks" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("keyway-rocks");
+  });
+
+  test("returns 502 when the upstream connection is refused", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy-dead/whatever`);
+    expect(res.status).toBe(502);
+  });
+});


### PR DESCRIPTION
Closes #29

## What

`proxyRequest` performed blocking connect/write/read on the worker thread — any slow upstream stalled every connection on that xev loop (P0 proactor violation). Replaced with an async state machine in new `src/http/proxy.zig` (~290 lines): connect → send (short-send loop) → recv-until-EOF → relay, driven by one reused `xev.Completion` via `xev.TCP` (the only public libxev surface that bridges Zig 0.16's `std.Io.net.IpAddress` into a connect op). The blocking implementation is deleted from handler.zig.

- **DNS at route registration, never per-request**: `ProxyRoute` carries a resolved `IpAddress`; literal IPs parse with zero I/O, hostnames resolve once in `addProxyRoute` (nginx resolve-at-config policy — same registration-time blocking class as `addStaticRoute`).
- **Teardown**: reuses the existing `pending_io_ops` deferred-deinit accounting; upstream fd and buffers freed exactly once via two mutually exclusive sites (post-relay-send in `onWrite`, or `Connection.deinit`'s null-checked hook on any abort path).
- **Relay**: buffers upstream response then sends directly from the stable buffer (no arena copy), matching the deleted implementation's read-until-EOF/`Connection: close` contract.
- Loop-unblocking proven live: on a single worker, `/health` and a fast proxy route answered in ~25ms while a 2s-delayed upstream request was in flight.

## Scope guard (deliberately unchanged, tracked issues)
- #72: no upstream deadline — read-until-EOF can wait out a non-compliant upstream's idle timeout (reproduced during testing, exactly as #72 describes).
- #73: access log still reports 200 regardless of upstream status.

## Review
Opus review found one blocker in the first cut — a use-after-free on the response-send OOM path (synchronous deinit inside `submitSend`'s arena-dupe failure, then cleanup on freed memory). Fixed structurally: the send no longer dupes (fallible branch unreachable) and cleanup moved behind the write completion; delta re-review traced all four completion paths (success, send-fail, client-abort, forceCloseAll) to exactly-once cleanup. Also dropped an unread `.proxying` state variant (#72 will reintroduce it with an actual reader).

## Verification
- `zig build test` — 103/103; `zig build` clean (three independent runs at final SHA)
- Integration: 20 pass / 0 fail (incl. new `proxy.test.ts`: relay + header forwarding, 500 KB across ~31 recv chunks, POST body, request headers, 502 on refused connect; upstream spun in-test)
- Manual: relay integrity, 502 on dead port, clean teardown, no dangling processes

Follow-up issues to file (found in review, none regressions): hot-reload blocking DNS for hostname upstreams, unbounded upstream response accumulation (pairs with #72), forceCloseAll not covering an in-flight upstream fd.