### PR TITLE
fix(http): reject ambiguous request framing (request smuggling, #169)

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -112,6 +112,17 @@ pub const Header = struct {
     value: []const u8,
 };
 
+/// True if `s` is a valid HTTP field-value integer: 1*DIGIT, nothing else.
+/// `std.fmt.parseInt` alone also accepts a leading '+', '-', and Zig's '_'
+/// digit separators — none of which RFC 7230 permits for Content-Length.
+fn isDigitsOnly(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |b| {
+        if (!std.ascii.isDigit(b)) return false;
+    }
+    return true;
+}
+
 /// HTTP parser using picohttpparser
 pub const Parser = struct {
     allocator: std.mem.Allocator,
@@ -174,33 +185,55 @@ pub const Parser = struct {
         // Without this, leftover body bytes corrupt the next keep-alive request.
         const bytes_consumed = @as(usize, @intCast(result));
 
-        var content_length: usize = 0;
+        // Single pass over headers: collect Content-Length (rejecting malformed
+        // values and duplicates whose parsed values disagree) and the value of
+        // the last Transfer-Encoding header (repeated TE headers combine per
+        // RFC 7230 §3.3.2 — the final coding is what determines chunked-ness).
+        var content_length: ?usize = null;
+        var transfer_encoding: ?[]const u8 = null;
         for (0..num_headers) |i| {
             const h = c_headers[i];
             const name = h.name[0..h.name_len];
             if (std.ascii.eqlIgnoreCase(name, "content-length")) {
-                content_length = std.fmt.parseInt(usize, h.value[0..h.value_len], 10) catch 0;
-                break;
-            }
-        }
-
-        // Check for Transfer-Encoding: chunked (mutually exclusive with Content-Length)
-        var is_chunked = false;
-        if (content_length == 0) {
-            for (0..num_headers) |i| {
-                const h = c_headers[i];
-                const name = h.name[0..h.name_len];
-                if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) {
-                    const val = h.value[0..h.value_len];
-                    if (std.ascii.indexOfIgnoreCase(val, "chunked") != null) {
-                        is_chunked = true;
-                        break;
-                    }
+                const val = h.value[0..h.value_len];
+                if (!isDigitsOnly(val)) {
+                    self.allocator.free(headers);
+                    return error.InvalidRequest;
                 }
+                const parsed = std.fmt.parseInt(usize, val, 10) catch {
+                    self.allocator.free(headers);
+                    return error.InvalidRequest;
+                };
+                if (content_length) |existing| {
+                    if (existing != parsed) {
+                        self.allocator.free(headers);
+                        return error.InvalidRequest;
+                    }
+                } else {
+                    content_length = parsed;
+                }
+            } else if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) {
+                transfer_encoding = h.value[0..h.value_len];
             }
         }
 
-        if (is_chunked) {
+        // A request with both headers is the classic CL.TE/TE.CL smuggling
+        // primitive — reject rather than picking a framing to trust (RFC 7230 §3.3.3).
+        if (transfer_encoding != null and content_length != null) {
+            self.allocator.free(headers);
+            return error.InvalidRequest;
+        }
+
+        if (transfer_encoding) |te_val| {
+            // Final coding is the last comma-separated token of the last TE header.
+            const last_token = if (std.mem.lastIndexOfScalar(u8, te_val, ',')) |idx| te_val[idx + 1 ..] else te_val;
+            const final_coding = std.mem.trim(u8, last_token, " \t");
+            if (!std.ascii.eqlIgnoreCase(final_coding, "chunked")) {
+                // Non-chunked final coding: body length is undeterminable.
+                self.allocator.free(headers);
+                return error.InvalidRequest;
+            }
+
             // Decode chunked body: hex-size\r\n + data\r\n + ... + 0\r\n\r\n
             const chunk_data = buf[bytes_consumed..];
             const decoded = decodeChunkedBody(chunk_data, self.allocator) catch |err| {
@@ -220,14 +253,15 @@ pub const Parser = struct {
             };
         }
 
-        const total_needed = bytes_consumed + content_length;
+        const cl = content_length orelse 0;
+        const total_needed = bytes_consumed + cl;
         if (buf.len < total_needed) {
             // Body not fully received yet — need more data
             self.allocator.free(headers);
             return error.Incomplete;
         }
 
-        const body = if (content_length > 0) buf[bytes_consumed .. bytes_consumed + content_length] else &[_]u8{};
+        const body = if (cl > 0) buf[bytes_consumed .. bytes_consumed + cl] else &[_]u8{};
 
         return Request{
             .method = method,
@@ -296,6 +330,92 @@ test "http parser - incomplete request" {
     const partial_request = "GET /test HTTP";
     const result = parser.parseRequest(partial_request);
     try std.testing.expectError(error.Incomplete, result);
+}
+
+test "http parser - rejects Content-Length and Transfer-Encoding together" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nping\r\n0\r\n\r\n";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - rejects duplicate Content-Length with distinct values" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\nhello";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - accepts duplicate Content-Length with identical values" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nContent-Length: 04\r\n\r\nping";
+    const request_result = try parser.parseRequest(request);
+    defer allocator.free(request_result.headers);
+    try std.testing.expectEqualStrings("ping", request_result.body);
+}
+
+test "http parser - rejects malformed Content-Length" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: abc\r\n\r\nping";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - rejects signed Content-Length" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: +4\r\n\r\nping";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - rejects Content-Length with digit separator" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1_0\r\n\r\nping";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - plain Transfer-Encoding: chunked decodes" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nping\r\n0\r\n\r\n";
+    const request_result = try parser.parseRequest(request);
+    defer allocator.free(request_result.headers);
+    defer allocator.free(request_result.body);
+    try std.testing.expectEqualStrings("ping", request_result.body);
+}
+
+test "http parser - Transfer-Encoding with chunked as final coding decodes" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip, chunked\r\n\r\n4\r\nping\r\n0\r\n\r\n";
+    const request_result = try parser.parseRequest(request);
+    defer allocator.free(request_result.headers);
+    defer allocator.free(request_result.body);
+    try std.testing.expectEqualStrings("ping", request_result.body);
+}
+
+test "http parser - rejects Transfer-Encoding with non-chunked final coding" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked, gzip\r\n\r\n4\r\nping\r\n0\r\n\r\n";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
 }
 
 test "101 switching protocols serialization" {
@@ -397,6 +517,7 @@ fn decodeChunkedBody(data: []const u8, allocator: std.mem.Allocator) !ChunkedRes
 /// Returns null if header is missing or value is malformed.
 pub fn getContentLength(request: *const Request) ?u64 {
     const val = Parser.getHeader(request, "content-length") orelse return null;
+    if (!isDigitsOnly(val)) return null;
     return std.fmt.parseInt(u64, val, 10) catch null;
 }
 

--- a/tests/integration/smuggling.test.ts
+++ b/tests/integration/smuggling.test.ts
@@ -36,7 +36,7 @@ async function rawStatus(request: string): Promise<number> {
 
 describe("request smuggling regressions", () => {
   // (#169)
-  test.failing("rejects requests with both Content-Length and Transfer-Encoding", async () => {
+  test("rejects requests with both Content-Length and Transfer-Encoding", async () => {
     const status = await rawStatus(
       `POST /test/echo HTTP/1.1\r\n` +
         `Host: 127.0.0.1:${port()}\r\n` +
@@ -49,7 +49,7 @@ describe("request smuggling regressions", () => {
   });
 
   // (#169)
-  test.failing("rejects duplicate Content-Length headers", async () => {
+  test("rejects duplicate Content-Length headers", async () => {
     const status = await rawStatus(
       `POST /test/echo HTTP/1.1\r\n` +
         `Host: 127.0.0.1:${port()}\r\n` +
@@ -57,6 +57,30 @@ describe("request smuggling regressions", () => {
         `Content-Length: 5\r\n` +
         `Connection: close\r\n\r\n` +
         `hello`,
+    );
+    expect(status).toBe(400);
+  });
+
+  // (#169)
+  test("rejects malformed Content-Length", async () => {
+    const status = await rawStatus(
+      `POST /test/echo HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Content-Length: abc\r\n` +
+        `Connection: close\r\n\r\n` +
+        `hello`,
+    );
+    expect(status).toBe(400);
+  });
+
+  // (#169)
+  test("rejects signed Content-Length", async () => {
+    const status = await rawStatus(
+      `POST /test/echo HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Content-Length: +4\r\n` +
+        `Connection: close\r\n\r\n` +
+        `ping`,
     );
     expect(status).toBe(400);
   });

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -116,7 +116,7 @@ function clientFrame(opcode: number, data: string, fin = true): Uint8Array {
 
 describe("websocket adversarial framing", () => {
   // (#165)
-  test.failing("echoes a frame whose header and payload arrive in separate writes", async () => {
+  test("echoes a frame whose header and payload arrive in separate writes", async () => {
     await withServer(async ({ port }) => {
       const ws = await openRawWs(port);
       const frame = clientFrame(0x1, "x".repeat(4096));
@@ -132,7 +132,7 @@ describe("websocket adversarial framing", () => {
   });
 
   // (#166)
-  test.failing("rejects a 127-length frame declaring more than 1MB", async () => {
+  test("rejects a 127-length frame declaring more than 1MB", async () => {
     await withServer(async ({ port }) => {
       const ws = await openRawWs(port);
       const frame = new Uint8Array(14);
@@ -148,7 +148,7 @@ describe("websocket adversarial framing", () => {
   });
 
   // (#167)
-  test.failing("echoes a text message sent as three continuation frames", async () => {
+  test("echoes a text message sent as three continuation frames", async () => {
     await withServer(async ({ port }) => {
       const ws = await openRawWs(port);
       ws.socket.write(clientFrame(0x1, "he", false));


### PR DESCRIPTION
Closes #169

## What

The parser resolved ambiguous framing the opposite of RFC 7230 §3.3.3 — Content-Length won over Transfer-Encoding, which is the CL.TE/TE.CL desync primitive for a gateway. `parseRequest` now does a single validated header scan:

- **Content-Length + Transfer-Encoding together → 400.** Rejecting is the conservative branch RFC 7230 permits; no framing guess to get wrong.
- **Duplicate Content-Length with distinct parsed values → 400** (identical repeats like `4`/`04` tolerated).
- **Content-Length must be `1*DIGIT`.** Malformed values were previously swallowed as `0`, turning the body into a pipelined "next request." Also guards against Zig `parseInt` extensions (`+4`, `-0`, `1_0`) that an upstream would parse differently — the proxy forwards CL verbatim, so any syntax leniency here is a desync primitive. Same guard applied to `getContentLength` (the 413 pre-check).
- **Transfer-Encoding is honored only when `chunked` is the final coding** (last comma-token of the last TE header, trimmed, case-insensitive) — no more substring matching; non-chunked final coding → 400 (body length undeterminable).

Also drops three stale `test.failing` markers in `ws_framing.test.ts` left behind by the merged #165–#167 fix — they were "unexpectedly passing" and failing `bun run test:ci --bail` on every branch (separate commit).

## Out of scope, tracked

- Proxy re-encodes decoded chunked bodies under the original TE header → already #170.
- 400 responses advertise `Connection: close` but keep the socket alive → filed #180.

## Verify

- 9 new parser unit tests in `src/http/http.zig` (CL+TE, duplicate distinct/identical CL, malformed CL, `+4`, `1_0`, plain chunked, `gzip, chunked`, `chunked, gzip`).
- `tests/integration/smuggling.test.ts`: the two `test.failing` regressions flipped to real assertions, plus `Content-Length: abc` and `Content-Length: +4` → 400.
- `zig build test` green (no leaks); `bun run test:ci` 48 pass / 0 fail.