### PR TITLE
fix(core): exit fatally when every worker fails during startup

### DIFF
--- a/src/core/worker.zig
+++ b/src/core/worker.zig
@@ -66,6 +66,7 @@ pub const Worker = struct {
         reload_coordinator: ?*ReloadCoordinator,
         metrics: *WorkerMetrics,
         ready_count: *std.atomic.Value(usize),
+        live_count: *std.atomic.Value(usize),
         script_path: []const u8,
         watch: bool,
     };
@@ -100,6 +101,11 @@ pub const Worker = struct {
         prom.worker_id = @intCast(ctx.worker_id);
 
         defer ctx.allocator.destroy(ctx);
+
+        // Mark this worker as exited (success or error) so waitUntilReady can
+        // detect "every worker died during startup" instead of spinning
+        // forever — see #114.
+        defer _ = ctx.live_count.fetchSub(1, .release);
 
         if (pinned) {
             log.debug().string("msg", "worker pinned to core").int("core", ctx.worker_id).log();
@@ -365,6 +371,7 @@ pub const ThreadPool = struct {
     reload_coordinator: ?*ReloadCoordinator = null,
     worker_metrics: []WorkerMetrics,
     ready_count: *std.atomic.Value(usize),
+    live_count: *std.atomic.Value(usize),
 
     /// Create thread pool with the given number of workers.
     /// Pass worker_count=0 to auto-detect (one worker per CPU core).
@@ -401,6 +408,13 @@ pub const ThreadPool = struct {
         ready_count.* = std.atomic.Value(usize).init(0);
         errdefer allocator.destroy(ready_count);
 
+        // Create worker liveness counter (decremented as each worker thread
+        // exits, success or failure). Lets waitUntilReady detect "zero
+        // survivors" instead of spinning forever — see #114.
+        const live_count = try allocator.create(std.atomic.Value(usize));
+        live_count.* = std.atomic.Value(usize).init(num_workers);
+        errdefer allocator.destroy(live_count);
+
         // Create SSE broadcast bus (shared across all workers)
         const sse_bus = SseBroadcastBus.init(allocator, num_workers) catch null;
 
@@ -417,6 +431,7 @@ pub const ThreadPool = struct {
                 .reload_coordinator = reload_coordinator,
                 .metrics = &worker_metrics[i],
                 .ready_count = ready_count,
+                .live_count = live_count,
                 .script_path = script_path,
                 .watch = watch,
             });
@@ -431,12 +446,18 @@ pub const ThreadPool = struct {
             .reload_coordinator = reload_coordinator,
             .worker_metrics = worker_metrics,
             .ready_count = ready_count,
+            .live_count = live_count,
         };
     }
 
-    /// Block until all workers have bound their sockets and are accepting connections.
-    pub fn waitUntilReady(self: *ThreadPool) void {
+    /// Block until all workers have bound their sockets and are accepting
+    /// connections. Returns error.AllWorkersFailed if every worker thread
+    /// exited before any reached readiness (e.g. the entry script failed to
+    /// load) — without this check the caller spins forever on a zombie
+    /// server. See #114.
+    pub fn waitUntilReady(self: *ThreadPool) error{AllWorkersFailed}!void {
         while (self.ready_count.load(.acquire) < self.workers.len) {
+            if (self.live_count.load(.acquire) == 0) return error.AllWorkersFailed;
             std.atomic.spinLoopHint();
         }
     }
@@ -453,6 +474,7 @@ pub const ThreadPool = struct {
         if (self.sse_bus) |bus| bus.deinit();
         self.allocator.destroy(self.bpf_ready);
         self.allocator.destroy(self.ready_count);
+        self.allocator.destroy(self.live_count);
         self.allocator.free(self.worker_metrics);
         self.allocator.free(self.workers);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -86,8 +86,13 @@ pub fn main(init: std.process.Init.Minimal) !void {
     var pool = try ThreadPool.init(allocator, server_config, cli_config.workers, &coordinator, &reload_coordinator, cli_config.script, cli_config.watch);
     defer pool.deinit();
 
-    // Block until all workers have bound sockets and are accepting connections
-    pool.waitUntilReady();
+    // Block until all workers have bound sockets and are accepting connections.
+    // If every worker died during startup (e.g. the entry script failed to
+    // load), fail fast instead of leaving a zombie server — see #114.
+    pool.waitUntilReady() catch {
+        log.err().string("msg", "all workers failed to start — exiting").log();
+        std.process.exit(1);
+    };
     log.info().string("msg", "Keyway - Ready").stringSafe("host", server_config.host).int("port", server_config.port).log();
 
     // Wait for all workers (runs until Ctrl+C)


### PR DESCRIPTION
## Summary

Closes #114

When the Lua entry script can't be loaded, `workerMain` returns an error and the OS thread exits, but nothing signaled that to the main thread. `ThreadPool.waitUntilReady()` only checked `ready_count` (incremented after a worker successfully binds and starts accepting), so with zero workers ever reaching readiness it spun forever — no listening socket, no error exit code, main thread parked.

Fix: add a `live_count` atomic on `ThreadPool`/`Worker.Context`, initialized to `num_workers` and decremented (via `defer`) as each worker thread exits, success or failure. `waitUntilReady()` now returns `error.AllWorkersFailed` if `live_count` hits zero before `ready_count` reaches `workers.len`; `main.zig` logs a fatal message and calls `std.process.exit(1)`.

A single worker dying while others stay up is untouched — that's a separate policy question per the issue; this only guarantees zero survivors never idles.

## Verification

- `zig build` — clean.
- `zig build test` — exit 0 (all unit tests pass).
- Failure path — `timeout 10 ./zig-out/bin/keyway` (repo root, no `keyway.lua`): all 8 workers log `"Lua error loading script"`, then `"all workers failed to start — exiting"`, **exit code 1** (well under the 10s timeout — no hang).
- Happy path — `timeout 5 ./zig-out/bin/keyway --script dashboard/keyway.lua`: server comes up (background `curl localhost:8080/` returns HTTP 404, i.e. connection succeeded and got routed), runs until timeout sends SIGTERM, workers drain and shut down gracefully, **exit code 124** (timeout killed it — did not exit early).

## Test plan
- [x] `zig build`
- [x] `zig build test`
- [x] Manual failure-path repro (exit 1, fatal log, no hang)
- [x] Manual happy-path repro (server stays up, curl succeeds)
- [ ] Bun integration suite (left for Mayor at merge, per instructions)