### PR TITLE
fix(proxy): strip hop-by-hop headers, regenerate upstream framing (#170)

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -201,8 +201,48 @@ fn onProxyCancelComplete(
     return .disarm;
 }
 
+/// Headers stripped before forwarding upstream, per RFC 7230 §6.1: hop-by-hop
+/// headers plus framing headers (Content-Length/Transfer-Encoding, which we
+/// regenerate below rather than forward — request.body is already decoded,
+/// so a forwarded Transfer-Encoding: chunked would corrupt the upstream read).
+/// `host` isn't actually hop-by-hop — it's stripped because the request line
+/// above already re-emits a rewritten Host for the upstream.
+const HOP_BY_HOP_HEADERS = [_][]const u8{
+    "host",
+    "connection",
+    "content-length",
+    "transfer-encoding",
+    "te",
+    "trailer",
+    "upgrade",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+};
+
+/// True if `name` is a hop-by-hop header: one of HOP_BY_HOP_HEADERS, or named
+/// as a connection-option token in any of the client's Connection headers
+/// (RFC 7230 §6.1, e.g. `Connection: keep-alive, X-Hop`). Checks every header
+/// named `connection` rather than just one — RFC 7230 §3.2.2 allows repeated
+/// headers to be combined, and a header nominated by an earlier Connection
+/// header must not leak upstream just because a later one didn't repeat it.
+fn isHopByHop(name: []const u8, headers: []const http.Header) bool {
+    for (HOP_BY_HOP_HEADERS) |hop| {
+        if (std.ascii.eqlIgnoreCase(name, hop)) return true;
+    }
+    for (headers) |h| {
+        if (!std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
+        var it = std.mem.splitScalar(u8, h.value, ',');
+        while (it.next()) |token| {
+            if (std.ascii.eqlIgnoreCase(name, std.mem.trim(u8, token, " \t"))) return true;
+        }
+    }
+    return false;
+}
+
 /// Build the HTTP/1.1 request to send upstream: request line, rewritten Host,
-/// forced `Connection: close`, forwarded client headers, then the body.
+/// forced `Connection: close`, forwarded client headers (minus hop-by-hop),
+/// regenerated framing, then the body.
 fn buildUpstreamRequest(
     allocator: std.mem.Allocator,
     request: *const http.Request,
@@ -219,10 +259,22 @@ fn buildUpstreamRequest(
         route.upstream_host,
         route.upstream_port,
     });
+
+    // Whether the original request carried framing, checked before the write
+    // loop below strips/emits headers.
+    var had_framing = false;
     for (request.headers) |h| {
-        if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
-        if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
+        if (std.ascii.eqlIgnoreCase(h.name, "content-length") or std.ascii.eqlIgnoreCase(h.name, "transfer-encoding")) had_framing = true;
+    }
+
+    for (request.headers) |h| {
+        if (isHopByHop(h.name, request.headers)) continue;
         try w.print("{s}: {s}\r\n", .{ h.name, h.value });
+    }
+    // Regenerate framing rather than forwarding the client's CL/TE (already
+    // stripped above): request.body is always the fully-decoded payload.
+    if (request.body.len > 0 or had_framing) {
+        try w.print("Content-Length: {d}\r\n", .{request.body.len});
     }
     try w.writeAll("\r\n");
     if (request.body.len > 0) try w.writeAll(request.body);
@@ -432,4 +484,117 @@ test "parseUpstreamStatus: malformed status line" {
 test "parseUpstreamStatus: short buffer" {
     try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus(""));
     try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1 2"));
+}
+
+fn testRoute() router_mod.ProxyRoute {
+    return .{
+        .prefix = "/api",
+        .upstream_host = "127.0.0.1",
+        .upstream_port = 3000,
+        .upstream_addr = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable,
+    };
+}
+
+test "buildUpstreamRequest: regenerates Content-Length for a decoded chunked body" {
+    var headers = [_]http.Header{
+        .{ .name = "Transfer-Encoding", .value = "chunked" },
+    };
+    const request = http.Request{
+        .method = "POST",
+        .path = "/upload",
+        .headers = &headers,
+        .body = "hello world",
+        .raw_len = 0,
+    };
+    const built = try buildUpstreamRequest(std.testing.allocator, &request, testRoute(), "/upload");
+    defer std.testing.allocator.free(built);
+
+    try std.testing.expect(std.mem.indexOf(u8, built, "Content-Length: 11\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, built, "Transfer-Encoding") == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, built, "hello world"));
+}
+
+test "buildUpstreamRequest: strips hop-by-hop headers, keeps ordinary ones" {
+    var headers = [_]http.Header{
+        .{ .name = "TE", .value = "trailers" },
+        .{ .name = "Trailer", .value = "X-Foo" },
+        .{ .name = "Upgrade", .value = "websocket" },
+        .{ .name = "Keep-Alive", .value = "timeout=5" },
+        .{ .name = "Proxy-Authorization", .value = "Basic xyz" },
+        .{ .name = "X-Custom", .value = "keep-me" },
+        .{ .name = "Accept", .value = "*/*" },
+    };
+    const request = http.Request{
+        .method = "GET",
+        .path = "/",
+        .headers = &headers,
+        .body = "",
+        .raw_len = 0,
+    };
+    const built = try buildUpstreamRequest(std.testing.allocator, &request, testRoute(), "/");
+    defer std.testing.allocator.free(built);
+
+    for ([_][]const u8{ "TE:", "Trailer:", "Upgrade:", "Keep-Alive:", "Proxy-Authorization:" }) |hop| {
+        try std.testing.expect(std.mem.indexOf(u8, built, hop) == null);
+    }
+    try std.testing.expect(std.mem.indexOf(u8, built, "X-Custom: keep-me\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, built, "Accept: */*\r\n") != null);
+}
+
+test "buildUpstreamRequest: strips headers named as Connection tokens, keeps unnamed ones" {
+    var headers = [_]http.Header{
+        .{ .name = "Connection", .value = "keep-alive, X-Hop" },
+        .{ .name = "X-Hop", .value = "strip-me" },
+        .{ .name = "X-Hop2", .value = "keep-me" },
+    };
+    const request = http.Request{
+        .method = "GET",
+        .path = "/",
+        .headers = &headers,
+        .body = "",
+        .raw_len = 0,
+    };
+    const built = try buildUpstreamRequest(std.testing.allocator, &request, testRoute(), "/");
+    defer std.testing.allocator.free(built);
+
+    try std.testing.expect(std.mem.indexOf(u8, built, "X-Hop:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, built, "X-Hop2: keep-me\r\n") != null);
+}
+
+test "buildUpstreamRequest: honors every Connection header, not just the last" {
+    var headers = [_]http.Header{
+        .{ .name = "Connection", .value = "X-First" },
+        .{ .name = "X-First", .value = "strip-me" },
+        .{ .name = "Connection", .value = "X-Second" },
+        .{ .name = "X-Second", .value = "strip-me-too" },
+    };
+    const request = http.Request{
+        .method = "GET",
+        .path = "/",
+        .headers = &headers,
+        .body = "",
+        .raw_len = 0,
+    };
+    const built = try buildUpstreamRequest(std.testing.allocator, &request, testRoute(), "/");
+    defer std.testing.allocator.free(built);
+
+    try std.testing.expect(std.mem.indexOf(u8, built, "X-First:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, built, "X-Second:") == null);
+}
+
+test "buildUpstreamRequest: GET with no body and no framing headers emits no Content-Length" {
+    var headers = [_]http.Header{
+        .{ .name = "Accept", .value = "*/*" },
+    };
+    const request = http.Request{
+        .method = "GET",
+        .path = "/",
+        .headers = &headers,
+        .body = "",
+        .raw_len = 0,
+    };
+    const built = try buildUpstreamRequest(std.testing.allocator, &request, testRoute(), "/");
+    defer std.testing.allocator.free(built);
+
+    try std.testing.expect(std.mem.indexOf(u8, built, "Content-Length") == null);
 }

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -15,6 +15,7 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Server, TCPSocketListener } from "bun";
 
 const base = () => globalThis.__KEYWAY_BASE;
+const port = () => globalThis.__KEYWAY_PORT;
 const UPSTREAM_PORT = 38291;
 const HUNG_UPSTREAM_PORT = 38292;
 const LARGE_SIZE = 500_000; // ~32 chunks at a 16 KB recv buffer
@@ -42,6 +43,16 @@ beforeAll(() => {
           return new Response(req.headers.get("X-Client-Header") ?? "(none)");
         case "/status500":
           return new Response("upstream error", { status: 500 });
+        case "/dump":
+          // Reflect what the upstream actually received (#170): body plus
+          // presence/value of the framing headers, so the test can assert
+          // the proxy regenerated Content-Length instead of forwarding a
+          // stale Transfer-Encoding alongside an already-de-chunked body.
+          return Response.json({
+            body: await req.text(),
+            contentLength: req.headers.get("content-length"),
+            transferEncoding: req.headers.get("transfer-encoding"),
+          });
         default:
           return new Response("not found", { status: 404 });
       }
@@ -71,7 +82,68 @@ afterAll(() => {
   hungUpstream = null;
 });
 
+// Raw-socket helper (mirrors smuggling.test.ts's rawStatus): fetch() can't
+// hand-roll chunked request framing, and we need that to reach the proxy
+// with a real Transfer-Encoding: chunked request. Resolves as soon as the
+// full response (headers + Content-Length body bytes) has arrived — keyway
+// keeps the client connection alive (only the upstream leg forces
+// Connection: close), so waiting on socket close would just burn the
+// fallback timeout on every run.
+async function rawRequest(request: string): Promise<string> {
+  let buf = "";
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: port(),
+    socket: {
+      data(s, data) {
+        buf += data.toString();
+        const headerEnd = buf.indexOf("\r\n\r\n");
+        if (headerEnd === -1) return;
+        const match = buf.slice(0, headerEnd).match(/content-length:\s*(\d+)/i);
+        const bodyLen = match ? Number(match[1]) : 0;
+        if (buf.length >= headerEnd + 4 + bodyLen) {
+          resolve(buf);
+          s.end();
+        }
+      },
+      close() {
+        resolve(buf);
+      },
+      error(_socket, error) {
+        resolve(buf || String(error));
+      },
+    },
+  });
+  socket.write(request);
+  socket.flush();
+  const resp = await Promise.race([promise, Bun.sleep(2000).then(() => buf)]);
+  socket.end();
+  return resp;
+}
+
 describe("reverse proxy", () => {
+  // (#170) Regression: the parser decodes a chunked request body before
+  // proxy.zig ever sees it, but buildUpstreamRequest used to forward the
+  // client's original Transfer-Encoding: chunked header unchanged and append
+  // the already-decoded body — the upstream then saw a framing header that
+  // didn't match the bytes on the wire. It must regenerate Content-Length
+  // and never forward Transfer-Encoding/Content-Length from the client.
+  test("de-chunks a chunked request body and forwards Content-Length, not Transfer-Encoding", async () => {
+    const raw = await rawRequest(
+      `POST /__keyway/test-proxy/dump HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Transfer-Encoding: chunked\r\n` +
+        `Connection: close\r\n\r\n` +
+        `5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n`,
+    );
+    const bodyStart = raw.indexOf("\r\n\r\n") + 4;
+    const parsed = JSON.parse(raw.slice(bodyStart));
+    expect(parsed.body).toBe("hello world");
+    expect(parsed.contentLength).toBe("11");
+    expect(parsed.transferEncoding).toBeNull();
+  });
+
   test("forwards a small GET and relays the upstream body + headers", async () => {
     const res = await fetch(`${base()}/__keyway/test-proxy/small`);
     expect(res.status).toBe(200);


### PR DESCRIPTION
Closes #170

**Stacked on #181** (base is `kw/169-request-smuggling`; GitHub will retarget to `main` when #181 merges and its branch is deleted). Only the top commit is this PR.

## What

`buildUpstreamRequest` forwarded every client header except `Host`/`Connection` verbatim and appended `request.body`. The parser has already de-chunked the body, so a chunked POST reached upstream with a stale `Transfer-Encoding: chunked` header and non-chunked bytes — upstream parse error or hang-to-504 — and hop-by-hop headers (`TE`, `Trailer`, `Upgrade`, `Keep-Alive`, `Proxy-*`) leaked upstream.

- **Hop-by-hop stripping per RFC 7230 §6.1**: static list plus any header nominated as a connection-option token in *any* of the client's `Connection` headers (repeated Connection headers combine per §3.2.2 — honoring only the last would let an earlier nomination leak).
- **Framing regenerated, never forwarded**: the client's `Content-Length`/`Transfer-Encoding` are always stripped; the proxy emits `Content-Length: {body.len}` when the body is non-empty or the original request carried framing. Combined with #169's parser guarantees (no CL+TE, digit-only CL), the upstream request framing is always self-consistent.
- Host rewrite and forced upstream `Connection: close` unchanged.

## Out of scope, tracked

- Response path relays raw upstream bytes verbatim (hop-by-hop response headers leak to the client) → filed #182.
- Keyway ignores the client's `Connection: close` and unconditionally keep-alives → noted on #180.

## Verify

- 5 unit tests on `buildUpstreamRequest` (chunked→CL regeneration, static hop-by-hop strip, Connection-nominated strip, multi-Connection-header strip, bodyless GET emits no CL).
- Integration: hand-rolled chunked POST through `/__keyway/test-proxy/dump`; the Bun upstream asserts it received the decoded body with `Content-Length: 11` and no `Transfer-Encoding`.
- `zig build test` green; `bun run test:ci` 49 pass / 0 fail.