### PR TITLE
fix(server): shut upstream fd in forceCloseAll pass 2

### DIFF
--- a/src/core/server.zig
+++ b/src/core/server.zig
@@ -328,6 +328,13 @@ pub const Server = struct {
             it = node.next;
             const conn: *Connection = @alignCast(@fieldParentPtr("link", node));
             helpers.shutdownBoth(conn.socket);
+            // A proxied request's in-flight op is armed on the upstream fd, not
+            // the client socket above — shutting down only the client fd never
+            // completes it, leaving pending_io_ops > 0 forever. proxy_state is
+            // only ever set once its xev.TCP owns a live socket (see
+            // proxy.zig's serveProxy), so its presence alone is the "valid fd"
+            // guard here.
+            if (conn.proxy_state) |ps| helpers.shutdownBoth(ps.tcp.fd);
         }
     }
 


### PR DESCRIPTION
Closes #130

`forceCloseAll` pass 2 called `shutdownBoth(conn.socket)` on the client socket to unblock pending xev ops — but a proxied request's in-flight op (connect/send/recv) is armed on the **upstream** fd (`ProxyState.tcp.fd`), which the client shutdown never completes. A hung upstream then keeps `loop.active > 0` and delays that worker's exit.

Pass 2 now also `shutdownBoth(ps.tcp.fd)` when `conn.proxy_state != null`. That null-check is itself the valid-fd guard: `cleanupProxy` closes the upstream fd and nulls `proxy_state` together (proxy.zig:402), and the only other close path is full `Connection.deinit`, so a live `proxy_state` always carries a live fd — no stale/recycled-fd hazard. Reuses the existing `helpers.shutdownBoth`; pass 1 untouched.

(Note: `forceCloseAll` lives in `server.zig`, not `shutdown.zig` as the issue stated.)