### PR TITLE
Split Lua entry surface into prod/test/control-plane roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # Keyway server configuration
 KEYWAY_HOST=0.0.0.0
+# Dashboard is opt-in: run with --script dashboard/keyway.lua.
 KEYWAY_PORT=8080
 KEYWAY_WORKERS=0
-KEYWAY_SCRIPT=dashboard/keyway.lua
+KEYWAY_SCRIPT=examples/minimal.lua
 KEYWAY_TLS_CERT=
 KEYWAY_TLS_KEY=
 KEYWAY_LOG_LEVEL=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,10 @@ WORKDIR /app
 
 COPY --from=build /build/zig-out/bin/keyway .
 COPY dashboard/ dashboard/
+COPY examples/ examples/
 COPY lua/ lua/
 
 EXPOSE 8080
 
 ENTRYPOINT ["./keyway"]
-CMD ["--script", "dashboard/keyway.lua"]
+CMD ["--script", "examples/minimal.lua"]

--- a/dashboard/keyway.lua
+++ b/dashboard/keyway.lua
@@ -82,22 +82,8 @@ local function localhost_guard(ctx, next)
     next()
 end
 
--- ─── Test Middleware ──────────────────────────────────────────────────
-
-local function mw_before(ctx, next)
-    ctx.headers["X-MW-Before"] = "applied"
-    next()
-end
-
-local function mw_after(ctx, next)
-    next()
-    ctx.headers["X-MW-After"] = "applied"
-end
-
 -- Register built-in middleware
 keyway.middleware.register("localhost_guard", localhost_guard)
-keyway.middleware.register("mw_before", mw_before)
-keyway.middleware.register("mw_after", mw_after)
 
 local function ws_reply(ws, tbl)
     ws:send(json.encode(tbl))
