### PR TITLE
fix(static): close on mid-transfer truncation instead of keep-alive

### DIFF
--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -383,13 +383,13 @@ fn onStaticPreadComplete(
         return .disarm;
     }
 
-    const bytes_read = result.pread catch |err| {
-        if (err == error.EOF) {
-            // File truncated under us — stop, send what was already delivered.
-            finishStaticFile(self);
-        } else {
-            self.close();
-        }
+    const bytes_read = result.pread catch {
+        // pread failed, or hit EOF before file_size (file shrank mid-transfer):
+        // either way fewer bytes than the promised Content-Length were sent, so
+        // the client's framing is desynced and unrecoverable — close instead of
+        // returning to keep-alive. (A pread is only submitted while
+        // bytes_sent < file_size, so EOF here always means a short body.)
+        self.close();
         return .disarm;
     };
 


### PR DESCRIPTION
Closes #131

If a file shrinks while being served, a 0-byte `pread` surfaces as `error.EOF` and the old code returned the connection to keep-alive after sending fewer bytes than the promised `Content-Length` — desyncing the client's HTTP framing. Now the connection closes on `pread` failure/EOF.

Since a `pread` is only ever submitted while `bytes_sent < file_size` (and empty files are handled before any read), reaching EOF here always means a short body — so the EOF and real-error cases collapse to the same `self.close()`, no dead branch. Normal (full-length) transfers are unaffected: completion goes through `sendNextChunk`'s `bytes_sent >= file_size` guard → `finishStaticFile`, never this pread path.