### PR TITLE
fix(lua): reject out-of-range ctx.status without crossing the C boundary (#172)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -576,6 +576,13 @@ pub const Connection = struct {
             .completed => {
                 self.lua_state.current_connection = null;
 
+                if (exchange.handler_error) |msg| {
+                    log.err().string("msg", "lua handler error").int("fd", self.socket).stringSafe("method", request.method).string("path", clean_path).string("error", msg).log();
+                    self.logAccess(500);
+                    error_response.sendError(self, .server_error, "lua handler error");
+                    return;
+                }
+
                 if (self.tryUpgrade(exchange, request)) return;
 
                 self.logAccess(exchange.status);

--- a/src/http/http_exchange.zig
+++ b/src/http/http_exchange.zig
@@ -34,6 +34,13 @@ pub const HttpExchange = struct {
     // === STREAM UPGRADE (chunked transfer encoding) ===
     upgrade_stream: bool = false,
 
+    // === HANDLER ERROR (set by __newindex on invalid ctx writes, e.g. bad ctx.status) ===
+    // Sticky: first error wins. Checked after a normal (non-yielding) handler return.
+    // ponytail: stream-upgrade and async-resume completions don't consume this —
+    // they proceed with the default status instead of a 500 (no crash either way,
+    // the guard is at the assignment site). Hoist into those paths with #173.
+    handler_error: ?[]const u8 = null,
+
     // === INTERNAL ===
     allocator: std.mem.Allocator,
 

--- a/src/lua/lua_api.zig
+++ b/src/lua/lua_api.zig
@@ -81,7 +81,17 @@ fn luaExchangeNewIndex(lua: *Lua) callconv(.c) c_int {
 
     if (std.mem.eql(u8, key_str, "status")) {
         const status = lua.toInteger(3);
-        ex.status = @intCast(status);
+        if (status < 100 or status > 599) {
+            // Reject, don't clamp or crash: leave ex.status untouched and mark the
+            // exchange failed. dispatchToHandler checks handler_error after a normal
+            // return and sends 500 — a Lua-raised error here can't be safely unwound
+            // through the coroutine (see #186).
+            if (ex.handler_error == null) {
+                ex.handler_error = std.fmt.allocPrint(ex.allocator, "ctx.status: {d} out of range (100-599)", .{status}) catch "ctx.status: out of range (100-599)";
+            }
+        } else {
+            ex.status = @intCast(status);
+        }
     } else if (std.mem.eql(u8, key_str, "body")) {
         const body_span = checkString(lua, 3, "ctx.body: value must be a string");
         // Arena-dupe immediately — Lua string lifetime is unpredictable across yields.
@@ -346,3 +356,52 @@ pub fn registerKeywayModule(lua: *Lua) void {
     log.debug().string("msg", "keyway lua module registered").log();
 }
 
+// (#172) ctx.status out of range must not raise (unsafe to unwind through a coroutine,
+// see #186) — it should leave ex.status untouched and set the sticky handler_error flag.
+test "ctx.status rejects out-of-range values via handler_error, not raiseError" {
+    const allocator = std.testing.allocator;
+
+    const lua = try Lua.init(allocator);
+    defer lua.deinit();
+    registerHttpExchangeMetatable(lua);
+
+    var url_params = params.ParamArray{};
+    var query = params.QueryArray{};
+    var response_headers = try std.ArrayList(http.Header).initCapacity(allocator, 0);
+    defer response_headers.deinit(allocator);
+
+    var exchange = HttpExchange{
+        .method = "GET",
+        .path = "/test",
+        .headers = &[_]http.Header{},
+        .params = &url_params,
+        .query = &query,
+        .body = "",
+        .status = 200,
+        .response_headers = response_headers,
+        .response_body = "",
+        .allocator = allocator,
+    };
+
+    const ud = lua.newUserdata(@sizeOf(*HttpExchange));
+    castUserdata(*HttpExchange, @as(?*anyopaque, ud)).* = &exchange;
+    lua.getMetatableRegistry("HttpExchange");
+    lua.setMetatable(-2);
+    lua.setGlobal("ctx");
+
+    try lua.doString("ctx.status = 70000");
+    try std.testing.expectEqual(@as(u16, 200), exchange.status);
+    try std.testing.expect(exchange.handler_error != null);
+    try std.testing.expect(std.mem.indexOf(u8, exchange.handler_error.?, "70000") != null);
+
+    // Sticky: a second out-of-range write must not overwrite the first error.
+    try lua.doString("ctx.status = -1");
+    try std.testing.expect(std.mem.indexOf(u8, exchange.handler_error.?, "70000") != null);
+    allocator.free(exchange.handler_error.?);
+    exchange.handler_error = null;
+
+    // A fresh, valid assignment still works and leaves handler_error null.
+    try lua.doString("ctx.status = 204");
+    try std.testing.expectEqual(@as(u16, 204), exchange.status);
+    try std.testing.expect(exchange.handler_error == null);
+}

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -3,9 +3,11 @@ import { rawStatus, withServer } from "../harness";
 
 describe("worker resilience regressions", () => {
   // (#172)
-  test.failing("out-of-range Lua status does not kill the next request", async () => {
+  test("out-of-range Lua status does not kill the next request", async () => {
     await withServer(async ({ base }) => {
-      await fetch(`${base}/test/status/70000`).catch(() => null);
+      const bad = await fetch(`${base}/test/status/70000`);
+      expect(bad.status).toBe(500);
+
       const next = await fetch(`${base}/test/hello`);
       expect(next.status).toBe(200);
     });


### PR DESCRIPTION
Closes #172

## What

`ctx.status = 70000` in a tenant handler `@intCast`-panicked in ReleaseSafe and killed the whole worker. The natural fix — validate and raise a Lua error from the `__newindex` metamethod — turned out to be **worse than the bug**: C-raised Lua errors are uncontained in this LuaJIT build and silently `exit(1)` the entire 8-worker process, even under `pcall` (confirmed live against the real binary; filed as #186 with the three pre-existing dormant raise sites and the unwind investigation).

So the design deliberately never crosses the C boundary with an error:

- `luaExchangeNewIndex` validates `100 <= status <= 599` at assignment. Out of range → an arena-allocated message lands in a new sticky `HttpExchange.handler_error` field (first error wins), `ex.status` stays untouched, and the metamethod returns normally — no raise, no longjmp.
- `dispatchToHandler` checks the flag after a completed handler: logged 500 (same shape and metrics as the existing Lua-error catch branch), upgrades skipped — `ctx.status = 70000` + `ctx.upgrade = "websocket"` gets a 500, not a socket.
- Known, deliberate ceiling (`ponytail:` comment on the field): stream-upgrade and async-resume completions don't consume the flag yet — they proceed with the default status. No crash on those paths either (the guard is at the assignment site); hoisting the 500-signal into them is noted on #173, which owns the streaming lifecycle.

## Review highlights (Opus, adversarial)

- Exchange lifecycle verified: fresh `HttpExchange` per request, arena reset on keep-alive — a stale flag can never 500 the next request.
- Coercion edges: `ctx.status = 1e20` (truncates negative) and `ctx.status = "abc"` (coerces 0) are both caught → 500, no crash.
- Log/metrics parity with the existing handler-error path confirmed.

## Verify

- Unit (`lua_api.zig`): exercises the metatable directly with no coroutine/pcall machinery — 70000 and −1 leave `status` untouched and set the sticky message; valid 204 works. `zig build test` 117/117, no leaks.
- Integration (`resilience.test.ts`): the pre-seeded `test.failing` placeholder flipped real — `ctx.status = 70000` route → **500**, follow-up request → **200** (worker survives; this exact scenario killed the whole process under both the original bug and the raise-based fix).
- `bun run test:ci` 50 pass / 0 fail.