### PR TITLE
fix(build): make zig build run pass the default script path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -42,6 +42,7 @@ pub fn build(b: *std.Build) void {
     // Run command
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
+    run_cmd.addArgs(&.{ "--script", "dashboard/keyway.lua" });
 
     if (b.args) |args| {
         run_cmd.addArgs(args);


### PR DESCRIPTION
Closes #115

## What changed
`build.zig`: the run step now passes `--script dashboard/keyway.lua` on `run_cmd` before the existing `if (b.args) |args| run_cmd.addArgs(args);` passthrough, so a user-supplied `--script` still overrides it.

## Why
`zig build run` resolves `--script` against cwd with no matching file at the repo root (`src/util/cli.zig` default is `keyway.lua`); the real entry point is `dashboard/keyway.lua`. A fresh `zig build run` hit the zero-workers zombie instead of a running server.

## Observed behavior
- `zig build` — green, no errors.
- `zig build test` — green, no errors.
- `timeout 5 zig build run` from repo root: spawned 8 workers, registered routes from `dashboard/keyway.lua` (static/proxy routes), logged `Keyway - Ready host=0.0.0.0 port=8080`. `curl localhost:8080` returned a real HTTP 404 (route-not-found), confirming the server was listening. Ran until the timeout killed it, then shut down cleanly (drained 0 active connections per worker).

CLAUDE.md/README already document `zig build run` correctly (aspirationally); no doc changes needed since they now match reality.