### PR TITLE
feat(metrics): per-worker keyway_script_generation gauge

### DIFF
--- a/src/core/worker.zig
+++ b/src/core/worker.zig
@@ -383,7 +383,9 @@ fn onReloadSignal(
     }
 
     log.info().string("msg", "performing hot reload").log();
-    ctx.lua_state.reload(ctx.router, ctx.script_path);
+    if (ctx.lua_state.reload(ctx.router, ctx.script_path)) {
+        prom.scriptReloadSucceeded();
+    }
 
     return .rearm;
 }

--- a/src/io/file_watcher.zig
+++ b/src/io/file_watcher.zig
@@ -13,6 +13,7 @@ const xev = @import("xev");
 const log = @import("../observability/log.zig");
 const LuaState = @import("../lua/lua_state.zig").LuaState;
 const Router = @import("../http/router.zig").Router;
+const prom = @import("../observability/prom.zig");
 
 const DEBOUNCE_MS = 200;
 
@@ -196,7 +197,9 @@ pub const FileWatcher = struct {
         if (self.draining) return .disarm;
 
         log.info().string("msg", "file change detected — reloading").log();
-        self.lua_state.reload(self.router, self.script_path);
+        if (self.lua_state.reload(self.router, self.script_path)) {
+            prom.scriptReloadSucceeded();
+        }
 
         return .disarm;
     }

--- a/src/lua/lua_state.zig
+++ b/src/lua/lua_state.zig
@@ -423,7 +423,10 @@ pub const LuaState = struct {
 
     /// Hot-reload: unref old routes, reset router, clear package.loaded, re-execute script.
     /// On script error: logs the error and leaves the router empty (all requests 404).
-    pub fn reload(self: *LuaState, router: *Router, script_path: []const u8) void {
+    /// Returns true on success, false on failure — callers use this to gate the
+    /// script-generation counter (see prom.scriptReloadSucceeded), since a
+    /// fire-and-forget reload otherwise leaves failures invisible (#117).
+    pub fn reload(self: *LuaState, router: *Router, script_path: []const u8) bool {
         // 1. Collect old lua_refs from router and unref each
         var refs: std.ArrayListUnmanaged(i32) = .empty;
         defer refs.deinit(self.allocator);
@@ -435,7 +438,7 @@ pub const LuaState = struct {
         // 2. Reset router (free trie + static routes)
         router.reset() catch |err| {
             log.err().string("msg", "reload: router reset failed").err(err).log();
-            return;
+            return false;
         };
 
         // 3. Clear package.loaded for non-stdlib modules
@@ -459,24 +462,25 @@ pub const LuaState = struct {
         // 4. Re-execute the entry point script
         self.loadScript(script_path) catch |err| {
             log.err().string("msg", "reload: script load failed").string("path", script_path).err(err).log();
-            return;
+            return false;
         };
 
         // 5. Rebuild route table from fresh keyway.routes
         self.processRouteTable(router) catch |err| {
             log.err().string("msg", "reload: processRouteTable failed").err(err).log();
-            return;
+            return false;
         };
         self.processStaticTable(router) catch |err| {
             log.err().string("msg", "reload: processStaticTable failed").err(err).log();
-            return;
+            return false;
         };
         self.processProxyTable(router) catch |err| {
             log.err().string("msg", "reload: processProxyTable failed").err(err).log();
-            return;
+            return false;
         };
 
         log.info().string("msg", "reload complete").string("script", script_path).log();
+        return true;
     }
 
     /// Clean up Lua state

--- a/src/observability/prom.zig
+++ b/src/observability/prom.zig
@@ -37,6 +37,12 @@ pub const Metrics = struct {
     lua_coroutines_active: ConnectionGauge,
     lua_script_duration_seconds: LuaScriptDuration,
 
+    // -- Hot reload --
+    // Per-worker generation counter, incremented only on a successful reload
+    // (#117). A client polls this before/after POST /__keyway/reload: no
+    // advance means that worker's reload failed; workers disagreeing means skew.
+    script_generation: ConnectionGauge,
+
     // Bucket bounds (must live inside the struct so HistogramVec comptime refs resolve)
     const latency_buckets = [_]f64{ 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 5.0, 10.0 };
     const body_size_buckets = [_]u64{ 64, 256, 1_024, 4_096, 16_384, 65_536, 262_144, 1_048_576, 4_194_304 };
@@ -86,6 +92,9 @@ pub fn init(allocator: Allocator) !void {
         .lua_script_duration_seconds = try Metrics.LuaScriptDuration.init(allocator, io, "keyway_lua_script_duration_seconds", .{
             .help = "Lua script execution time in seconds",
         }, .{}),
+        .script_generation = try Metrics.ConnectionGauge.init(allocator, io, "keyway_script_generation", .{
+            .help = "Per-worker Lua script generation, incremented on each successful hot reload",
+        }, .{}),
     };
 }
 
@@ -97,6 +106,7 @@ pub fn deinit() void {
     global.connections_rejected_total.deinit();
     global.lua_coroutines_active.deinit();
     global.lua_script_duration_seconds.deinit();
+    global.script_generation.deinit();
     metrics_io.deinit();
 }
 
@@ -160,6 +170,11 @@ pub fn luaCoroutineFinished() void {
 pub fn luaScriptDuration(route: []const u8, duration_us: i64) void {
     const duration_seconds: f64 = @as(f64, @floatFromInt(duration_us)) / 1_000_000.0;
     global.lua_script_duration_seconds.observe(.{ .worker_id = worker_id, .route = route }, duration_seconds) catch {};
+}
+
+/// Hot reload succeeded — advance this worker's script generation (#117).
+pub fn scriptReloadSucceeded() void {
+    global.script_generation.incr(wlabels()) catch {};
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #117

Hot reload was fire-and-forget: `POST /__keyway/reload` returned success unconditionally, and a per-worker reload failure (syntax error in the edited script) was logged to stdout only — the dashboard showed "Reload triggered" while workers kept running old code, and partial failures left workers on different script versions with nothing surfacing it.

`LuaState.reload` now returns `bool` (false on all five failure paths, true after "reload complete"). Both callers of the shared `reload()` — `onReloadSignal` (the `POST /reload` path) and `file_watcher.onDebounceTimer` (the `--watch` path) — bump a new per-worker gauge `keyway_script_generation{worker_id}` **only on success**. A client polls it around a reload: no advance ⇒ that worker's reload failed; workers disagreeing ⇒ skew.

Reuses the existing `GaugeVec`/`ConnectionGauge` machinery — no new metric type. Series is absent until the first success (treated as 0), then 1. Deliberately just the gauge; the synchronous reload-result API the issue mentions stays deferred.