### PR TITLE
fix(proxy): bound the upstream exchange with a deadline

### DIFF
--- a/dashboard/keyway.lua
+++ b/dashboard/keyway.lua
@@ -197,9 +197,12 @@ keyway.proxy = {
     ["/__keyway/grafana"] = { host = "127.0.0.1", port = 3000, redirect = "/__keyway/dashboard/grafana.html", strip_prefix = false },
     -- Integration-test upstreams (see tests/integration/proxy.test.ts).
     -- The live upstream is spawned by the test on this fixed port; the dead
-    -- one points at a closed port to exercise the 502 connect-failure path.
+    -- one points at a closed port to exercise the 502 connect-failure path;
+    -- the hung one accepts but never responds, exercising the upstream
+    -- deadline (#72).
     ["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true },
     ["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true },
+    ["/__keyway/test-proxy-hung"] = { host = "127.0.0.1", port = 38292, strip_prefix = true },
 }
 
 -- ─── Routes ──────────────────────────────────────────────────────────

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -277,7 +277,10 @@ pub const Connection = struct {
 
     /// Cancel the per-request deadline timer on normal response completion.
     /// Safe to call if timer already fired or was never started.
-    fn cancelRequestTimer(self: *Connection) void {
+    /// pub: also cancels proxy.zig's upstream deadline (#72), which reuses this
+    /// same timer_completion — the request timer is never armed on the proxy
+    /// path, so the field is idle and safe to share.
+    pub fn cancelRequestTimer(self: *Connection) void {
         if (!self.timer_armed) return; // no timer to cancel (e.g. health endpoint)
         if (self.timed_out) return; // already fired, nothing to cancel
         self.timer_armed = false;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -15,7 +15,13 @@
 //! Zig 0.16's std.Io migration no longer exposes to callers. xev.TCP is the
 //! only public surface that can bridge std.Io.net.IpAddress into a connect op.
 //!
-//! Known gaps tracked as follow-ups: no upstream deadline (#72).
+//! Upstream deadline (#72): one timer covers the whole exchange (connect+send+
+//! recv), reusing Connection's request-timer fields (idle on this path — see
+//! startProxyTimer). On fire, an io_uring `.cancel` op targets the in-flight
+//! upstream completion directly rather than shutdown()ing the fd: shutdown()
+//! on a socket still in SYN_SENT (mid-connect) is a documented no-op on Linux,
+//! so it wouldn't bound a hung *connect* — only hung send/recv. `.cancel`
+//! (IORING_OP_ASYNC_CANCEL) aborts any of the three phases uniformly.
 
 const std = @import("std");
 const xev = @import("xev");
@@ -25,6 +31,7 @@ const http = @import("http.zig");
 const helpers = @import("../util/helpers.zig");
 const error_response = @import("error_response.zig");
 const router_mod = @import("router.zig");
+const config = @import("../util/config.zig");
 
 /// Size of each upstream recv chunk (bytes), appended to the response buffer.
 const RECV_CHUNK = 16384;
@@ -42,6 +49,10 @@ pub const ProxyState = struct {
     sent: usize = 0, // bytes of request_buf already sent (short-send loop)
     recv_buf: []u8, // fixed-size upstream recv chunk
     response: std.ArrayListUnmanaged(u8) = .empty, // accumulated upstream response
+    // Distinct completion for the `.cancel` op that aborts `completion` on
+    // timeout (see onProxyTimeout) — a cancel op needs its own completion
+    // struct, separate from the one it targets.
+    cancel_completion: xev.Completion = .{},
 
     pub fn deinit(self: *ProxyState, allocator: std.mem.Allocator) void {
         helpers.closeFd(self.tcp.fd);
@@ -105,9 +116,89 @@ pub fn serveProxy(self: *Connection, request: *const http.Request, proxy_match: 
         .recv_buf = recv_buf,
     };
 
+    startProxyTimer(self);
+
     // Async connect to the pre-resolved upstream address.
     self.pending_io_ops += 1;
     tcp.connect(self.loop, &self.proxy_state.?.completion, route.upstream_addr, Connection, self, onProxyConnect);
+}
+
+/// Arm the deadline covering the whole upstream exchange (connect+send+recv).
+/// Reuses Connection's request-timer fields (timer_completion, timer_armed,
+/// pending_timer_ops) — idle here since dispatchToHandler's startRequestTimer
+/// is never reached on the proxy short-circuit path (see routeRequest). Timer
+/// removal reuses cancelRequestTimer, which is agnostic to which logical
+/// deadline is currently armed on the shared completion.
+fn startProxyTimer(self: *Connection) void {
+    self.timer_armed = true;
+    self.pending_timer_ops += 1;
+    self.loop.timer(&self.timer_completion, config.PROXY_UPSTREAM_TIMEOUT_MS, self, onProxyTimeout);
+}
+
+/// Upstream deadline fired — cancel the in-flight upstream op so its callback
+/// (onProxyConnect/onProxyUpstreamSent/onProxyUpstreamRecv) runs with an
+/// error, sending 504 through the ordinary proxyFail path exactly once.
+/// Mirrors handler.zig's onRequestTimeout guard structure.
+fn onProxyTimeout(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    const self = helpers.castUserdata(Connection, userdata);
+    // ECANCELED here means cancelRequestTimer's timer_remove fired (normal
+    // exit) — not a real deadline. Ignore it, matching onRequestTimeout.
+    const trigger = result.timer catch {
+        self.pending_timer_ops -= 1;
+        self.maybeFinishClose();
+        return .disarm;
+    };
+    self.pending_timer_ops -= 1;
+    if (trigger == .cancel) {
+        self.maybeFinishClose();
+        return .disarm;
+    }
+    self.timer_armed = false;
+    if (self.state == .closing) return .disarm;
+    // Stale fire that raced an already-in-flight cancellation: the exchange
+    // finished (forwardProxyResponse or proxyFail already ran cleanupProxy)
+    // before this expiry was processed. Nothing left to time out.
+    if (self.proxy_state == null) return .disarm;
+    self.timed_out = true;
+    self.pending_io_ops += 1;
+    const ps = &self.proxy_state.?;
+    // cancel_completion's address stays valid even after cleanupProxy runs
+    // (from the op it's cancelling) and nulls proxy_state: nulling an
+    // optional writes only the tag, not the payload bytes, and
+    // onProxyCancelComplete never dereferences proxy_state — it only
+    // touches self. pending_io_ops (bumped above) defers Connection deinit
+    // until this op is reaped either way.
+    ps.cancel_completion = .{
+        .op = .{ .cancel = .{ .c = &ps.completion } },
+        .userdata = self,
+        .callback = onProxyCancelComplete,
+    };
+    self.loop.add(&ps.cancel_completion);
+    return .disarm;
+}
+
+/// The cancel op itself completed. Best-effort — the cancelled op's own
+/// callback (not this one) drives the actual cleanup and 504 response.
+fn onProxyCancelComplete(
+    userdata: ?*anyopaque,
+    loop: *xev.Loop,
+    completion: *xev.Completion,
+    result: xev.Result,
+) xev.CallbackAction {
+    _ = loop;
+    _ = completion;
+    _ = result;
+    const self = helpers.castUserdata(Connection, userdata);
+    self.pending_io_ops -= 1;
+    self.maybeFinishClose();
+    return .disarm;
 }
 
 /// Build the HTTP/1.1 request to send upstream: request line, rewritten Host,
@@ -262,6 +353,7 @@ fn parseUpstreamStatus(response: []const u8) ?u16 {
 
 /// Relay the buffered upstream response to the client.
 fn forwardProxyResponse(self: *Connection) void {
+    self.cancelRequestTimer();
     const ps = &self.proxy_state.?;
     if (ps.response.items.len == 0) {
         proxyFail(self, 502, "proxy upstream empty response");
@@ -285,9 +377,17 @@ fn forwardProxyResponse(self: *Connection) void {
 /// Send an error to the client and tear down proxy state. Safe to call from any
 /// upstream callback: we are inside the only in-flight op (already decremented),
 /// so no upstream completion references the fd we close here.
+///
+/// If the upstream deadline (#72) fired, `self.timed_out` is already set by
+/// onProxyTimeout — the caller's status/message (e.g. 502 for a connect
+/// failure) is overridden to 504, since the real cause was the timeout's
+/// cancel, not whatever error the cancelled op happened to report.
 fn proxyFail(self: *Connection, status: u16, internal_msg: []const u8) void {
+    self.cancelRequestTimer();
     cleanupProxy(self);
-    error_response.sendErrorStatus(self, status, internal_msg);
+    const actual_status: u16 = if (self.timed_out) 504 else status;
+    const msg = if (self.timed_out) "proxy upstream timeout" else internal_msg;
+    error_response.sendErrorStatus(self, actual_status, msg);
 }
 
 /// Tear down proxy_state (closes the upstream fd, frees buffers). Called from

--- a/src/util/config.zig
+++ b/src/util/config.zig
@@ -60,6 +60,10 @@ pub const STATIC_READ_SIZE: usize = 65536;
 /// Maximum static file size (100 MB). Files larger than this get 413.
 pub const STATIC_MAX_SIZE: u64 = 100 * 1024 * 1024;
 
+/// Deadline for the whole reverse-proxy upstream exchange (connect+send+recv
+/// combined, not per-op). Requests exceeding this get 504.
+pub const PROXY_UPSTREAM_TIMEOUT_MS: u64 = 30_000;
+
 comptime {
     // Buffer sizes must be at least 4096 for reasonable HTTP operation
     if (READ_BUFFER_SIZE < 4096)
@@ -84,4 +88,6 @@ comptime {
         @compileError("HEADER_TIMEOUT_MS must be > 0");
     if (STATIC_READ_SIZE < 4096)
         @compileError("STATIC_READ_SIZE must be >= 4096");
+    if (PROXY_UPSTREAM_TIMEOUT_MS == 0)
+        @compileError("PROXY_UPSTREAM_TIMEOUT_MS must be > 0");
 }

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,8 +1,9 @@
 // Reverse proxy — exercises the async connect/send/recv path (issue #29).
 //
-// The dashboard config (dashboard/keyway.lua) registers two proxy routes:
+// The dashboard config (dashboard/keyway.lua) registers three proxy routes:
 //   /__keyway/test-proxy       -> 127.0.0.1:38291 (the upstream spawned below)
 //   /__keyway/test-proxy-dead  -> 127.0.0.1:1     (closed port -> 502)
+//   /__keyway/test-proxy-hung  -> 127.0.0.1:38292 (accepts, never responds -> 504)
 // strip_prefix=true, so /__keyway/test-proxy/small forwards as /small upstream.
 //
 // We spin up a tiny Bun upstream here so the proxy has something real to talk
@@ -11,14 +12,16 @@
 // corrupt or short the body.
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import type { Server } from "bun";
+import type { Server, TCPSocketListener } from "bun";
 
 const base = () => globalThis.__KEYWAY_BASE;
 const UPSTREAM_PORT = 38291;
+const HUNG_UPSTREAM_PORT = 38292;
 const LARGE_SIZE = 500_000; // ~32 chunks at a 16 KB recv buffer
 const LARGE_BODY = "x".repeat(LARGE_SIZE);
 
 let upstream: Server | null = null;
+let hungUpstream: TCPSocketListener | null = null;
 
 beforeAll(() => {
   upstream = Bun.serve({
@@ -44,11 +47,28 @@ beforeAll(() => {
       }
     },
   });
+
+  // Raw TCP listener (not Bun.serve, which always answers): accepts the
+  // connection and the request bytes, then never writes a response and
+  // never closes — the shape of a hung/non-compliant upstream (#72).
+  hungUpstream = Bun.listen({
+    hostname: "127.0.0.1",
+    port: HUNG_UPSTREAM_PORT,
+    socket: {
+      data() {},
+      open() {},
+      close() {},
+      drain() {},
+      error() {},
+    },
+  });
 });
 
 afterAll(() => {
   upstream?.stop(true);
   upstream = null;
+  hungUpstream?.stop(true);
+  hungUpstream = null;
 });
 
 describe("reverse proxy", () => {
@@ -101,4 +121,31 @@ describe("reverse proxy", () => {
     const metrics = await (await fetch(`${base()}/metrics`)).text();
     expect(metrics).toMatch(/keyway_http_requests_total\{[^}]*status="500"[^}]*\}/);
   });
+});
+
+describe("reverse proxy upstream deadline (#72)", () => {
+  // Runs against the real PROXY_UPSTREAM_TIMEOUT_MS (config.zig, 30s) — no
+  // test-only config surface for a shorter deadline (keyway.proxy routes
+  // don't take a timeout option, and adding one just for this test would be
+  // new production API surface for a value that's otherwise a fixed
+  // constant). The per-test timeout override below is local to this test and
+  // doesn't touch the suite's shared 10s default (see tests/preload.ts).
+  test(
+    "hung upstream (accepts, never responds) gets 504 after the deadline; server stays healthy after",
+    async () => {
+      const start = Date.now();
+      const res = await fetch(`${base()}/__keyway/test-proxy-hung/whatever`);
+      const elapsed = Date.now() - start;
+      expect(res.status).toBe(504);
+      // Sanity check this actually rode out the real deadline rather than
+      // failing fast on some other path (e.g. connect refused -> 502).
+      expect(elapsed).toBeGreaterThan(25_000);
+
+      // The connection must be usable afterward — not left half-torn-down —
+      // and the worker must still be accepting/serving other requests.
+      const health = await fetch(`${base()}/health`);
+      expect(health.status).toBe(200);
+    },
+    35_000,
+  );
 });


### PR DESCRIPTION
Closes #72

## What

The async proxy (#29) had no deadline anywhere: a hung upstream, or one that ignores `Connection: close` and never FINs, tied up the client connection indefinitely. Now one 30 s deadline (`config.PROXY_UPSTREAM_TIMEOUT_MS`) covers the whole upstream exchange (connect + send + recv).

- **Reuses the Connection's request-timer fields** (`timer_completion`/`timer_armed`/`timed_out`/`pending_timer_ops`) — idle on the proxy path since the request timer is never armed there; `cancelRequestTimer` made `pub` and called on every normal exit. No new timer machinery.
- **On fire: io_uring `.cancel` at the in-flight op**, not fd-shutdown — `shutdown()` is a documented no-op in SYN_SENT, so it wouldn't bound a hung *connect*; `IORING_OP_ASYNC_CANCEL` aborts all three phases uniformly (same idiom as the existing accept-cancel). The cancelled op falls into its existing error branch → `proxyFail` overrides to **504** ("proxy upstream timeout") exactly once; connect/protocol failures keep their 502.
- The timeout path forces close (no keep-alive on a timed-out connection); `pending_io_ops` defers deinit until the cancel op reaps, and the cancel completion's lifetime across the nulled `?ProxyState` is documented at the submission site.
- No per-route timeout option, no env config — one comptime constant (YAGNI until asked).

## Review
Opus review APPROVE with all five requested memory/race traces verified (timer-field sharing across keep-alive, expiry-vs-success race → benign, completion-inside-nulled-optional → safe on both CQE orderings, phase-uniform cancel, op accounting incl. forced shutdown). Ponytail nits applied (inlined a one-line helper, dropped its redundant unit tests).

## Verification
- `zig build test` / `zig build` — pass
- Integration: 26 pass / 0 fail — new test uses a raw TCP listener that accepts and never responds: asserts **504 after > 25 s** (proving the real deadline fired, not a faster failure path) and that the server serves `/health` normally afterward. Note: this adds ~30 s to the suite (deliberate — the test rides the real production constant instead of adding test-only config surface).
- Manual: hung upstream → 504 at 30.011 s; 502 dead-port path unchanged afterward.

Known interactions: forced shutdown during a hung upstream still waits on the upstream (pre-existing, #130); the benign expiry-vs-success race costs at most one keep-alive connection after a ~30 s request.