@@ -141,14 +127,6 @@ keyway.static = {
 
 keyway.proxy = {
     ["/__keyway/grafana"] = { host = "127.0.0.1", port = 3000, redirect = "/__keyway/dashboard/grafana.html", strip_prefix = false },
-    -- Integration-test upstreams (see tests/integration/proxy.test.ts).
-    -- The live upstream is spawned by the test on this fixed port; the dead
-    -- one points at a closed port to exercise the 502 connect-failure path;
-    -- the hung one accepts but never responds, exercising the upstream
-    -- deadline (#72).
-    ["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true },
-    ["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true },
-    ["/__keyway/test-proxy-hung"] = { host = "127.0.0.1", port = 38292, strip_prefix = true },
 }
 
 -- ─── Routes ──────────────────────────────────────────────────────────
@@ -409,102 +387,4 @@ keyway.routes = {
         end,
     },
 
-    -- ─── Integration Test Endpoints ──────────────────────────────
-
-    ["/test/hello"] = {
-        GET = function(ctx)
-            ctx.status = 200
-            ctx.body = "hello world"
-        end,
-    },
-
-    ["/test/users/{id}"] = {
-        GET = function(ctx)
-            response.json_response(ctx, 200, { id = ctx.params.id })
-        end,
-    },
-
-    ["/test/search"] = {
-        GET = function(ctx)
-            response.json_response(ctx, 200, { q = ctx.query.q })
-        end,
-    },
-
-    ["/test/headers"] = {
-        GET = function(ctx)
-            local ua = response.get_header(ctx, "User-Agent") or "unknown"
-            ctx.status = 200
-            ctx.headers["X-Echo-UA"] = ua
-            ctx.headers["X-Worker"] = tostring(keyway.worker_id)
-            ctx.body = "headers ok"
-        end,
-    },
-
-    ["/test/echo"] = {
-        POST = function(ctx)
-            ctx.status = 200
-            ctx.body = ctx.body
-        end,
-    },
-
-    ["/test/status/{code}"] = {
-        GET = function(ctx)
-            local code = tonumber(ctx.params.code) or 200
-            ctx.status = code
-            ctx.body = "status " .. tostring(code)
-        end,
-    },
-
-    ["/test/json"] = {
-        GET = function(ctx)
-            response.json_response(ctx, 200, { message = "hello", worker_id = keyway.worker_id })
-        end,
-    },
-
-    ["/test/sse"] = {
-        GET = function(ctx)
-            ctx.upgrade = "sse"
-            ctx.sse_room = "test:events"
-        end,
-    },
-
-    ["/test/ws"] = {
-        GET = function(ctx)
-            ctx.upgrade = "websocket"
-            ctx.on_message = function(ws)
-                ws:send(ws.message)
-            end
-            ctx.on_close = function() end
-        end,
-    },
-
-    ["/test/stream"] = {
-        GET = function(ctx)
-            ctx.upgrade = "stream"
-            ctx.status = 200
-            ctx.body = "chunk1\n"
-            coroutine.yield()
-            ctx.body = "chunk2\n"
-            coroutine.yield()
-            ctx.body = "chunk3\n"
-            coroutine.yield()
-        end,
-    },
-
-    ["/test/broadcast"] = {
-        POST = function(ctx)
-            local data = ctx.body
-            pcall(response.broadcast_event, "test:events", { message = data })
-            ctx.status = 200
-            ctx.body = "ok"
-        end,
-    },
-
-    ["/test/mw"] = {
-        middleware = { mw_before, mw_after },
-        GET = function(ctx)
-            ctx.status = 200
-            ctx.body = "middleware ok"
-        end,
-    },
 }

--- a/examples/minimal.lua
+++ b/examples/minimal.lua
@@ -1,0 +1,24 @@
+-- Production-safe default entry surface.
+local response = require("keyway.response")
+
+keyway.routes = {
+    ["/ping"] = {
+        GET = function(ctx)
+            ctx.status = 200
+            ctx.body = "pong"
+        end,
+    },
+
+    ["/hello/{name}"] = {
+        GET = function(ctx)
+            ctx.status = 200
+            ctx.body = "hello " .. (ctx.params.name or "world")
+        end,
+    },
+
+    ["/json"] = {
+        GET = function(ctx)
+            response.json_response(ctx, 200, { message = "hello from keyway" })
+        end,
+    },
+}

--- a/tests/fixtures.lua
+++ b/tests/fixtures.lua
@@ -17,8 +17,6 @@ end
 keyway.middleware.register("mw_before", mw_before)
 keyway.middleware.register("mw_after", mw_after)
 
-keyway.proxy = keyway.proxy or {}
-
 -- Integration-test upstreams (see tests/integration/proxy.test.ts).
 keyway.proxy["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true }
 keyway.proxy["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true }

--- a/tests/fixtures.lua
+++ b/tests/fixtures.lua
@@ -1,0 +1,122 @@
+-- Integration-test reference surface.
+-- Compose the opt-in dashboard control plane, then add test-only fixtures.
+dofile("dashboard/keyway.lua")
+
+local response = require("keyway.response")
+
+local function mw_before(ctx, next)
+    ctx.headers["X-MW-Before"] = "applied"
+    next()
+end
+
+local function mw_after(ctx, next)
+    next()
+    ctx.headers["X-MW-After"] = "applied"
+end
+
+keyway.middleware.register("mw_before", mw_before)
+keyway.middleware.register("mw_after", mw_after)
+
+keyway.proxy = keyway.proxy or {}
+
+-- Integration-test upstreams (see tests/integration/proxy.test.ts).
+keyway.proxy["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true }
+keyway.proxy["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true }
+keyway.proxy["/__keyway/test-proxy-hung"] = { host = "127.0.0.1", port = 38292, strip_prefix = true }
+
+keyway.routes["/test/hello"] = {
+    GET = function(ctx)
+        ctx.status = 200
+        ctx.body = "hello world"
+    end,
+}
+
+keyway.routes["/test/users/{id}"] = {
+    GET = function(ctx)
+        response.json_response(ctx, 200, { id = ctx.params.id })
+    end,
+}
+
+keyway.routes["/test/search"] = {
+    GET = function(ctx)
+        response.json_response(ctx, 200, { q = ctx.query.q })
+    end,
+}
+
+keyway.routes["/test/headers"] = {
+    GET = function(ctx)
+        local ua = response.get_header(ctx, "User-Agent") or "unknown"
+        ctx.status = 200
+        ctx.headers["X-Echo-UA"] = ua
+        ctx.headers["X-Worker"] = tostring(keyway.worker_id)
+        ctx.body = "headers ok"
+    end,
+}
+
+keyway.routes["/test/echo"] = {
+    POST = function(ctx)
+        ctx.status = 200
+        ctx.body = ctx.body
+    end,
+}
+
+keyway.routes["/test/status/{code}"] = {
+    GET = function(ctx)
+        local code = tonumber(ctx.params.code) or 200
+        ctx.status = code
+        ctx.body = "status " .. tostring(code)
+    end,
+}
+
+keyway.routes["/test/json"] = {
+    GET = function(ctx)
+        response.json_response(ctx, 200, { message = "hello", worker_id = keyway.worker_id })
+    end,
+}
+
+keyway.routes["/test/sse"] = {
+    GET = function(ctx)
+        ctx.upgrade = "sse"
+        ctx.sse_room = "test:events"
+    end,
+}
+
+keyway.routes["/test/ws"] = {
+    GET = function(ctx)
+        ctx.upgrade = "websocket"
+        ctx.on_message = function(ws)
+            ws:send(ws.message)
+        end
+        ctx.on_close = function() end
+    end,
+}
+
+keyway.routes["/test/stream"] = {
+    GET = function(ctx)
+        ctx.upgrade = "stream"
+        ctx.status = 200
+        ctx.body = "chunk1\n"
+        coroutine.yield()
+        ctx.body = "chunk2\n"
+        coroutine.yield()
+        ctx.body = "chunk3\n"
+        coroutine.yield()
+    end,
+}
+
+keyway.routes["/test/broadcast"] = {
+    POST = function(ctx)
+        local data = ctx.body
+        pcall(response.broadcast_event, "test:events", { message = data })
+        ctx.status = 200
+        ctx.body = "ok"
+    end,
+}
+
+keyway.routes["/test/mw"] = {
+    middleware = { mw_before, mw_after },
+    GET = function(ctx)
+        ctx.status = 200
+        ctx.body = "middleware ok"
+    end,
+}

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,0 +1,27 @@
+import { resolve } from "path";
+
+const PROJECT_ROOT = resolve(import.meta.dir, "..");
+const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
+const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
+
+export async function withServer(fn: (server: { base: string; port: number }) => Promise<void>) {
+  const port = 10000 + Math.floor(Math.random() * 50000);
+  const proc = Bun.spawn(
+    [BINARY, "--script", SCRIPT, "--workers", "1", "--port", String(port)],
+    { cwd: PROJECT_ROOT, stdout: "ignore", stderr: "pipe" },
+  );
+  const stderr = new Response(proc.stderr).text();
+
+  try {
+    const base = `http://127.0.0.1:${port}`;
+    for (let i = 0; i < 50; i++) {
+      const res = await fetch(`${base}/health`).catch(() => null);
+      if (res?.ok) return await fn({ base, port });
+      await Bun.sleep(100);
+    }
+    throw new Error(`isolated keyway did not start: ${await stderr}`);
+  } finally {
+    proc.kill("SIGKILL");
+    await Promise.race([proc.exited.catch(() => {}), Bun.sleep(500)]);
+  }
+}

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,6 +1,6 @@
 // Reverse proxy — exercises the async connect/send/recv path (issue #29).
 //
-// The dashboard config (dashboard/keyway.lua) registers three proxy routes:
+// The integration fixtures (tests/fixtures.lua) register three proxy routes:
 //   /__keyway/test-proxy       -> 127.0.0.1:38291 (the upstream spawned below)
 //   /__keyway/test-proxy-dead  -> 127.0.0.1:1     (closed port -> 502)
 //   /__keyway/test-proxy-hung  -> 127.0.0.1:38292 (accepts, never responds -> 504)

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "path";
+
+const PROJECT_ROOT = resolve(import.meta.dir, "../..");
+const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
+const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
+const base = () => globalThis.__KEYWAY_BASE;
+
+async function withServer(fn: (base: string) => Promise<void>) {
+  const port = 10000 + Math.floor(Math.random() * 50000);
+  const proc = Bun.spawn(
+    [BINARY, "--script", SCRIPT, "--workers", "1", "--port", String(port)],
+    { cwd: PROJECT_ROOT, stdout: "ignore", stderr: "pipe" },
+  );
+  const stderr = new Response(proc.stderr).text();
+
+  try {
+    const url = `http://127.0.0.1:${port}`;
+    for (let i = 0; i < 50; i++) {
+      const res = await fetch(`${url}/health`).catch(() => null);
+      if (res?.ok) return await fn(url);
+      await Bun.sleep(100);
+    }
+    throw new Error(`isolated keyway did not start: ${await stderr}`);
+  } finally {
+    proc.kill("SIGKILL");
+    await Promise.race([proc.exited.catch(() => {}), Bun.sleep(500)]);
+  }
+}
+
+describe("worker resilience regressions", () => {
+  // (#172)
+  test.failing("out-of-range Lua status does not kill the next request", async () => {
+    await withServer(async (url) => {
+      await fetch(`${url}/test/status/70000`).catch(() => null);
+      const next = await fetch(`${url}/test/hello`);
+      expect(next.status).toBe(200);
+    });
+  });
+
+  // (#171)
+  test.failing("POST /test/echo accepts a 100KB body", async () => {
+    const body = "x".repeat(100 * 1024);
+    const res = await fetch(`${base()}/test/echo`, { method: "POST", body });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(body);
+  });
+});

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -4,7 +4,6 @@ import { resolve } from "path";
 const PROJECT_ROOT = resolve(import.meta.dir, "../..");
 const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
 const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
-const base = () => globalThis.__KEYWAY_BASE;
 
 async function withServer(fn: (base: string) => Promise<void>) {
   const port = 10000 + Math.floor(Math.random() * 50000);
@@ -41,8 +40,10 @@ describe("worker resilience regressions", () => {
   // (#171)
   test.failing("POST /test/echo accepts a 100KB body", async () => {
     const body = "x".repeat(100 * 1024);
-    const res = await fetch(`${base()}/test/echo`, { method: "POST", body });
-    expect(res.status).toBe(200);
-    expect(await res.text()).toBe(body);
+    await withServer(async (url) => {
+      const res = await fetch(`${url}/test/echo`, { method: "POST", body });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(body);
+    });
   });
 });

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -1,38 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "path";
-
-const PROJECT_ROOT = resolve(import.meta.dir, "../..");
-const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
-const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
-
-async function withServer(fn: (base: string) => Promise<void>) {
-  const port = 10000 + Math.floor(Math.random() * 50000);
-  const proc = Bun.spawn(
-    [BINARY, "--script", SCRIPT, "--workers", "1", "--port", String(port)],
-    { cwd: PROJECT_ROOT, stdout: "ignore", stderr: "pipe" },
-  );
-  const stderr = new Response(proc.stderr).text();
-
-  try {
-    const url = `http://127.0.0.1:${port}`;
-    for (let i = 0; i < 50; i++) {
-      const res = await fetch(`${url}/health`).catch(() => null);
-      if (res?.ok) return await fn(url);
-      await Bun.sleep(100);
-    }
-    throw new Error(`isolated keyway did not start: ${await stderr}`);
-  } finally {
-    proc.kill("SIGKILL");
-    await Promise.race([proc.exited.catch(() => {}), Bun.sleep(500)]);
-  }
-}
+import { withServer } from "../harness";
 
 describe("worker resilience regressions", () => {
   // (#172)
   test.failing("out-of-range Lua status does not kill the next request", async () => {
-    await withServer(async (url) => {
-      await fetch(`${url}/test/status/70000`).catch(() => null);
-      const next = await fetch(`${url}/test/hello`);
+    await withServer(async ({ base }) => {
+      await fetch(`${base}/test/status/70000`).catch(() => null);
+      const next = await fetch(`${base}/test/hello`);
       expect(next.status).toBe(200);
     });
   });
@@ -40,8 +14,8 @@ describe("worker resilience regressions", () => {
   // (#171)
   test.failing("POST /test/echo accepts a 100KB body", async () => {
     const body = "x".repeat(100 * 1024);
-    await withServer(async (url) => {
-      const res = await fetch(`${url}/test/echo`, { method: "POST", body });
+    await withServer(async ({ base }) => {
+      const res = await fetch(`${base}/test/echo`, { method: "POST", body });
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(body);
     });

--- a/tests/integration/smuggling.test.ts
+++ b/tests/integration/smuggling.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+const port = () => globalThis.__KEYWAY_PORT;
+
+async function rawStatus(request: string): Promise<number> {
+  let buf = "";
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: port(),
+    socket: {
+      data(s, data) {
+        buf += data.toString();
+        if (buf.includes("\r\n\r\n")) {
+          resolve(buf);
+          s.end();
+        }
+      },
+      close() {
+        resolve(buf);
+      },
+      error(_socket, error) {
+        resolve(buf || String(error));
+      },
+    },
+  });
+  socket.write(request);
+  socket.flush();
+  const resp = await Promise.race([
+    promise,
+    Bun.sleep(1500).then(() => ""),
+  ]);
+  socket.end();
+  return Number(resp.split(" ")[1]);
+}
+
+describe("request smuggling regressions", () => {
+  // (#169)
+  test.failing("rejects requests with both Content-Length and Transfer-Encoding", async () => {
+    const status = await rawStatus(
+      `POST /test/echo HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Content-Length: 4\r\n` +
+        `Transfer-Encoding: chunked\r\n` +
+        `Connection: close\r\n\r\n` +
+        `4\r\nping\r\n0\r\n\r\n`,
+    );
+    expect(status).toBe(400);
+  });
+
+  // (#169)
+  test.failing("rejects duplicate Content-Length headers", async () => {
+    const status = await rawStatus(
+      `POST /test/echo HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Content-Length: 4\r\n` +
+        `Content-Length: 5\r\n` +
+        `Connection: close\r\n\r\n` +
+        `hello`,
+    );
+    expect(status).toBe(400);
+  });
+});

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -1,33 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "path";
+import { withServer } from "../harness";
 
-const PROJECT_ROOT = resolve(import.meta.dir, "../..");
-const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
-const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
-
-async function withServer(fn: (port: number) => Promise<void>) {
-  const port = 10000 + Math.floor(Math.random() * 50000);
-  const proc = Bun.spawn(
-    [BINARY, "--script", SCRIPT, "--workers", "1", "--port", String(port)],
-    { cwd: PROJECT_ROOT, stdout: "ignore", stderr: "pipe" },
-  );
-  const stderr = new Response(proc.stderr).text();
-
-  try {
-    const base = `http://127.0.0.1:${port}`;
-    for (let i = 0; i < 50; i++) {
-      const res = await fetch(`${base}/health`).catch(() => null);
-      if (res?.ok) return await fn(port);
-      await Bun.sleep(100);
-    }
-    throw new Error(`isolated keyway did not start: ${await stderr}`);
-  } finally {
-    proc.kill("SIGKILL");
-    await Promise.race([proc.exited.catch(() => {}), Bun.sleep(500)]);
-  }
-}
 
 async function openRawWs(port: number) {
   let bytes: number[] = [];
@@ -109,7 +84,7 @@ function readFrame(bytes: number[], opcode: number): string | null {
     pos = 4;
   } else if (len === 127) {
     if (bytes.length < 10) return null;
-    len = Number((BigInt(bytes[2]) << 56n) | (BigInt(bytes[3]) << 48n) | (BigInt(bytes[4]) << 40n) | (BigInt(bytes[5]) << 32n) | (BigInt(bytes[6]) << 24n) | (BigInt(bytes[7]) << 16n) | (BigInt(bytes[8]) << 8n) | BigInt(bytes[9]));
+    len = Number(new DataView(Uint8Array.from(bytes.slice(2, 10)).buffer).getBigUint64(0));
     pos = 10;
   }
   if (bytes.length < pos + len) return null;
@@ -142,7 +117,7 @@ function clientFrame(opcode: number, data: string, fin = true): Uint8Array {
 describe("websocket adversarial framing", () => {
   // (#165)
   test.failing("echoes a frame whose header and payload arrive in separate writes", async () => {
-    await withServer(async (port) => {
+    await withServer(async ({ port }) => {
       const ws = await openRawWs(port);
       const frame = clientFrame(0x1, "x".repeat(4096));
       const payloadOffset = frame.length - 4096;
@@ -158,7 +133,7 @@ describe("websocket adversarial framing", () => {
 
   // (#166)
   test.failing("rejects a 127-length frame declaring more than 1MB", async () => {
-    await withServer(async (port) => {
+    await withServer(async ({ port }) => {
       const ws = await openRawWs(port);
       const frame = new Uint8Array(14);
       frame[0] = 0x81;
@@ -174,7 +149,7 @@ describe("websocket adversarial framing", () => {
 
   // (#167)
   test.failing("echoes a text message sent as three continuation frames", async () => {
-    await withServer(async (port) => {
+    await withServer(async ({ port }) => {
       const ws = await openRawWs(port);
       ws.socket.write(clientFrame(0x1, "he", false));
       ws.socket.write(clientFrame(0x0, "llo", false));

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "path";
+
+const PROJECT_ROOT = resolve(import.meta.dir, "../..");
+const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
+const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function withServer(fn: (port: number) => Promise<void>) {
+  const port = 10000 + Math.floor(Math.random() * 50000);
+  const proc = Bun.spawn(
+    [BINARY, "--script", SCRIPT, "--workers", "1", "--port", String(port)],
+    { cwd: PROJECT_ROOT, stdout: "ignore", stderr: "pipe" },
+  );
+  const stderr = new Response(proc.stderr).text();
+
+  try {
+    const base = `http://127.0.0.1:${port}`;
+    for (let i = 0; i < 50; i++) {
+      const res = await fetch(`${base}/health`).catch(() => null);
+      if (res?.ok) return await fn(port);
+      await Bun.sleep(100);
+    }
+    throw new Error(`isolated keyway did not start: ${await stderr}`);
+  } finally {
+    proc.kill("SIGKILL");
+    await Promise.race([proc.exited.catch(() => {}), Bun.sleep(500)]);
+  }
+}
+
+async function openRawWs(port: number) {
+  let bytes: number[] = [];
+  let closed = false;
+  let err: Error | null = null;
+  let wake: (() => void) | null = null;
+  const notify = () => {
+    wake?.();
+    wake = null;
+  };
+
+  const socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    socket: {
+      data(_socket, data) {
+        bytes.push(...data);
+        notify();
+      },
+      close() {
+        closed = true;
+        notify();
+      },
+      error(_socket, error) {
+        err = error;
+        notify();
+      },
+    },
+  });
+
+  async function waitFor<T>(read: () => T | null, timeout = 1500): Promise<T> {
+    const deadline = Date.now() + timeout;
+    while (true) {
+      const value = read();
+      if (value !== null) return value;
+      if (err) throw err;
+      const left = deadline - Date.now();
+      if (left <= 0) throw new Error("timed out waiting for raw websocket data");
+      const { promise, resolve } = Promise.withResolvers<void>();
+      wake = resolve;
+      await Promise.race([promise, Bun.sleep(left)]);
+    }
+  }
+
+  socket.write(
+    `GET /test/ws HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:${port}\r\n` +
+      `Upgrade: websocket\r\n` +
+      `Connection: Upgrade\r\n` +
+      `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n` +
+      `Sec-WebSocket-Version: 13\r\n\r\n`,
+  );
+  socket.flush();
+
+  const headers = await waitFor(() => {
+    const text = String.fromCharCode(...bytes);
+    const end = text.indexOf("\r\n\r\n");
+    if (end === -1) return null;
+    const head = text.slice(0, end + 4);
+    bytes = bytes.slice(end + 4);
+    return head;
+  });
+  expect(headers.startsWith("HTTP/1.1 101")).toBe(true);
+
+  return {
+    socket,
+    readText: () => waitFor(() => readFrame(bytes, 0x1)),
+    readClose: () => waitFor(() => (closed || readFrame(bytes, 0x8) !== null ? true : null)),
+  };
+}
+
+function readFrame(bytes: number[], opcode: number): string | null {
+  if (bytes.length < 2) return null;
+  let len = bytes[1] & 0x7f;
+  let pos = 2;
+  if (len === 126) {
+    if (bytes.length < 4) return null;
+    len = (bytes[2] << 8) | bytes[3];
+    pos = 4;
+  } else if (len === 127) {
+    if (bytes.length < 10) return null;
+    len = Number((BigInt(bytes[2]) << 56n) | (BigInt(bytes[3]) << 48n) | (BigInt(bytes[4]) << 40n) | (BigInt(bytes[5]) << 32n) | (BigInt(bytes[6]) << 24n) | (BigInt(bytes[7]) << 16n) | (BigInt(bytes[8]) << 8n) | BigInt(bytes[9]));
+    pos = 10;
+  }
+  if (bytes.length < pos + len) return null;
+  if ((bytes[0] & 0x0f) !== opcode) return null;
+  const payload = Uint8Array.from(bytes.slice(pos, pos + len));
+  bytes.splice(0, pos + len);
+  return decoder.decode(payload);
+}
+
+function clientFrame(opcode: number, data: string, fin = true): Uint8Array {
+  const payload = encoder.encode(data);
+  const header = payload.length < 126 ? 2 : payload.length <= 65535 ? 4 : 10;
+  const out = new Uint8Array(header + 4 + payload.length);
+  out[0] = (fin ? 0x80 : 0) | opcode;
+  if (payload.length < 126) {
+    out[1] = 0x80 | payload.length;
+  } else if (payload.length <= 65535) {
+    out[1] = 0x80 | 126;
+    out[2] = payload.length >> 8;
+    out[3] = payload.length & 0xff;
+  } else {
+    out[1] = 0x80 | 127;
+    new DataView(out.buffer).setBigUint64(2, BigInt(payload.length));
+  }
+  out.set([1, 2, 3, 4], header);
+  for (let i = 0; i < payload.length; i++) out[header + 4 + i] = payload[i] ^ out[header + (i % 4)];
+  return out;
+}
+
+describe("websocket adversarial framing", () => {
+  // (#165)
+  test.failing("echoes a frame whose header and payload arrive in separate writes", async () => {
+    await withServer(async (port) => {
+      const ws = await openRawWs(port);
+      const frame = clientFrame(0x1, "x".repeat(4096));
+      const payloadOffset = frame.length - 4096;
+      ws.socket.write(frame.slice(0, payloadOffset));
+      ws.socket.flush();
+      await Bun.sleep(10);
+      ws.socket.write(frame.slice(payloadOffset));
+      ws.socket.flush();
+      expect(await ws.readText()).toBe("x".repeat(4096));
+      ws.socket.end();
+    });
+  });
+
+  // (#166)
+  test.failing("rejects a 127-length frame declaring more than 1MB", async () => {
+    await withServer(async (port) => {
+      const ws = await openRawWs(port);
+      const frame = new Uint8Array(14);
+      frame[0] = 0x81;
+      frame[1] = 0xff;
+      new DataView(frame.buffer).setBigUint64(2, 1_048_577n);
+      frame.set([1, 2, 3, 4], 10);
+      ws.socket.write(frame);
+      ws.socket.flush();
+      expect(await ws.readClose()).toBe(true);
+      ws.socket.end();
+    });
+  });
+
+  // (#167)
+  test.failing("echoes a text message sent as three continuation frames", async () => {
+    await withServer(async (port) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x1, "he", false));
+      ws.socket.write(clientFrame(0x0, "llo", false));
+      ws.socket.write(clientFrame(0x0, " ws", true));
+      ws.socket.flush();
+      expect(await ws.readText()).toBe("hello ws");
+      ws.socket.end();
+    });
+  });
+});

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -4,12 +4,12 @@
 // kills it after all tests. Exposes globalThis.__KEYWAY_BASE
 // and globalThis.__KEYWAY_PORT for test files to use.
 
-import { afterAll, beforeAll } from "bun:test";
+import { afterAll, afterEach, beforeAll } from "bun:test";
 import { resolve } from "path";
 
 const PROJECT_ROOT = resolve(import.meta.dir, "..");
 const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
-const SCRIPT = resolve(PROJECT_ROOT, "dashboard/keyway.lua");
+const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
 const PORT = 10000 + Math.floor(Math.random() * 50000);
 
 declare global {
@@ -18,6 +18,18 @@ declare global {
 }
 
 let proc: ReturnType<typeof Bun.spawn> | null = null;
+let stderr = "";
+let stderrDone: Promise<void> | null = null;
+let exitCode: number | null = null;
+let stopping = false;
+
+async function failIfExited(phase: string) {
+  if (exitCode === null || stopping) return;
+
+  await stderrDone;
+  if (stderr) console.error(stderr);
+  throw new Error(`Keyway server exited during ${phase} with code ${exitCode}`);
+}
 
 beforeAll(async () => {
   // Verify binary exists
@@ -33,13 +45,20 @@ beforeAll(async () => {
     {
       cwd: PROJECT_ROOT,
       stdout: "ignore",
-      stderr: "ignore",
+      stderr: "pipe",
     }
   );
+  stderrDone = new Response(proc.stderr).text().then((text) => {
+    stderr = text;
+  });
+  proc.exited.then((code) => {
+    exitCode = code;
+  });
 
   // Poll /health until the server is ready
   const base = `http://127.0.0.1:${PORT}`;
   for (let i = 0; i < 50; i++) {
+    await failIfExited("startup");
     try {
       const res = await fetch(`${base}/health`);
       if (res.ok) break;
@@ -50,9 +69,13 @@ beforeAll(async () => {
   }
 
   // Final check
+  await failIfExited("startup");
   const res = await fetch(`${base}/health`).catch(() => null);
   if (!res?.ok) {
+    stopping = true;
     proc.kill();
+    await stderrDone;
+    if (stderr) console.error(stderr);
     throw new Error(`Keyway server did not become ready on port ${PORT}`);
   }
 
@@ -60,8 +83,13 @@ beforeAll(async () => {
   globalThis.__KEYWAY_PORT = PORT;
 });
 
+afterEach(async () => {
+  await failIfExited("test run");
+});
+
 afterAll(() => {
   if (proc) {
+    stopping = true;
     proc.kill();
     proc = null;
   }


### PR DESCRIPTION
## Summary
- Split the production default into examples/minimal.lua with only /ping, /hello/{name}, and a JSON response route.
- Slimmed dashboard/keyway.lua to the opt-in /__keyway/* control plane, with tests/fixtures.lua composing it and owning all /test/* routes plus test proxy mounts.
- Repointed Docker/.env/preload defaults and made preload capture stderr plus fail loudly on unexpected server exits.

## Captured-not-fixed regressions
- Added test.failing adversarial coverage for #165, #166, #167, #169, #171, and #172.

## Verification
- zig build
- zig build test
- cd tests && bun run test:ci
- Smoke: /test/hello 200 and /__keyway/dashboard 200 from tests/fixtures.lua

Closes #174