### PR TITLE
build(tls): migrate OpenSSL @cImport to build.zig addTranslateC

### DIFF
--- a/.claude/rules/zig-gotchas.md
+++ b/.claude/rules/zig-gotchas.md
@@ -13,6 +13,6 @@ Read this before editing any `.zig` file. (Zig version + deps live in `build.zig
 - **Async-yield coroutine hack (WS/SSE/stream) — keep it.** zig-luajit marks `resumeCoroutine`/`yieldCoroutine` private. We declare `extern "c" fn lua_yield` and export `lua_resume` (both in `src/lua/lua_state.zig`), calling them via `@ptrCast(lua)` because `*Lua` maps 1:1 to `lua_State*`. Don't route this through the wrapper API.
 - **GCC 15 linker workaround — don't remove.** `link_gc_sections = true` in `build.zig`: GCC 15's `crt1.o` has `.sframe` sections with `R_X86_64_PC64` relocations that Zig's bundled lld can't handle; `--gc-sections` discards the unreferenced ones.
 - **`rdynamic` on the exe** (`build.zig`) exports symbols so Lua `.so` modules (LuaRocks) resolve at runtime. Don't drop it.
-- **OpenSSL is a system lib** — `linkSystemLibrary("ssl")` / `("crypto")` + inline `@cImport` in `src/tls/tls.zig`.
+- **OpenSSL is a system lib** — `linkSystemLibrary("ssl")` / `("crypto")` + `b.addTranslateC` on `src/tls/openssl.h` in `build.zig`, imported in `src/tls/tls.zig` as `@import("openssl")`.
 - **`std.debug.assert` is stripped in release builds.** Never use it as a runtime guard for conditions that can actually occur (bad input, ring overflow, null state) — use real error returns.
 - **Proactor rule (it bites here):** no blocking syscalls on the worker thread — no `std.net.tcpConnectToHost`, no blocking `read`/`pread`/`writeAll`. All I/O goes through libxev/io_uring. See MANIFEST.md.

--- a/build.zig
+++ b/build.zig
@@ -22,6 +22,16 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // OpenSSL headers translated to a Zig module (Zig 0.16 moved C translation
+    // into the build system — no more inline @cImport).
+    const openssl_translate = b.addTranslateC(.{
+        .root_source_file = b.path("src/tls/openssl.h"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const openssl_mod = openssl_translate.createModule();
+
     // Main executable
     const exe = b.addExecutable(.{
         .name = "keyway",
@@ -31,7 +41,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    addSharedDeps(b, exe, libxev_dep, luajit_dep, metrics_dep, logz_dep);
+    addSharedDeps(b, exe, libxev_dep, luajit_dep, metrics_dep, logz_dep, openssl_mod);
 
     // Export all symbols so LuaRocks C modules can find Lua API functions
     // This is required for dynamically loaded .so modules to resolve symbols like lua_getmetatable
@@ -59,7 +69,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    addSharedDeps(b, exe_unit_tests, libxev_dep, luajit_dep, metrics_dep, logz_dep);
+    addSharedDeps(b, exe_unit_tests, libxev_dep, luajit_dep, metrics_dep, logz_dep, openssl_mod);
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
     const test_step = b.step("test", "Run unit tests");
@@ -75,11 +85,13 @@ fn addSharedDeps(
     luajit_dep: *std.Build.Dependency,
     metrics_dep: *std.Build.Dependency,
     logz_dep: *std.Build.Dependency,
+    openssl_mod: *std.Build.Module,
 ) void {
     compile.root_module.addImport("xev", libxev_dep.module("xev"));
     compile.root_module.addImport("luajit", luajit_dep.module("luajit"));
     compile.root_module.addImport("metrics", metrics_dep.module("metrics"));
     compile.root_module.addImport("logz", logz_dep.module("logz"));
+    compile.root_module.addImport("openssl", openssl_mod);
     // Lua stdlib: lua/stdlib.zig uses @embedFile for sibling .lua files
     compile.root_module.addImport("stdlib", b.createModule(.{
         .root_source_file = b.path("lua/stdlib.zig"),

--- a/src/tls/openssl.h
+++ b/src/tls/openssl.h
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+#include <linux/tls.h>
+#include <netinet/tcp.h>

--- a/src/tls/tls.zig
+++ b/src/tls/tls.zig
@@ -2,15 +2,7 @@ const std = @import("std");
 const log = @import("../observability/log.zig");
 const config = @import("../util/config.zig");
 const helpers = @import("../util/helpers.zig");
-const c = @cImport({
-    @cInclude("openssl/ssl.h");
-    @cInclude("openssl/err.h");
-    @cInclude("openssl/bio.h");
-    @cInclude("openssl/hmac.h");
-    @cInclude("openssl/evp.h");
-    @cInclude("linux/tls.h");
-    @cInclude("netinet/tcp.h");
-});
+const c = @import("openssl");
 
 const ENCRYPT_BUF_SIZE = config.TLS_ENCRYPT_BUF_SIZE;
 


### PR DESCRIPTION
Closes #38

Zig 0.16 moves C translation into the build system. Replaces the inline `@cImport` in `src/tls/tls.zig` with a build-system translate-c module:

- new `src/tls/openssl.h` wrapping the 7 OpenSSL/kTLS headers
- `b.addTranslateC` on it in `build.zig`, exposed as an `openssl` module and wired through `addSharedDeps` for both the exe and the unit-test target
- `tls.zig`: `const c = @import("openssl");` — every `c.SSL_*`/`c.TLS_*`/`c.BIO_*` call site unchanged (same translate-c engine, same symbols)
- `linkSystemLibrary("ssl"/"crypto")` untouched (translate-c generates bindings; linking is separate)
- `.claude/rules/zig-gotchas.md` OpenSSL bullet updated

Verified: `zig build` + `zig build test` clean on a wiped cache; `nm -D` shows `SSL_CTX_new`/`TLS_server_method` as undefined dynamic symbols versioned `OPENSSL_3.0.0`, i.e. resolved through the new module and deferred to system libssl as before. picohttpparser's `@cImport` in `http.zig` is a separate follow-up.