### PR TITLE
refactor(core): drop redundant Connection.init params

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -157,15 +157,8 @@ pub const Connection = struct {
     // Sub-struct: inbound TLS (set once at connection init, persists across keep-alive)
     tls_state: TlsState = .{},
 
-    pub fn init(
-        allocator: std.mem.Allocator,
-        loop: *xev.Loop,
-        socket: std.posix.socket_t,
-        router: *Router,
-        lua_state: *LuaState,
-        sse_registry: ?*SseRegistry,
-        server: *Server,
-    ) !*Connection {
+    pub fn init(server: *Server, socket: std.posix.socket_t) !*Connection {
+        const allocator = server.allocator;
         const conn = try allocator.create(Connection);
         errdefer allocator.destroy(conn);
 
@@ -181,16 +174,16 @@ pub const Connection = struct {
         conn.* = Connection{
             .base_allocator = allocator,
             .arena = arena,
-            .loop = loop,
+            .loop = server.loop,
             .socket = socket,
-            .router = router,
-            .lua_state = lua_state,
+            .router = server.router,
+            .lua_state = server.lua_state,
             .read_completion = .{},
             .write_completion = .{},
             .read_buffer = read_buf,
             .param_cache = ParamArray{},
             .query_cache = QueryArray{},
-            .sse_registry = sse_registry,
+            .sse_registry = server.sse_registry,
             .server = server,
         };
 

--- a/src/core/server.zig
+++ b/src/core/server.zig
@@ -177,6 +177,7 @@ pub const Server = struct {
         result: xev.Result,
     ) xev.CallbackAction {
         _ = completion;
+        _ = loop;
 
         const self = castUserdata(Server, userdata);
 
@@ -217,15 +218,7 @@ pub const Server = struct {
         prom.connectionAccepted();
 
         // Create connection handler
-        const conn = Connection.init(
-            self.allocator,
-            loop,
-            client_socket,
-            self.router,
-            self.lua_state,
-            self.sse_registry,
-            self,
-        ) catch |err| {
+        const conn = Connection.init(self, client_socket) catch |err| {
             log.err().string("msg", "connection init failed").err(err).log();
             helpers.closeFd(client_socket);
             self.acceptNext();


### PR DESCRIPTION
Closes #48

`Connection.init` took 7 params, five of which (`allocator`, `loop`, `router`, `lua_state`, `sse_registry`) are already fields on the `server` param that's also passed. Signature becomes `init(server, socket)`; the rest are read off `server`. Net deletion, not a params struct.

Single call site (`server.zig`) updated to `Connection.init(self, client_socket)`. `onAccept`'s now-unused `loop` callback param gets a `_ = loop;` discard (xev's fixed callback signature); it's the same per-core `*xev.Loop` as `server.loop`, so reading it off `server` is behavior-identical.