### PR TITLE
refactor: swap hand-rolled code in src/ for stdlib equivalents

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -348,15 +348,7 @@ test "picohttpparser websocket upgrade headers" {
 
 /// Encode data as a chunked transfer encoding chunk: "{hex_len}\r\n{data}\r\n"
 pub fn encodeChunk(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
-    // Format: hex_length\r\ndata\r\n
-    const hex_len = std.fmt.count("{x}", .{data.len});
-    const total = hex_len + 2 + data.len + 2;
-    const buf = try allocator.alloc(u8, total);
-    var w = std.Io.Writer.fixed(buf);
-    w.print("{x}\r\n", .{data.len}) catch unreachable;
-    w.writeAll(data) catch unreachable;
-    w.writeAll("\r\n") catch unreachable;
-    return buf;
+    return std.fmt.allocPrint(allocator, "{x}\r\n{s}\r\n", .{ data.len, data });
 }
 
 /// Terminal chunk for chunked transfer encoding.

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -227,8 +227,7 @@ fn buildUpstreamRequest(
     try w.writeAll("\r\n");
     if (request.body.len > 0) try w.writeAll(request.body);
 
-    var list = aw.toArrayList();
-    return try list.toOwnedSlice(allocator);
+    return aw.toOwnedSlice();
 }
 
 /// Connect completed — start sending the upstream request.

--- a/src/lua/json.zig
+++ b/src/lua/json.zig
@@ -7,7 +7,7 @@ const Lua = @import("luajit").Lua;
 const max_depth = 128;
 const alloc = std.heap.c_allocator;
 
-const Buf = std.ArrayListUnmanaged(u8);
+const Buf = std.Io.Writer.Allocating;
 
 const EncodeError = error{
     DepthLimitExceeded,
@@ -25,10 +25,10 @@ pub fn jsonEncode(lua: *Lua) callconv(.c) c_int {
         lua.pushString("JSON encode: argument required");
         lua.raiseError();
     }
-    var buf: Buf = .empty;
+    var buf: Buf = .init(alloc);
 
     encodeValue(lua, 1, &buf, 0) catch |err| {
-        buf.deinit(alloc);
+        buf.deinit();
         const msg: [*:0]const u8 = switch (err) {
             error.DepthLimitExceeded => "JSON encode: depth limit exceeded (circular reference?)",
             error.OutOfMemory => "JSON encode: out of memory",
@@ -39,8 +39,8 @@ pub fn jsonEncode(lua: *Lua) callconv(.c) c_int {
         lua.raiseError();
     };
 
-    lua.pushLString(buf.items);
-    buf.deinit(alloc);
+    lua.pushLString(buf.written());
+    buf.deinit();
     return 1;
 }
 
@@ -51,8 +51,8 @@ fn encodeValue(lua: *Lua, idx: i32, buf: *Buf, depth: u32) EncodeError!void {
     const abs = if (idx > 0) idx else lua.getTop() + idx + 1;
 
     switch (lua.getType(abs)) {
-        .nil, .none => buf.appendSlice(alloc, "null") catch return error.OutOfMemory,
-        .boolean => buf.appendSlice(alloc, if (lua.toBoolean(abs)) "true" else "false") catch return error.OutOfMemory,
+        .nil, .none => buf.writer.writeAll("null") catch return error.OutOfMemory,
+        .boolean => buf.writer.writeAll(if (lua.toBoolean(abs)) "true" else "false") catch return error.OutOfMemory,
         .string => {
             const str = lua.toLString(abs) catch return error.NotSerializable;
             try encodeString(str, buf);
@@ -68,38 +68,12 @@ fn encodeNumber(lua: *Lua, idx: i32, buf: *Buf) EncodeError!void {
     if (std.math.isNan(n) or std.math.isInf(n)) return error.InvalidNumber;
 
     var num_buf: [64]u8 = undefined;
-    const floored = @floor(n);
-    if (floored == n and n >= -9007199254740992.0 and n <= 9007199254740992.0) {
-        const formatted = std.fmt.bufPrint(&num_buf, "{d}", .{@as(i64, @intFromFloat(n))}) catch return error.OutOfMemory;
-        buf.appendSlice(alloc, formatted) catch return error.OutOfMemory;
-    } else {
-        const formatted = std.fmt.bufPrint(&num_buf, "{d}", .{n}) catch return error.OutOfMemory;
-        buf.appendSlice(alloc, formatted) catch return error.OutOfMemory;
-    }
+    const formatted = std.fmt.bufPrint(&num_buf, "{d}", .{n}) catch return error.OutOfMemory;
+    buf.writer.writeAll(formatted) catch return error.OutOfMemory;
 }
 
 fn encodeString(str: []const u8, buf: *Buf) EncodeError!void {
-    buf.append(alloc, '"') catch return error.OutOfMemory;
-    for (str) |c| {
-        switch (c) {
-            '"' => buf.appendSlice(alloc, "\\\"") catch return error.OutOfMemory,
-            '\\' => buf.appendSlice(alloc, "\\\\") catch return error.OutOfMemory,
-            '\n' => buf.appendSlice(alloc, "\\n") catch return error.OutOfMemory,
-            '\r' => buf.appendSlice(alloc, "\\r") catch return error.OutOfMemory,
-            '\t' => buf.appendSlice(alloc, "\\t") catch return error.OutOfMemory,
-            0x08 => buf.appendSlice(alloc, "\\b") catch return error.OutOfMemory,
-            0x0C => buf.appendSlice(alloc, "\\f") catch return error.OutOfMemory,
-            else => {
-                if (c < 0x20) {
-                    const hex = "0123456789abcdef";
-                    buf.appendSlice(alloc, &[6]u8{ '\\', 'u', '0', '0', hex[c >> 4], hex[c & 0x0f] }) catch return error.OutOfMemory;
-                } else {
-                    buf.append(alloc, c) catch return error.OutOfMemory;
-                }
-            },
-        }
-    }
-    buf.append(alloc, '"') catch return error.OutOfMemory;
+    std.json.Stringify.encodeJsonString(str, .{}, &buf.writer) catch return error.OutOfMemory;
 }
 
 fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void {
@@ -107,7 +81,7 @@ fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void 
     const first_type = lua.getTableIndexRaw(abs_idx, 1);
     if (first_type != .nil) {
         lua.pop(1);
-        buf.append(alloc, '[') catch return error.OutOfMemory;
+        buf.writer.writeByte('[') catch return error.OutOfMemory;
         var i: i32 = 1;
         while (true) {
             const t = lua.getTableIndexRaw(abs_idx, i);
@@ -115,12 +89,12 @@ fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void 
                 lua.pop(1);
                 break;
             }
-            if (i > 1) buf.append(alloc, ',') catch return error.OutOfMemory;
+            if (i > 1) buf.writer.writeByte(',') catch return error.OutOfMemory;
             try encodeValue(lua, -1, buf, depth + 1);
             lua.pop(1);
             i += 1;
         }
-        buf.append(alloc, ']') catch return error.OutOfMemory;
+        buf.writer.writeByte(']') catch return error.OutOfMemory;
         return;
     }
     lua.pop(1); // pop nil from table[1] check
@@ -128,17 +102,17 @@ fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void 
     // Object mode (or empty table)
     lua.pushNil();
     if (!lua.next(abs_idx)) {
-        buf.appendSlice(alloc, "{}") catch return error.OutOfMemory;
+        buf.writer.writeAll("{}") catch return error.OutOfMemory;
         return;
     }
 
-    buf.append(alloc, '{') catch return error.OutOfMemory;
+    buf.writer.writeByte('{') catch return error.OutOfMemory;
     var first = true;
     // First key-value pair already on stack from next() above
     while (true) {
         // key at -2, value at -1
         if (lua.isString(-2)) {
-            if (!first) buf.append(alloc, ',') catch return error.OutOfMemory;
+            if (!first) buf.writer.writeByte(',') catch return error.OutOfMemory;
             first = false;
 
             const key = lua.toLString(-2) catch {
@@ -146,13 +120,13 @@ fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void 
                 return error.NotSerializable;
             };
             try encodeString(key, buf);
-            buf.append(alloc, ':') catch return error.OutOfMemory;
+            buf.writer.writeByte(':') catch return error.OutOfMemory;
             try encodeValue(lua, -1, buf, depth + 1);
         }
         lua.pop(1); // pop value, keep key for next()
         if (!lua.next(abs_idx)) break;
     }
-    buf.append(alloc, '}') catch return error.OutOfMemory;
+    buf.writer.writeByte('}') catch return error.OutOfMemory;
 }
 
 // ── Decode ──────────────────────────────────────────────────────────

--- a/src/lua/json.zig
+++ b/src/lua/json.zig
@@ -66,10 +66,7 @@ fn encodeValue(lua: *Lua, idx: i32, buf: *Buf, depth: u32) EncodeError!void {
 fn encodeNumber(lua: *Lua, idx: i32, buf: *Buf) EncodeError!void {
     const n = lua.toNumber(idx);
     if (std.math.isNan(n) or std.math.isInf(n)) return error.InvalidNumber;
-
-    var num_buf: [64]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&num_buf, "{d}", .{n}) catch return error.OutOfMemory;
-    buf.writer.writeAll(formatted) catch return error.OutOfMemory;
+    buf.writer.print("{d}", .{n}) catch return error.OutOfMemory;
 }
 
 fn encodeString(str: []const u8, buf: *Buf) EncodeError!void {

--- a/src/tls/tls.zig
+++ b/src/tls/tls.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const log = @import("../observability/log.zig");
 const config = @import("../util/config.zig");
+const helpers = @import("../util/helpers.zig");
 const c = @cImport({
     @cInclude("openssl/ssl.h");
     @cInclude("openssl/err.h");
@@ -16,18 +17,6 @@ pub const TLS_RECORD_MAX_SIZE = config.TLS_RECORD_MAX_SIZE;
 
 // kTLS setsockopt constants
 const SOL_TLS: i32 = 282;
-
-/// Decode errno from a raw Linux syscall return value.
-/// Raw syscalls return -errno as usize on failure. std.posix.errno() doesn't
-/// reliably decode all values (e.g. small negative values can slip through),
-/// so we decode manually: negate the signed value to get the errno integer.
-fn syscallErrno(rc: usize) std.posix.E {
-    const signed: isize = @bitCast(rc);
-    if (signed < 0 and signed > -4096) {
-        return @enumFromInt(@as(u16, @intCast(-signed)));
-    }
-    return .SUCCESS;
-}
 
 /// Per-worker TLS context wrapping SSL_CTX.
 /// One per worker thread — shares config across all connections on that worker.
@@ -127,21 +116,10 @@ fn parseKeylogSecret(rest: []const u8, out: *[48]u8, len: *u8) void {
     // client_random is 32 bytes = 64 hex chars, then a space, then the secret
     if (rest.len < 65) return;
     const secret_hex = rest[65..];
-    const n = secret_hex.len / 2;
+    const n = secret_hex.len / 2; // ignore a trailing odd hex digit, as before
     if (n == 0 or n > 48) return;
-    for (0..n) |i| {
-        out[i] = (hexVal(secret_hex[i * 2]) orelse return) << 4 | (hexVal(secret_hex[i * 2 + 1]) orelse return);
-    }
+    _ = std.fmt.hexToBytes(out[0..n], secret_hex[0 .. n * 2]) catch return;
     len.* = @intCast(n);
-}
-
-fn hexVal(ch: u8) ?u8 {
-    return switch (ch) {
-        '0'...'9' => ch - '0',
-        'a'...'f' => ch - 'a' + 10,
-        'A'...'F' => ch - 'A' + 10,
-        else => null,
-    };
 }
 
 // ============================================================================
@@ -433,7 +411,7 @@ pub const TlsConn = struct {
         const ulp = [4]u8{ 't', 'l', 's', 0 };
         const rc = std.os.linux.setsockopt(fd, std.posix.IPPROTO.TCP, c.TCP_ULP, &ulp, ulp.len);
         if (rc != 0) {
-            const e = syscallErrno(rc);
+            const e = helpers.syscallErrno(rc);
             if (e == .NOENT) {
                 log.warn().string("msg", "ktls tls kernel module not loaded (ENOENT from TCP_ULP) — run 'modprobe tls'").log();
             } else {
@@ -548,7 +526,7 @@ pub const TlsConn = struct {
             @intCast(info_bytes.len),
         );
         if (rc != 0) {
-            const e = syscallErrno(rc);
+            const e = helpers.syscallErrno(rc);
             log.err().string("msg", "ktls setsockopt SOL_TLS failed").int("dir", direction).int("errno", @intFromEnum(e)).stringSafe("errname", @tagName(e)).int("fd", fd).log();
             return error.KtlsSetupFailed;
         }
@@ -643,17 +621,6 @@ pub const TlsConn = struct {
 // Tests
 // ============================================================================
 
-test "hexVal decodes hex characters" {
-    try std.testing.expectEqual(@as(?u8, 0), hexVal('0'));
-    try std.testing.expectEqual(@as(?u8, 9), hexVal('9'));
-    try std.testing.expectEqual(@as(?u8, 10), hexVal('a'));
-    try std.testing.expectEqual(@as(?u8, 15), hexVal('f'));
-    try std.testing.expectEqual(@as(?u8, 10), hexVal('A'));
-    try std.testing.expectEqual(@as(?u8, 15), hexVal('F'));
-    try std.testing.expectEqual(@as(?u8, null), hexVal('g'));
-    try std.testing.expectEqual(@as(?u8, null), hexVal(' '));
-}
-
 test "parseKeylogSecret parses valid TLS 1.3 keylog line" {
     // 64 hex chars (client_random) + space + 64 hex chars (32-byte secret)
     const client_random_hex = "a" ** 64;
@@ -673,6 +640,17 @@ test "parseKeylogSecret rejects short input" {
     var out: [48]u8 = .{0} ** 48;
     var len: u8 = 0;
     parseKeylogSecret("tooshort", &out, &len);
+    try std.testing.expectEqual(@as(u8, 0), len);
+}
+
+test "parseKeylogSecret rejects invalid hex characters" {
+    const client_random_hex = "a" ** 64;
+    const secret_hex = "zz" ++ "00" ** 31; // invalid first byte, 64 hex chars total
+    const rest = client_random_hex ++ " " ++ secret_hex;
+
+    var out: [48]u8 = .{0} ** 48;
+    var len: u8 = 0;
+    parseKeylogSecret(rest, &out, &len);
     try std.testing.expectEqual(@as(u8, 0), len);
 }
 

--- a/src/util/cli.zig
+++ b/src/util/cli.zig
@@ -35,19 +35,30 @@ const ParseError = error{
 pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseError || std.process.Args.Iterator.InitError)!Config {
     var config = Config{};
 
-    // Track which fields were set by CLI args (env vars only apply to unset fields)
-    var cli_host = false;
+    // host/script/tls-*/enable-bpf/watch never fail to parse from env, so
+    // applying them before CLI args (which unconditionally overwrite below)
+    // is a safe reorder: still CLI > env > default, zero presence tracking.
+    if (helpers.getenv("KEYWAY_HOST")) |val| config.host = val;
+    if (helpers.getenv("KEYWAY_SCRIPT")) |val| config.script = val;
+    if (helpers.getenv("KEYWAY_TLS_CERT")) |val| config.tls_cert_path = val;
+    if (helpers.getenv("KEYWAY_TLS_KEY")) |val| config.tls_key_path = val;
+    if (helpers.getenv("KEYWAY_ENABLE_BPF")) |val| {
+        config.enable_bpf = std.mem.eql(u8, val, "1") or std.mem.eql(u8, val, "true");
+    }
+    if (helpers.getenv("KEYWAY_WATCH")) |val| {
+        config.watch = std.mem.eql(u8, val, "1") or std.mem.eql(u8, val, "true");
+    }
+
+    // port/workers/log-level/log-format *can* fail to parse. Applying their
+    // env fallback up front like the fields above would make a malformed env
+    // value raise an error even when a valid CLI flag was about to override
+    // it — a precedence violation. Keep presence tracking for just these four
+    // so env is only consulted when CLI never supplies the field.
     var cli_port = false;
     var cli_workers = false;
-    var cli_script = false;
-    var cli_tls_cert = false;
-    var cli_tls_key = false;
     var cli_log_level = false;
     var cli_log_format = false;
-    var cli_enable_bpf = false;
-    var cli_watch = false;
 
-    // Parse CLI arguments
     var args = try args_ctx.iterateAllocator(allocator);
     defer args.deinit();
 
@@ -62,7 +73,6 @@ pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseErr
             return config;
         } else if (std.mem.eql(u8, arg, "--host")) {
             config.host = args.next() orelse return ParseError.MissingValue;
-            cli_host = true;
         } else if (std.mem.eql(u8, arg, "--port")) {
             const val = args.next() orelse return ParseError.MissingValue;
             config.port = std.fmt.parseInt(u16, val, 10) catch return ParseError.InvalidPort;
@@ -73,13 +83,10 @@ pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseErr
             cli_workers = true;
         } else if (std.mem.eql(u8, arg, "--script")) {
             config.script = args.next() orelse return ParseError.MissingValue;
-            cli_script = true;
         } else if (std.mem.eql(u8, arg, "--tls-cert")) {
             config.tls_cert_path = args.next() orelse return ParseError.MissingValue;
-            cli_tls_cert = true;
         } else if (std.mem.eql(u8, arg, "--tls-key")) {
             config.tls_key_path = args.next() orelse return ParseError.MissingValue;
-            cli_tls_key = true;
         } else if (std.mem.eql(u8, arg, "--log-level")) {
             const val = args.next() orelse return ParseError.MissingValue;
             config.log_level = parseLogLevel(val) orelse return ParseError.InvalidLogLevel;
@@ -90,19 +97,13 @@ pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseErr
             cli_log_format = true;
         } else if (std.mem.eql(u8, arg, "--enable-bpf")) {
             config.enable_bpf = true;
-            cli_enable_bpf = true;
         } else if (std.mem.eql(u8, arg, "--watch")) {
             config.watch = true;
-            cli_watch = true;
         } else {
             return ParseError.UnknownOption;
         }
     }
 
-    // Apply environment variable fallbacks for fields not set by CLI
-    if (!cli_host) {
-        if (helpers.getenv("KEYWAY_HOST")) |val| config.host = val;
-    }
     if (!cli_port) {
         if (helpers.getenv("KEYWAY_PORT")) |val| {
             config.port = std.fmt.parseInt(u16, val, 10) catch return ParseError.InvalidPort;
@@ -112,15 +113,6 @@ pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseErr
         if (helpers.getenv("KEYWAY_WORKERS")) |val| {
             config.workers = std.fmt.parseInt(u16, val, 10) catch return ParseError.InvalidWorkers;
         }
-    }
-    if (!cli_script) {
-        if (helpers.getenv("KEYWAY_SCRIPT")) |val| config.script = val;
-    }
-    if (!cli_tls_cert) {
-        if (helpers.getenv("KEYWAY_TLS_CERT")) |val| config.tls_cert_path = val;
-    }
-    if (!cli_tls_key) {
-        if (helpers.getenv("KEYWAY_TLS_KEY")) |val| config.tls_key_path = val;
     }
     if (!cli_log_level) {
         if (helpers.getenv("KEYWAY_LOG_LEVEL")) |val| {
@@ -132,32 +124,16 @@ pub fn parse(allocator: std.mem.Allocator, args_ctx: std.process.Args) (ParseErr
             config.log_format = parseLogFormat(val) orelse return ParseError.InvalidLogFormat;
         }
     }
-    if (!cli_enable_bpf) {
-        if (helpers.getenv("KEYWAY_ENABLE_BPF")) |val| {
-            config.enable_bpf = std.mem.eql(u8, val, "1") or std.mem.eql(u8, val, "true");
-        }
-    }
-    if (!cli_watch) {
-        if (helpers.getenv("KEYWAY_WATCH")) |val| {
-            config.watch = std.mem.eql(u8, val, "1") or std.mem.eql(u8, val, "true");
-        }
-    }
 
     return config;
 }
 
 fn parseLogFormat(val: []const u8) ?Config.LogFormat {
-    if (std.mem.eql(u8, val, "logfmt")) return .logfmt;
-    if (std.mem.eql(u8, val, "json")) return .json;
-    return null;
+    return std.meta.stringToEnum(Config.LogFormat, val);
 }
 
 fn parseLogLevel(val: []const u8) ?std.log.Level {
-    if (std.mem.eql(u8, val, "err")) return .err;
-    if (std.mem.eql(u8, val, "warn")) return .warn;
-    if (std.mem.eql(u8, val, "info")) return .info;
-    if (std.mem.eql(u8, val, "debug")) return .debug;
-    return null;
+    return std.meta.stringToEnum(std.log.Level, val);
 }
 
 /// Write formatted output to stderr, propagating write errors instead of

--- a/src/util/helpers.zig
+++ b/src/util/helpers.zig
@@ -28,10 +28,14 @@ pub fn monotonicNanos() i64 {
 
 // -- Raw syscall wrappers ---------------------------------------------------
 // Zig 0.16 removed most `std.posix.*` syscall wrappers. These reimplement the
-// few keyway needs via raw `std.os.linux` / libc calls. Errno decode mirrors
-// the manual decoder in src/tls/tls.zig (raw syscalls return -errno as usize).
+// few keyway needs via raw `std.os.linux` / libc calls.
 
-fn syscallErrno(rc: usize) std.posix.E {
+/// Decode errno from a raw Linux syscall return value.
+/// Raw syscalls return -errno as usize on failure. std.posix.errno() doesn't
+/// reliably decode all values (e.g. small negative values can slip through),
+/// so we decode manually: negate the signed value to get the errno integer.
+/// Also used directly by src/tls/tls.zig for its raw setsockopt/getsockopt calls.
+pub fn syscallErrno(rc: usize) std.posix.E {
     const signed: isize = @bitCast(rc);
     if (signed < 0 and signed > -4096) return @enumFromInt(@as(u16, @intCast(-signed)));
     return .SUCCESS;


### PR DESCRIPTION
Closes #137

Mechanical stdlib substitution across src/, per the 2026-07-02 over-engineering audit. No behavior changes intended (see adaptation note on cli.zig below).

## Changes
- `src/lua/json.zig`: `encodeString` now calls `std.json.Stringify.encodeJsonString`; `Buf` switched from `ArrayListUnmanaged(u8)` to `std.Io.Writer.Allocating` (touches every append site in the file since the type is shared). `encodeNumber` drops the manual 2^53 integer fast-path — Zig 0.16's `{d}` on f64 already prints `42.0` as `42`.
- `src/util/cli.zig`: `parseLogLevel`/`parseLogFormat` now delegate to `std.meta.stringToEnum`.
- `src/tls/tls.zig`: `parseKeylogSecret` decodes hex via `std.fmt.hexToBytes` instead of a hand-rolled `hexVal` loop; `hexVal` and its unit test are deleted (replaced with one test on `parseKeylogSecret` covering invalid hex chars, since that was the only remaining coverage for that path). `syscallErrno` was byte-identical to `helpers.syscallErrno` — made the helpers one `pub` and imported it, deleted the tls.zig copy.
- `src/http/http.zig`: `encodeChunk` is now a single `std.fmt.allocPrint` call.
- `src/http/proxy.zig`: `buildUpstreamRequest` returns `aw.toOwnedSlice()` directly instead of round-tripping through `toArrayList()`.

## Adapted from the issue text
`cli.zig`'s env/CLI merge is the one behavior-sensitive bullet (precedence must stay exactly CLI > env > default). The issue's literal "apply env vars first, let CLI overwrite, zero flags" breaks precedence for the 4 fields with fallible parsing (port, workers, log-level, log-format): if env holds a malformed value but CLI supplies a valid override, applying env unconditionally up front raises a parse error *before* CLI gets a chance to override it — turning a previously-successful invocation into a hard failure.

Fix: the 6 fields that can never fail to parse from env (host, script, tls-cert, tls-key, enable-bpf, watch) use the straight env-first-then-CLI-overwrites reorder with zero presence tracking. The 4 fallible fields (port, workers, log-level, log-format) keep minimal presence tracking (4 booleans instead of the original 10) so env is only consulted — and only errors — when CLI never supplies that field. Net: still removes 60% of the bookkeeping and all ten guarded-fallback blocks collapse to four, while precedence and error behavior are unchanged bit-for-bit.

## Verification
- `zig build` — clean
- `zig build test` — all green (existing json/cli/tls unit tests unmodified except the one hexVal→parseKeylogSecret test swap noted above)
- Did not run the bun integration suite per instructions (Mayor runs it at merge).