### PR TITLE
fix(stream/sse): plug three long-lived-connection resource leaks (#173)

### DIFF
--- a/src/core/conn_sse.zig
+++ b/src/core/conn_sse.zig
@@ -5,6 +5,7 @@ const Connection = handler.Connection;
 const castUserdata = @import("../util/helpers.zig").castUserdata;
 const HttpExchange = @import("../http/http_exchange.zig").HttpExchange;
 const SseRegistry = @import("../protocol/sse.zig").SseRegistry;
+const config = @import("../util/config.zig");
 
 /// SSE connection state — set after successful SSE upgrade.
 /// Holds all SSE-specific fields; Connection.sse_state is ?SseState = null.
@@ -16,12 +17,20 @@ pub const SseState = struct {
     drain_index: usize,
     writing: bool,
     disconnect_completion: xev.Completion,
+    // Buffer currently owned by the in-flight async send (base_allocator),
+    // freed by onSseSendComplete once the write finishes. (#173)
+    in_flight: ?[]const u8 = null,
+    // Bytes queued but not yet sent, not counting in_flight. Caps memory for
+    // a slow consumer — see SSE_MAX_QUEUED_BYTES. (#173)
+    queued_bytes: usize = 0,
 
     /// Clean up SSE state on connection close.
-    /// Order: unsubscribe first (uses room as key), free room, free queue items, deinit queue.
+    /// Order: unsubscribe first (uses room as key), free room, free in-flight
+    /// send buffer, free queue items, deinit queue.
     pub fn deinit(self: *SseState, conn: *Connection) void {
         if (self.registry) |reg| reg.unsubscribe(self.room, conn);
         conn.base_allocator.free(self.room);
+        if (self.in_flight) |buf| conn.base_allocator.free(buf);
         for (self.send_queue.items[self.drain_index..]) |queued| conn.base_allocator.free(queued);
         self.send_queue.deinit(conn.base_allocator);
     }
@@ -115,9 +124,17 @@ fn onSseDisconnect(
 }
 
 /// Queue an SSE event for sending. Called by SseRegistry.broadcast.
+/// A subscriber that isn't draining fast enough (queued_bytes exceeds the
+/// cap) is disconnected rather than buffered further — dropping individual
+/// events would silently corrupt the stream. (#173)
 pub fn submitSseSend(self: *Connection, data: []const u8) void {
     if (self.state == .closing) return;
     const ss = &self.sse_state.?;
+
+    if (ss.queued_bytes + data.len > config.SSE_MAX_QUEUED_BYTES) {
+        self.close();
+        return;
+    }
 
     // Dupe data into base_allocator (caller's data is temporary)
     const duped = self.base_allocator.dupe(u8, data) catch return;
@@ -125,6 +142,7 @@ pub fn submitSseSend(self: *Connection, data: []const u8) void {
         self.base_allocator.free(duped);
         return;
     };
+    ss.queued_bytes += duped.len;
     if (!ss.writing) {
         drainSseQueue(self);
     }
@@ -145,12 +163,17 @@ pub fn drainSseQueue(self: *Connection) void {
     const data = ss.send_queue.items[ss.drain_index];
     ss.drain_index += 1;
     ss.writing = true;
+    ss.queued_bytes -= data.len;
 
-    self.submitSend(data, onSseSendComplete, true);
-    self.base_allocator.free(data);
+    // No arena dupe: the SSE connection's arena is never reset for its
+    // lifetime (long-lived), so an arena copy per event would leak. Send the
+    // base_allocator buffer directly and free it once the write completes. (#173)
+    ss.in_flight = data;
+    self.submitSend(data, onSseSendComplete, false);
 }
 
-/// Callback after SSE event chunk is sent — drain next from queue.
+/// Callback after SSE event chunk is sent — free the in-flight buffer, then
+/// drain next from queue.
 fn onSseSendComplete(
     userdata: ?*anyopaque,
     loop: *xev.Loop,
@@ -160,6 +183,13 @@ fn onSseSendComplete(
     _ = loop;
     _ = completion;
     const self = castUserdata(Connection, userdata);
+    const ss = &self.sse_state.?;
+    // Free before handleSendCompletion: on error it may close+deinit self
+    // synchronously, after which self is no longer safe to touch.
+    if (ss.in_flight) |buf| {
+        self.base_allocator.free(buf);
+        ss.in_flight = null;
+    }
     _ = self.handleSendCompletion(result) orelse return .disarm;
     drainSseQueue(self);
     return .disarm;

--- a/src/core/conn_stream.zig
+++ b/src/core/conn_stream.zig
@@ -16,6 +16,7 @@ const http = @import("../http/http.zig");
 const castUserdata = @import("../util/helpers.zig").castUserdata;
 const Lua = @import("luajit").Lua;
 const c = @import("luajit_c");
+const prom = @import("../observability/prom.zig");
 
 /// Stream connection state — set after successful stream upgrade.
 pub const StreamState = struct {
@@ -130,6 +131,16 @@ pub fn handleStreamPostWrite(self: *Connection) void {
                     const err_msg = thread.toString(-1) catch "unknown error";
                     log.err().string("msg", "stream handler error").int("fd", self.socket).string("error", std.mem.span(err_msg)).log();
                 }
+                // Errored coroutine is permanently dead (not reusable) — unref
+                // it and match dispatchCoroutine's start-of-request increment.
+                // Must happen before close(), which can synchronously deinit
+                // (deinit would otherwise see stream_state still set and
+                // double-handle it).
+                prom.luaCoroutineFinished();
+                if (ss.coroutine_ref != 0) {
+                    self.lua_state.lua.unref(Lua.PseudoIndex.Registry, ss.coroutine_ref);
+                }
+                self.stream_state = null;
                 self.close();
                 return;
             },
@@ -141,6 +152,8 @@ pub fn handleStreamPostWrite(self: *Connection) void {
 fn sendTerminalChunk(self: *Connection) void {
     // Return coroutine to cache
     const ss = self.stream_state.?;
+    // Match dispatchCoroutine's start-of-request increment (prom.luaCoroutineStarted).
+    prom.luaCoroutineFinished();
     if (ss.coroutine_ref != 0) {
         if (self.lua_state.cached_thread_ref == 0) {
             self.lua_state.cached_thread_ref = ss.coroutine_ref;

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -242,6 +242,17 @@ pub const Connection = struct {
             if (wss.on_close_ref != 0) self.lua_state.lua.unref(Lua.PseudoIndex.Registry, wss.on_close_ref);
             if (wss.fragment_buf) |*fb| fb.deinit(self.arena.allocator());
         }
+        // Clean up stream state if connection closes while a stream coroutine
+        // is still suspended mid-yield (never reached sendTerminalChunk or the
+        // Lua-error path, which both already unref + decrement themselves).
+        // Unref the pinned coroutine (Lua registry leak) and match
+        // dispatchCoroutine's start-of-request increment (#173).
+        if (self.stream_state) |*ss| {
+            prom.luaCoroutineFinished();
+            if (ss.coroutine_ref != 0) {
+                self.lua_state.lua.unref(Lua.PseudoIndex.Registry, ss.coroutine_ref);
+            }
+        }
         // Clean up SSE state
         if (self.sse_state) |*ss| ss.deinit(self);
         // Clean up static file state

--- a/src/util/config.zig
+++ b/src/util/config.zig
@@ -58,6 +58,11 @@ pub const STATIC_MAX_SIZE: u64 = 100 * 1024 * 1024;
 /// combined, not per-op). Requests exceeding this get 504.
 pub const PROXY_UPSTREAM_TIMEOUT_MS: u64 = 30_000;
 
+/// Maximum bytes queued for a single SSE subscriber awaiting drain (1 MB, #173).
+/// A slow consumer that exceeds this is disconnected rather than buffered
+/// further — dropping individual events would silently corrupt the stream.
+pub const SSE_MAX_QUEUED_BYTES: usize = 1_048_576;
+
 comptime {
     // Buffer sizes must be at least 4096 for reasonable HTTP operation
     if (READ_BUFFER_SIZE < 4096)

--- a/tests/integration/sse.test.ts
+++ b/tests/integration/sse.test.ts
@@ -1,6 +1,17 @@
 import { describe, test, expect } from "bun:test";
 
 const base = () => globalThis.__KEYWAY_BASE;
+const port = () => globalThis.__KEYWAY_PORT;
+
+/// Read a single-series Prometheus gauge value (worker_id="0", single-worker
+/// test server) from /metrics.
+async function readGauge(name: string): Promise<number> {
+  const res = await fetch(`${base()}/metrics`);
+  const text = await res.text();
+  const match = text.match(new RegExp(`${name}\\{worker_id="0"\\} (\\d+)`));
+  if (!match) throw new Error(`metric ${name} not found in /metrics output`);
+  return Number(match[1]);
+}
 
 describe("sse", () => {
   test("GET /test/sse returns event stream, POST /test/broadcast delivers events", async () => {
@@ -43,4 +54,52 @@ describe("sse", () => {
 
     expect(collected).toContain("test-payload");
   });
+
+  // (#173) A subscriber that never drains its queue must be disconnected
+  // once its backlog exceeds SSE_MAX_QUEUED_BYTES, not buffered forever.
+  // close() decrements keyway_connections_active synchronously, so that
+  // gauge returning to baseline is our signal the server dropped it.
+  test("SSE slow consumer is disconnected rather than growing unbounded", async () => {
+    const baseline = await readGauge("keyway_connections_active");
+
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: port(),
+      socket: {
+        open(s) {
+          s.write(
+            `GET /test/sse HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\nConnection: keep-alive\r\n\r\n`,
+          );
+          s.flush();
+          // Never drain the response — simulate a stalled consumer so the
+          // server's queued backlog for this connection can only grow.
+          s.pause();
+        },
+        data() {},
+        close() {},
+        error() {},
+      },
+    });
+
+    try {
+      // Comfortably over SSE_MAX_QUEUED_BYTES (1 MB) and past typical kernel
+      // receive-buffer defaults, so the paused socket forces real backpressure.
+      const payload = "x".repeat(50_000);
+      const maxBroadcasts = 200;
+      let disconnected = false;
+      for (let i = 0; i < maxBroadcasts && !disconnected; i++) {
+        await fetch(`${base()}/test/broadcast`, { method: "POST", body: payload });
+        if (i % 5 === 0) {
+          disconnected = (await readGauge("keyway_connections_active")) === baseline;
+        }
+      }
+      if (!disconnected) {
+        disconnected = (await readGauge("keyway_connections_active")) === baseline;
+      }
+
+      expect(disconnected).toBe(true);
+    } finally {
+      socket.terminate();
+    }
+  }, 20000);
 });

--- a/tests/integration/streaming.test.ts
+++ b/tests/integration/streaming.test.ts
@@ -1,6 +1,17 @@
 import { describe, test, expect } from "bun:test";
 
 const base = () => globalThis.__KEYWAY_BASE;
+const port = () => globalThis.__KEYWAY_PORT;
+
+/// Read a single-series Prometheus gauge value (worker_id="0", single-worker
+/// test server) from /metrics.
+async function readGauge(name: string): Promise<number> {
+  const res = await fetch(`${base()}/metrics`);
+  const text = await res.text();
+  const match = text.match(new RegExp(`${name}\\{worker_id="0"\\} (\\d+)`));
+  if (!match) throw new Error(`metric ${name} not found in /metrics output`);
+  return Number(match[1]);
+}
 
 describe("streaming", () => {
   test("GET /test/stream returns chunked body with all chunks", async () => {
@@ -10,5 +21,58 @@ describe("streaming", () => {
     expect(body).toContain("chunk1");
     expect(body).toContain("chunk2");
     expect(body).toContain("chunk3");
+  });
+
+  // (#173) Disconnecting mid-stream must not leak the stream coroutine: the
+  // Lua registry ref (Connection.deinit) and the active-coroutine gauge
+  // (dispatchCoroutine's start / the terminal transitions in conn_stream.zig)
+  // must stay paired even when the connection never reaches sendTerminalChunk.
+  test("stream requests disconnected mid-stream do not leak keyway_lua_coroutines_active", async () => {
+    const baseline = await readGauge("keyway_lua_coroutines_active");
+
+    const rounds = 10;
+    for (let i = 0; i < rounds; i++) {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      let acted = false;
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: port(),
+        socket: {
+          open(s) {
+            s.write(
+              `GET /test/stream HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\nConnection: keep-alive\r\n\r\n`,
+            );
+            s.flush();
+          },
+          data(s) {
+            // First bytes back mean the coroutine has already yielded at
+            // least once (mid-stream) — RST it now rather than let it
+            // finish, so the server is forced through the abnormal-close path.
+            if (!acted) {
+              acted = true;
+              s.terminate();
+            }
+          },
+          close() {
+            resolve();
+          },
+          error() {
+            resolve();
+          },
+        },
+      });
+      await promise;
+    }
+
+    // Give the server a moment to observe the RSTs and clean up.
+    let observed = baseline;
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      observed = await readGauge("keyway_lua_coroutines_active");
+      if (observed === baseline) break;
+      await Bun.sleep(100);
+    }
+
+    expect(observed).toBe(baseline);
   });
 });


### PR DESCRIPTION
Closes #173

Three resource leaks on long-lived streaming/SSE connections.

## 1. `stream_state.coroutine_ref` never freed → Lua registry leak
`Connection.deinit` cleaned every other sub-state but not `stream_state`. The stream path deliberately never sets `self.suspended`, so the coroutine lived only in `stream_state.coroutine_ref` — any abnormal end (client disconnect mid-stream, `encodeChunk` OOM, Lua error between yields, `forceCloseAll`) leaked that registry ref. Now `deinit` unrefs it, matching the existing `suspended`/`ws_state` pattern.

## 2. `keyway_lua_coroutines_active` drifted upward
Root cause was worse than "abnormal ends leak it": the stream resume loop uses raw `c.lua_resume` and bypasses `resumeHandler` (where WS/SSE get their decrement), so the gauge **never** decremented for a stream — one permanent leak per streaming request. Fixed at all three mutually-exclusive terminal transitions (normal completion, Lua error, still-suspended teardown), **exactly once** by nulling `stream_state` before any `close()`/`submitSend` that can synchronously reach `deinit` — the nulling is the guard, no bool flag needed. Increment unchanged.

## 3. SSE slow consumer → unbounded memory
`send_queue` was uncapped and every event was `arena_dupe`'d into the connection arena, which is never reset for an SSE connection's lifetime — a subscriber that stops reading grew memory until OOM. Now: `config.SSE_MAX_QUEUED_BYTES` (1MB) cap, checked **before** the copy, disconnects the slow consumer on exceed (dropping SSE events silently corrupts the stream, so disconnect is the honest choice); and `drainSseQueue` sends with `arena_dupe=false` + a single `in_flight` buffer freed on send-complete (freed-and-nulled, so `SseState.deinit`'s safety-net free can't double-free).

## Review (Opus, adversarial)
Every termination path traced; confirmed exactly-once decrement (no double/never-decrement), no `in_flight` double-free, both UAF orderings correct (free/null before the call that can synchronously deinit), cap checked before allocation. Both new tests fail pre-fix (real regression guards).

## Verify
- `streaming.test.ts`: 10 mid-stream RST'd requests → `keyway_lua_coroutines_active` returns to baseline (leaked +1/request before).
- `sse.test.ts`: a paused SSE client under heavy broadcast → server disconnects it (bounded), observed via `connections_active`.
- `zig build test` green; `bun run test:ci` **52 pass / 0 fail**.