### PR TITLE
fix(proxy): log the real upstream status instead of hardcoded 200

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -15,8 +15,7 @@
 //! Zig 0.16's std.Io migration no longer exposes to callers. xev.TCP is the
 //! only public surface that can bridge std.Io.net.IpAddress into a connect op.
 //!
-//! Known gaps tracked as follow-ups: no upstream deadline (#72), access status
-//! always logged as 200 (#73).
+//! Known gaps tracked as follow-ups: no upstream deadline (#72).
 
 const std = @import("std");
 const xev = @import("xev");
@@ -250,6 +249,17 @@ fn onProxyUpstreamRecv(
     return .disarm;
 }
 
+/// Parse the 3-digit status code from a buffered upstream response's status
+/// line (e.g. "HTTP/1.1 502 Bad Gateway\r\n" -> 502). Returns null if the
+/// buffer is too short or doesn't start with a well-formed status line.
+/// Never allocates.
+fn parseUpstreamStatus(response: []const u8) ?u16 {
+    if (response.len < 12) return null;
+    if (!std.mem.startsWith(u8, response, "HTTP/1.")) return null;
+    if (!std.ascii.isDigit(response[7]) or response[8] != ' ') return null;
+    return std.fmt.parseInt(u16, response[9..12], 10) catch null;
+}
+
 /// Relay the buffered upstream response to the client.
 fn forwardProxyResponse(self: *Connection) void {
     const ps = &self.proxy_state.?;
@@ -257,7 +267,11 @@ fn forwardProxyResponse(self: *Connection) void {
         proxyFail(self, 502, "proxy upstream empty response");
         return;
     }
-    self.logAccess(200);
+    // Log the real upstream status rather than a hardcoded 200 (#73). The
+    // response bytes are relayed to the client verbatim regardless; if the
+    // status line doesn't parse, the upstream didn't send valid HTTP, so we
+    // log 502 (bad gateway) rather than lie with 200.
+    self.logAccess(parseUpstreamStatus(ps.response.items) orelse 502);
     // Send directly from proxy_state's base_allocator buffer (arena_dupe=false)
     // rather than through sendRawResponse: that buffer must stay valid until
     // the write completion actually fires (io_uring reads it asynchronously),
@@ -284,4 +298,32 @@ pub fn cleanupProxy(self: *Connection) void {
         ps.deinit(self.base_allocator);
         self.proxy_state = null;
     }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "parseUpstreamStatus: well-formed status lines" {
+    try std.testing.expectEqual(@as(?u16, 200), parseUpstreamStatus("HTTP/1.1 200 OK\r\n\r\n"));
+    try std.testing.expectEqual(@as(?u16, 404), parseUpstreamStatus("HTTP/1.1 404 Not Found\r\n\r\n"));
+    try std.testing.expectEqual(@as(?u16, 502), parseUpstreamStatus("HTTP/1.0 502 Bad Gateway\r\n\r\n"));
+}
+
+test "parseUpstreamStatus: 3-digit boundary codes" {
+    try std.testing.expectEqual(@as(?u16, 100), parseUpstreamStatus("HTTP/1.1 100 Continue\r\n\r\n"));
+    try std.testing.expectEqual(@as(?u16, 999), parseUpstreamStatus("HTTP/1.1 999 X\r\n\r\n"));
+    try std.testing.expectEqual(@as(?u16, 200), parseUpstreamStatus("HTTP/1.1 200")); // exact len == 12, no trailing bytes
+}
+
+test "parseUpstreamStatus: malformed status line" {
+    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("not an http response at all"));
+    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1-200 OK\r\n\r\n"));
+    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1 abc OK\r\n\r\n"));
+    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/2 200 OK\r\n\r\n")); // not HTTP/1.x
+}
+
+test "parseUpstreamStatus: short buffer" {
+    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus(""));
+    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1 2"));
 }

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -90,4 +90,15 @@ describe("reverse proxy", () => {
     const res = await fetch(`${base()}/__keyway/test-proxy-dead/whatever`);
     expect(res.status).toBe(502);
   });
+
+  // Regression target for #73: the proxy used to hardcode status 200 in its
+  // access log / metrics regardless of what the upstream actually returned.
+  test("relays and logs the real upstream status (500)", async () => {
+    const res = await fetch(`${base()}/__keyway/test-proxy/status500`);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("upstream error");
+
+    const metrics = await (await fetch(`${base()}/metrics`)).text();
+    expect(metrics).toMatch(/keyway_http_requests_total\{[^}]*status="500"[^}]*\}/);
+  });
 });


### PR DESCRIPTION
Closes #73

## What

`forwardProxyResponse` logged `logAccess(200)` unconditionally — access logs and Prometheus misreported proxied 4xx/5xx as 200. Now parses the status code from the buffered upstream status line with a 12-byte, no-alloc, no-panic check (`HTTP/1.x SSS`) and logs the real value.

- Fallback for unparseable-but-relayed bytes is **502** (matching the `upstream_error` precedent): logging 200 was the bug, and 0 is meaningless in the status label space. The empty-response path already short-circuits to `proxyFail(502)` before this line — untouched.
- Metrics/logging only: relay, buffering, cleanup, and error paths are byte-identical. No picohttpparser response binding added for 3 bytes.
- Review nits applied: parser edges pinned (`len==12` exact, `HTTP/2` prefix rejection past the length guard); redundant 404 integration test dropped in favor of the 500 one.

## Verification
- `zig build test` — pass (6 parser unit tests incl. boundary/malformed/short)
- Integration: 26 pass / 0 fail — new test asserts the relayed 500 AND `keyway_http_requests_total{...status="500"...}` counting under the real label (label-order-independent regex)

Found during this work, tracked elsewhere: proxied requests record `route=""` in Prometheus — appended to #119.