### PR TITLE
fix(proxy): cap upstream response at MAX_BODY_SIZE

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -335,6 +335,13 @@ fn onProxyUpstreamRecv(
         proxyFail(self, 502, "proxy response buffer failed");
         return .disarm;
     };
+    // Cap accumulated upstream response (#129): an adversarial/huge upstream
+    // otherwise grows this buffer unbounded on base_allocator. Reuses
+    // MAX_BODY_SIZE (the request-body cap) rather than adding a new constant.
+    if (ps.response.items.len > config.MAX_BODY_SIZE) {
+        proxyFail(self, 502, "proxy upstream response too large");
+        return .disarm;
+    }
     submitUpstreamRecv(self);
     return .disarm;
 }


### PR DESCRIPTION
Closes #129

`ProxyState.response` accumulated the full upstream response on `base_allocator` with no cap — an adversarial or huge upstream could OOM a worker. Now each recv chunk checks `ps.response.items.len > config.MAX_BODY_SIZE` (the existing 1 MB request-body limit, reused — no new constant); on overflow the recv loop stops and calls the existing `proxyFail(self, 502, ...)`, which runs the same `cleanupProxy` (closes upstream fd, frees buffers) + 502 teardown every other proxy-failure path uses.

**Accepted tradeoff:** proxied responses larger than `MAX_BODY_SIZE` now 502. The issue explicitly defers true streaming relay (the bigger fix) — this closes the memory-safety hole first. If large proxied bodies become a real need, a separate `PROXY_MAX_RESPONSE` constant or streaming relay is the follow-up.