### PR TITLE
test(integration): dashboard data-source contract tests

### DIFF
--- a/tests/integration/dashboard-ws.test.ts
+++ b/tests/integration/dashboard-ws.test.ts
@@ -1,0 +1,53 @@
+// /__keyway/ws command round-trips — the dashboard's console/live-reload UI
+// drives this socket. Only commands that actually exist in ws_commands
+// (dashboard/keyway.lua) are covered: ping and lua.
+
+import { describe, test, expect } from "bun:test";
+
+const port = () => globalThis.__KEYWAY_PORT;
+
+function sendAndReceive(payload: object): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port()}/__keyway/ws`);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("dashboard ws command timed out"));
+    }, 5000);
+
+    ws.onopen = () => ws.send(JSON.stringify(payload));
+    ws.onmessage = (e) => {
+      clearTimeout(timeout);
+      ws.close();
+      resolve(JSON.parse(String(e.data)));
+    };
+    ws.onerror = (e) => {
+      clearTimeout(timeout);
+      reject(new Error(`WebSocket error: ${e}`));
+    };
+  });
+}
+
+describe("dashboard ws commands", () => {
+  test("cmd:ping replies with pong + worker_id", async () => {
+    const msg = await sendAndReceive({ cmd: "ping" });
+    expect(msg.cmd).toBe("pong");
+    expect(typeof msg.worker_id).toBe("number");
+  });
+
+  test("cmd:lua evaluates code and returns the result", async () => {
+    const msg = await sendAndReceive({ cmd: "lua", code: "1+1" });
+    expect(msg.cmd).toBe("lua");
+    expect(msg.result).toBe("2");
+  });
+
+  test("cmd:lua surfaces a compile error instead of hanging", async () => {
+    const msg = await sendAndReceive({ cmd: "lua", code: "this is not lua(" });
+    expect(msg.cmd).toBe("lua");
+    expect(typeof msg.error).toBe("string");
+  });
+
+  test("unknown command returns an error, not a hang", async () => {
+    const msg = await sendAndReceive({ cmd: "does-not-exist" });
+    expect(typeof msg.error).toBe("string");
+  });
+});

--- a/tests/integration/files.test.ts
+++ b/tests/integration/files.test.ts
@@ -1,0 +1,66 @@
+// File API CRUD round-trip (#118) — write / read / list / delete over the
+// dashboard's file endpoints (see dashboard/keyway.lua, __keyway_file_*).
+//
+// Operates on a THROWAWAY probe file (dashboard/kw118-probe.lua) that is not
+// tracked in git, so a mid-run SIGKILL leaves at worst an untracked `??`
+// file — never a modified tracked source. No entrypoint mutation, no reload:
+// reload only re-runs the --script entrypoint, so "new file -> reload ->
+// route live" isn't a real contract; this tests the file API itself.
+
+import { describe, test, expect, afterAll } from "bun:test";
+
+const base = () => globalThis.__KEYWAY_BASE;
+
+const PROBE = "kw118-probe.lua"; // /__keyway/api/files/{path} prefixes with "dashboard/"
+const CONTENT = "-- kw118 file API probe\nreturn 118\n"; // valid Lua (.lua writes are loadstring-validated)
+
+const filesUrl = () => `${base()}/__keyway/api/files`;
+const fileUrl = () => `${filesUrl()}/${PROBE}`;
+
+async function deleteProbe() {
+  return fetch(fileUrl(), { method: "DELETE" });
+}
+
+async function listProbePaths(): Promise<string[]> {
+  const res = await fetch(filesUrl());
+  const { files } = await res.json();
+  return files.map((f: { path: string }) => f.path);
+}
+
+// Idempotent teardown: worst case leaves nothing tracked-modified.
+afterAll(async () => {
+  await deleteProbe();
+});
+
+describe("file API CRUD round-trip", () => {
+  test("write -> read -> list -> delete a throwaway file", async () => {
+    // Idempotent start: clear any leftover probe from a killed prior run.
+    await deleteProbe();
+
+    try {
+      // -- write --
+      const put = await fetch(fileUrl(), {
+        method: "PUT",
+        body: JSON.stringify({ content: CONTENT }),
+      });
+      expect(put.status).toBe(200);
+      expect((await put.json()).ok).toBe(true);
+
+      // -- read back: content matches what we wrote --
+      const read = await fetch(fileUrl());
+      expect(read.status).toBe(200);
+      expect((await read.json()).content).toBe(CONTENT);
+
+      // -- list: probe appears in the tree --
+      expect(await listProbePaths()).toContain(PROBE);
+    } finally {
+      // -- delete --
+      const del = await deleteProbe();
+      expect(del.status).toBe(200);
+    }
+
+    // -- gone: read 404s and it's absent from the listing --
+    expect((await fetch(fileUrl())).status).toBe(404);
+    expect(await listProbePaths()).not.toContain(PROBE);
+  });
+});

--- a/tests/integration/metrics.test.ts
+++ b/tests/integration/metrics.test.ts
@@ -1,0 +1,55 @@
+// /metrics label contract — the dashboard's metrics panel parses these
+// families/labels out of the Prometheus exposition text (#118). This test
+// pins the CURRENT actual label set so a format change breaks CI instead of
+// silently breaking the dashboard.
+//
+// Note: #119 may later refine what the `route` label carries (it's currently
+// the matched route *pattern*, e.g. "/test/hello", or "" when no route
+// matched). Update this test if that changes.
+
+import { describe, test, expect } from "bun:test";
+
+const base = () => globalThis.__KEYWAY_BASE;
+
+describe("metrics", () => {
+  test("GET /metrics exposes the families and labels the dashboard consumes", async () => {
+    // Generate some traffic first so the counters/histograms have series.
+    await fetch(`${base()}/test/hello`);
+    await fetch(`${base()}/test/json`);
+
+    const res = await fetch(`${base()}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+
+    const body = await res.text();
+
+    // -- keyway_http_requests_total: worker_id, method, status, route --
+    expect(body).toContain("# TYPE keyway_http_requests_total counter");
+    expect(body).toMatch(
+      /keyway_http_requests_total\{worker_id="0",method="GET",status="200",route="\/test\/hello"\} \d+/,
+    );
+    expect(body).toMatch(
+      /keyway_http_requests_total\{worker_id="0",method="GET",status="200",route="\/test\/json"\} \d+/,
+    );
+
+    // -- request-duration histogram: worker_id, route, standard buckets --
+    expect(body).toContain(
+      "# TYPE keyway_http_request_duration_seconds histogram",
+    );
+    expect(body).toMatch(
+      /keyway_http_request_duration_seconds_bucket\{le="\+Inf",worker_id="0",route="\/test\/hello"\} \d+/,
+    );
+    expect(body).toMatch(
+      /keyway_http_request_duration_seconds_count\{worker_id="0",route="\/test\/hello"\} \d+/,
+    );
+
+    // -- gauges: connections_active and script_generation (#117) --
+    expect(body).toContain("# TYPE keyway_connections_active gauge");
+    expect(body).toMatch(/keyway_connections_active\{worker_id="0"\} \d+/);
+
+    expect(body).toContain("# TYPE keyway_script_generation gauge");
+    expect(body).toContain(
+      "# HELP keyway_script_generation Per-worker Lua script generation, incremented on each successful hot reload",
+    );
+  });
+});


### PR DESCRIPTION
Closes #118

The dashboard is keyway's integration test client, but its own data sources had no contract tests — a dead SSE pipeline shipped unnoticed. Adds tests against a running server (via the existing `preload.ts` harness):

- **`metrics.test.ts`** — pins the `/metrics` families + labels the UI parses: `keyway_http_requests_total{worker_id,method,status,route}`, the request-duration histogram, and the `keyway_connections_active` + `keyway_script_generation` gauges. A format change now breaks CI instead of silently breaking the dashboard. (Comment flags that #119 may later refine the `route`/`method` labels and update this test.)
- **`dashboard-ws.test.ts`** — `/__keyway/ws` command round-trips: `ping` (→ pong + worker_id), `lua` eval, plus compile-error and unknown-command paths. Only the commands that actually exist (`ping`, `lua`) are tested.
- **`files.test.ts`** — file API write→read→list→delete CRUD on a throwaway untracked file (`dashboard/kw118-probe.lua`), idempotent and self-cleaning.

SSE broadcast round-trip is already covered by `sse.test.ts`, so it's not duplicated. The dead `keyway:access` room is intentionally not tested (being removed in the redesign). 6 new tests; full suite stays green.