### PR TITLE
docs(dashboard): note control-plane paths are cwd-relative

### DIFF
--- a/dashboard/keyway.lua
+++ b/dashboard/keyway.lua
@@ -1,5 +1,8 @@
 -- keyway.lua — Admin dashboard + file management control plane
 -- Lua files on disk control the runtime. The dashboard is a file editor.
+-- Run from the repo root (as `zig build run` does): this example's static
+-- and file-API paths are resolved relative to the current working directory,
+-- not to this script's location.
 
 local response = require("keyway.response")
 local json = require("keyway.json")


### PR DESCRIPTION
Closes #116

#116 reported that launching from `dashboard/` 404s the dashboard's static assets and lists the wrong file tree, because `dashboard/keyway.lua` uses cwd-relative paths (`dashboard/public`, `dashboard/...`).

Resolving as **docs / by-design**, not an engine change. Script-internal paths resolving relative to cwd is intentional and conventional (nginx uses a configured prefix, not script-relative). The dashboard is an *example* control plane meant to run from the repo root — which `zig build run` does (post-#115). Exposing a `keyway.script_dir` global to make one example relocatable would be speculative v1 API surface; if a real deployment needs launch-dir-independent configs later, that's a deliberate feature, not a patch.

This adds a 3-line header comment to the example stating the launch contract — where a confused user actually looks.