### PR TITLE
fix(http): send real 403 on static traversal/symlink-escape rejections

### DIFF
--- a/src/http/error_response.zig
+++ b/src/http/error_response.zig
@@ -45,17 +45,24 @@ fn comptimeErrorResponse(comptime status: u16, comptime reason: []const u8, comp
         "\r\n" ++ body;
 }
 
-/// Pre-serialized error responses for each category's default status.
-const response_400 = comptimeErrorResponse(400, "Bad Request", "Bad Request");
-const response_500 = comptimeErrorResponse(500, "Internal Server Error", "Internal Server Error");
-const response_502 = comptimeErrorResponse(502, "Bad Gateway", "Bad Gateway");
-const response_504 = comptimeErrorResponse(504, "Gateway Timeout", "Gateway Timeout");
+/// Pre-serialized error responses. Reason phrase (and body) come from
+/// std.http.Status, so the numeric code and phrase can't desync — registering
+/// a status is one line and there's no hand-typed table (a missing row is
+/// exactly what caused #161).
+fn cannedResponse(comptime s: std.http.Status) []const u8 {
+    return comptimeErrorResponse(@intFromEnum(s), s.phrase().?, s.phrase().?);
+}
 
-/// Pre-serialized 413 response for oversized request bodies.
+const response_400 = cannedResponse(.bad_request);
+const response_403 = cannedResponse(.forbidden);
+const response_404 = cannedResponse(.not_found);
+const response_500 = cannedResponse(.internal_server_error);
+const response_502 = cannedResponse(.bad_gateway);
+const response_504 = cannedResponse(.gateway_timeout);
+
+// 413: std's phrase is the older "Payload Too Large"; keep the RFC 9110 name
+// "Content Too Large" deliberately, so this one stays explicit.
 const response_413 = comptimeErrorResponse(413, "Content Too Large", "Content Too Large");
-
-/// Pre-serialized 404 response for route misses.
-const response_404 = comptimeErrorResponse(404, "Not Found", "Not Found");
 
 /// Get pre-serialized response bytes for a specific status code.
 /// Returns null if no pre-serialized response exists for that status.
@@ -64,6 +71,7 @@ const response_404 = comptimeErrorResponse(404, "Not Found", "Not Found");
 fn statusResponse(status: u16) ?[]const u8 {
     return switch (status) {
         400 => response_400,
+        403 => response_403,
         404 => response_404,
         413 => response_413,
         500 => response_500,
@@ -131,7 +139,7 @@ test "ErrorCategory.logLevel maps correctly" {
 }
 
 test "pre-serialized responses are valid HTTP" {
-    const responses = [_][]const u8{ response_400, response_404, response_413, response_500, response_502, response_504 };
+    const responses = [_][]const u8{ response_400, response_403, response_404, response_413, response_500, response_502, response_504 };
     for (responses) |resp| {
         try std.testing.expect(std.mem.startsWith(u8, resp, "HTTP/1.1"));
         try std.testing.expect(std.mem.indexOf(u8, resp, "Content-Length:") != null);

--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -125,16 +125,12 @@ describe("static file serving", () => {
   });
 
   // resolveStaticPath (src/http/static.zig) rejects a resolved path that
-  // escapes route.root and logs status 403 ("path traversal blocked") via
-  // error_response.sendErrorStatus. But error_response.zig's statusResponse()
-  // switch has no 403 entry, so sendErrorStatus falls through to the
-  // client_error category default and the client actually receives 400 Bad
-  // Request over the wire — pinning that REAL observed status, not the 403
-  // the access log claims. Tracked in #161; when that lands, this assertion
-  // and the symlink-escape one below flip to 403.
+  // escapes route.root, returning 403 via error_response.sendErrorStatus
+  // (the 403 arm was added in #161). fetch() collapses ".." client-side, so
+  // this uses the raw-socket helper to get a literal ".." onto the wire.
   test("blocks a literal path traversal out of the mount root (403)", async () => {
     const status = await rawGetStatus("/__keyway/dashboard/../keyway.lua");
-    expect(status).toBe(400);
+    expect(status).toBe(403);
   });
 
   // Percent-encoded dot segments are never decoded before static path
@@ -149,12 +145,11 @@ describe("static file serving", () => {
 
   // dashboard/public/test-symlink-escape -> ../../README.md, resolving
   // outside dashboard/public. No dot segments in the request path, so plain
-  // fetch() is fine here (unlike the traversal cases above). Same
-  // statusResponse() gap: logged as 403 "symlink traversal blocked", wire
-  // status is 400 — see the note above.
+  // fetch() is fine here (unlike the traversal cases above). Rejected with
+  // 403 "symlink traversal blocked" (the 403 arm was added in #161).
   test("blocks a symlink that escapes the mount root (403)", async () => {
     const res = await fetch(`${base()}/__keyway/dashboard/test-symlink-escape`);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(403);
   });
 
   // dashboard/public/test-symlink-alias.css -> main.js, both inside


### PR DESCRIPTION
Closes #161

`statusResponse()` had no `403` arm, so `sendErrorStatus(403, …)` logged 403 but fell back to the `client_error` default and put **400** on the wire — the access log lied about the status of security-relevant static rejections (path traversal, symlink escape).

Adds the 403 case, and — per the discussion that surfaced this — stops hand-maintaining the status→phrase table: the canned responses now derive their reason phrase from `std.http.Status` (single source of truth for code + phrase), which is exactly the kind of missing-row bug that caused #161. `413` stays explicit to keep the RFC 9110 name "Content Too Large" (std still uses the older "Payload Too Large"). The full pre-serialized response bytes stay hand-rolled — nothing in std produces them, and a zero-copy proactor engine can't use `std.http.Server` (it does its own I/O).

Flips #132's traversal + symlink-escape assertions from 400 → 403; CI's integration suite verifies the wire status end-to-end.