### PR TITLE
fix(ws): enforce RFC 6455 conformance (#175)

### DIFF
--- a/src/core/conn_ws.zig
+++ b/src/core/conn_ws.zig
@@ -22,14 +22,63 @@ pub const WsState = struct {
     fragment_opcode: ws.Opcode = .text,
 };
 
+/// True if the comma-separated header `value` contains `token` (case-insensitive).
+/// RFC 6455 §4.2.1 rules 5-6 phrase the Upgrade/Connection checks this way.
+fn headerHasToken(value: []const u8, token: []const u8) bool {
+    var it = std.mem.splitScalar(u8, value, ',');
+    while (it.next()) |part| {
+        if (std.ascii.eqlIgnoreCase(std.mem.trim(u8, part, " \t"), token)) return true;
+    }
+    return false;
+}
+
 /// Validate upgrade request, build 101 response, store WsState, send it.
 pub fn handleWsUpgrade(conn: *Connection, exchange: *HttpExchange, request: *const http.Request) !void {
+    // ctx.on_message/on_close are ref'd into the Lua registry before this
+    // runs (lua_api.zig). The success path below moves those refs into
+    // conn.ws_state and zeroes the exchange copies; every other return from
+    // this function is a rejected handshake, and nothing else ever unrefs
+    // the exchange copies — so free them here on any path that doesn't
+    // zero them first. No-op on success.
+    const lua = conn.lua_state.lua;
+    defer {
+        if (exchange.ws_on_message_ref != 0) lua.unref(Lua.PseudoIndex.Registry, exchange.ws_on_message_ref);
+        if (exchange.ws_on_close_ref != 0) lua.unref(Lua.PseudoIndex.Registry, exchange.ws_on_close_ref);
+    }
+
+    // RFC 6455 §4.2.1 rule 1: the request line MUST be GET.
+    if (!std.mem.eql(u8, request.method, "GET")) {
+        return error.InvalidWsMethod;
+    }
+
+    const alloc = conn.arena.allocator();
+
+    // RFC 6455 §4.4: on an unsupported version, respond 426 with the
+    // version we support instead of failing the handshake generically.
+    const version_hdr = http.Parser.getHeader(request, "Sec-WebSocket-Version");
+    const version = if (version_hdr) |v| std.mem.trim(u8, v, " \t") else null;
+    if (version == null or !std.mem.eql(u8, version.?, "13")) {
+        var resp = http.Response.init(alloc);
+        resp.status = 426;
+        try resp.addHeader("Sec-WebSocket-Version", "13");
+        try resp.addHeader("Connection", "close");
+        conn.logAccess(426);
+        try conn.writeResponseDirect(&resp);
+        return;
+    }
+
+    // RFC 6455 §4.2.1 rules 5-6: Upgrade/Connection headers must carry the
+    // upgrade tokens (case-insensitive, possibly comma-separated).
+    const upgrade_hdr = http.Parser.getHeader(request, "Upgrade") orelse return error.MissingUpgradeHeader;
+    if (!headerHasToken(upgrade_hdr, "websocket")) return error.InvalidUpgradeHeader;
+
+    const connection_hdr = http.Parser.getHeader(request, "Connection") orelse return error.MissingConnectionHeader;
+    if (!headerHasToken(connection_hdr, "upgrade")) return error.InvalidConnectionHeader;
+
     // Validate Sec-WebSocket-Key header
     const sec_key = http.Parser.getHeader(request, "Sec-WebSocket-Key") orelse {
         return error.MissingWebSocketKey;
     };
-
-    const alloc = conn.arena.allocator();
 
     // Compute accept key
     var accept_key: [28]u8 = undefined;
@@ -192,9 +241,21 @@ pub fn processWsFrames(conn: *Connection) void {
 
                 // Handle control frames immediately (RFC 6455 §5.5):
                 // control frames can be interleaved during fragmentation
+                if ((f.frame.opcode == .ping or f.frame.opcode == .pong or f.frame.opcode == .close) and
+                    (!f.frame.fin or f.frame.payload.len > 125))
+                {
+                    // RFC 6455 §5.5: control frames MUST NOT be fragmented
+                    // and MUST carry a payload of 125 bytes or fewer.
+                    sendWsClose(conn, 1002);
+                    return;
+                }
+
                 switch (f.frame.opcode) {
                     .ping => {
-                        sendWsFrame(conn, .pong, f.frame.payload);
+                        sendWsFrame(conn, .pong, f.frame.payload) catch {
+                            sendWsClose(conn, 1002);
+                            return;
+                        };
                         continue;
                     },
                     .pong => continue,
@@ -214,7 +275,7 @@ pub fn processWsFrames(conn: *Connection) void {
                             sendWsClose(conn, 1002);
                             return;
                         }
-                        dispatchWsMessage(conn, f.frame.payload);
+                        dispatchWsMessage(conn, f.frame.payload, f.frame.opcode == .text);
                         return;
                     }
                     // First fragment of a multi-frame message
@@ -261,7 +322,7 @@ pub fn processWsFrames(conn: *Connection) void {
                         defer conn.base_allocator.free(payload);
                         fb.deinit(conn.arena.allocator());
                         wss.fragment_buf = null;
-                        dispatchWsMessage(conn, payload);
+                        dispatchWsMessage(conn, payload, wss.fragment_opcode == .text);
                         return;
                     }
                 } else {
@@ -277,13 +338,23 @@ pub fn processWsFrames(conn: *Connection) void {
 }
 
 /// Dispatch a WebSocket message to the Lua on_message callback as a fresh coroutine.
-fn dispatchWsMessage(conn: *Connection, payload: []const u8) void {
+/// `is_text` is true for a (possibly reassembled) text message; binary messages
+/// are exempt from UTF-8 validation.
+fn dispatchWsMessage(conn: *Connection, payload: []const u8, is_text: bool) void {
     log.debug().string("msg", "ws dispatchWsMessage").int("payload_len", payload.len).log();
     const wss = conn.ws_state orelse {
         log.err().string("msg", "ws no ws_state, closing").log();
         conn.close();
         return;
     };
+
+    // RFC 6455 §8.1: a text message — including one reassembled from
+    // continuation frames — must be valid UTF-8, checked on the reassembled
+    // result since a multi-byte codepoint may split across fragments.
+    if (is_text and !std.unicode.utf8ValidateSlice(payload)) {
+        sendWsClose(conn, 1007);
+        return;
+    }
 
     if (wss.on_message_ref == 0) {
         // No callback registered — just continue reading
@@ -393,11 +464,13 @@ pub fn routeWsYield(conn: *Connection) void {
     }
 }
 
-/// Send a WS frame directly (for pong, close responses).
-fn sendWsFrame(conn: *Connection, opcode: ws.Opcode, payload: []const u8) void {
-    var frame_buf: [128 + ws.MAX_FRAME_OVERHEAD]u8 = undefined;
-    const truncated = if (payload.len > 128) payload[0..128] else payload;
-    const frame_len = ws.serializeFrame(opcode, truncated, &frame_buf);
+/// Send a WS control frame (currently only pong). RFC 6455 §5.5: control-frame
+/// payloads MUST be 125 bytes or fewer — reject rather than silently
+/// truncate, since truncating a pong would echo the wrong payload back.
+fn sendWsFrame(conn: *Connection, opcode: ws.Opcode, payload: []const u8) !void {
+    if (payload.len > 125) return error.ControlFramePayloadTooLarge;
+    var frame_buf: [125 + ws.MAX_FRAME_OVERHEAD]u8 = undefined;
+    const frame_len = ws.serializeFrame(opcode, payload, &frame_buf);
 
     conn.submitSend(frame_buf[0..frame_len], onWsControlSent, true);
 }
@@ -445,8 +518,43 @@ fn onWsCloseSent(
     return .disarm;
 }
 
+/// RFC 6455 §7.4.1: valid application close codes. 1004-1006 and 1012-1015
+/// are reserved and MUST NOT appear on the wire; 3000-4999 are
+/// library/framework-registered or private-use.
+fn isValidCloseCode(code: u16) bool {
+    return switch (code) {
+        1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011 => true,
+        3000...4999 => true,
+        else => false,
+    };
+}
+
 /// Handle incoming close frame — fire on_close, echo close back, disconnect.
 fn handleWsClose(conn: *Connection, payload: []const u8) void {
+    // RFC 6455 §7.4.1: a close code, if present, must be a 2-byte payload;
+    // a lone 1-byte payload is a protocol error.
+    if (payload.len == 1) {
+        sendWsClose(conn, 1002);
+        return;
+    }
+
+    const status_code: u16 = if (payload.len >= 2)
+        std.mem.readInt(u16, payload[0..2], .big)
+    else
+        1000;
+
+    if (payload.len >= 2 and !isValidCloseCode(status_code)) {
+        sendWsClose(conn, 1002);
+        return;
+    }
+
+    // RFC 6455 §7.4.1 / Autobahn 7.5.1: the close reason, if present, must
+    // be valid UTF-8.
+    if (payload.len > 2 and !std.unicode.utf8ValidateSlice(payload[2..])) {
+        sendWsClose(conn, 1007);
+        return;
+    }
+
     // Fire on_close callback if registered
     if (conn.ws_state) |wss| {
         if (wss.on_close_ref != 0) {
@@ -455,12 +563,6 @@ fn handleWsClose(conn: *Connection, payload: []const u8) void {
             lua.callProtected(0, 0, 0) catch {};
         }
     }
-
-    // Extract status code from payload (first 2 bytes) or default to 1000
-    const status_code: u16 = if (payload.len >= 2)
-        std.mem.readInt(u16, payload[0..2], .big)
-    else
-        1000;
 
     // Echo close frame back, then disconnect (onWsCloseSent calls conn.close())
     sendWsClose(conn, status_code);

--- a/src/protocol/ws.zig
+++ b/src/protocol/ws.zig
@@ -23,7 +23,8 @@ pub const ParseResult = union(enum) {
 };
 
 /// Parse a single WebSocket frame from data. Unmasking is done in-place.
-/// Client frames MUST be masked per RFC 6455.
+/// Client frames MUST be masked per RFC 6455 §5.1 (unmasked -> protocol
+/// error). RSV1-3 must be unset since we negotiate no extensions (§5.2).
 pub fn parseFrame(data: []u8) !ParseResult {
     if (data.len < 2) return .incomplete;
 
@@ -31,6 +32,9 @@ pub fn parseFrame(data: []u8) !ParseResult {
     const b1 = data[1];
 
     const fin = (b0 & 0x80) != 0;
+    // RFC 6455 §5.2: RSV1-3 (bits 0x40, 0x20, 0x10) are reserved for
+    // extensions; we negotiate none, so a client setting any is a protocol error.
+    if (b0 & 0x70 != 0) return error.ReservedBitsSet;
     const opcode: Opcode = @enumFromInt(@as(u4, @truncate(b0 & 0x0F)));
     const masked = (b1 & 0x80) != 0;
     var payload_len: u64 = b1 & 0x7F;
@@ -68,14 +72,9 @@ pub fn parseFrame(data: []u8) !ParseResult {
             .consumed = end,
         } };
     } else {
-        const end = std.math.add(usize, pos, payload_len_usize) catch return error.FrameTooLarge;
-        if (data.len < end) return .incomplete;
-
-        const payload = data[pos..end];
-        return .{ .frame = .{
-            .frame = .{ .fin = fin, .opcode = opcode, .payload = payload },
-            .consumed = end,
-        } };
+        // RFC 6455 §5.1: a server MUST close the connection upon receiving
+        // an unmasked frame from a client.
+        return error.UnmaskedFrame;
     }
 }
 
@@ -168,22 +167,24 @@ test "parseFrame - rejects oversized 64-bit length" {
     try std.testing.expectError(error.FrameTooLarge, parseFrame(&data));
 }
 
-test "parseFrame - unmasked ping" {
+test "parseFrame - unmasked frame rejected (#175)" {
+    // RFC 6455 §5.1: server MUST close on an unmasked client frame.
     var data = [_]u8{
         0x89, // FIN + ping
         0x00, // no mask, len=0
     };
+    try std.testing.expectError(error.UnmaskedFrame, parseFrame(&data));
+}
 
-    const result = try parseFrame(&data);
-    switch (result) {
-        .frame => |f| {
-            try std.testing.expect(f.frame.fin);
-            try std.testing.expectEqual(Opcode.ping, f.frame.opcode);
-            try std.testing.expectEqual(@as(usize, 0), f.frame.payload.len);
-            try std.testing.expectEqual(@as(usize, 2), f.consumed);
-        },
-        .incomplete => return error.TestUnexpectedResult,
-    }
+test "parseFrame - RSV bit set rejected (#175)" {
+    // RFC 6455 §5.2: RSV1-3 must be unset; we negotiate no extensions.
+    var data = [_]u8{
+        0xC1, // FIN + RSV1 + text
+        0x82, // MASK + len=2
+        0x37, 0xfa, 0x21, 0x3d, // mask key
+        'H' ^ 0x37, 'i' ^ 0xfa, // masked payload
+    };
+    try std.testing.expectError(error.ReservedBitsSet, parseFrame(&data));
 }
 
 test "serializeFrame - small text" {

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -4,11 +4,12 @@ const PROJECT_ROOT = resolve(import.meta.dir, "..");
 const BINARY = resolve(PROJECT_ROOT, "zig-out/bin/keyway");
 const SCRIPT = resolve(PROJECT_ROOT, "tests/fixtures.lua");
 
-/// Send a raw HTTP request over its own socket and return the response status
-/// code. Bypasses fetch()'s connection pooling — needed when a test wants a
+/// Send a raw HTTP request over its own socket and return the full response
+/// text (status line + headers, and body if it arrived before the deadline).
+/// Bypasses fetch()'s connection pooling — needed when a test wants a
 /// guaranteed-fresh connection (e.g. checking behavior after a response that
 /// advertises `Connection: close`, see #180).
-export async function rawStatus(port: number, request: string): Promise<number> {
+export async function rawResponse(port: number, request: string): Promise<string> {
   let buf = "";
   const { promise, resolve } = Promise.withResolvers<string>();
   const socket = await Bun.connect({
@@ -34,6 +35,12 @@ export async function rawStatus(port: number, request: string): Promise<number> 
   socket.flush();
   const resp = await Promise.race([promise, Bun.sleep(1500).then(() => "")]);
   socket.end();
+  return resp;
+}
+
+/// Same as `rawResponse`, but returns just the status code.
+export async function rawStatus(port: number, request: string): Promise<number> {
+  const resp = await rawResponse(port, request);
   return Number(resp.split(" ")[1]);
 }
 

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { withServer } from "../harness";
+import { rawResponse, rawStatus, withServer } from "../harness";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -71,6 +71,9 @@ async function openRawWs(port: number) {
     socket,
     readText: () => waitFor(() => readFrame(bytes, 0x1)),
     readClose: () => waitFor(() => (closed || readFrame(bytes, 0x8) !== null ? true : null)),
+    // (#175) Parses the close frame's 2-byte big-endian status code instead
+    // of just detecting that a close happened.
+    readCloseCode: () => waitFor(() => readCloseCode(bytes)),
   };
 }
 
@@ -94,24 +97,63 @@ function readFrame(bytes: number[], opcode: number): string | null {
   return decoder.decode(payload);
 }
 
-function clientFrame(opcode: number, data: string, fin = true): Uint8Array {
-  const payload = encoder.encode(data);
+// (#175) Reads a close frame (opcode 0x8) and returns its status code, or 0
+// if the close carried no payload. Returns null while more data is needed.
+function readCloseCode(bytes: number[]): number | null {
+  if (bytes.length < 2) return null;
+  let len = bytes[1] & 0x7f;
+  let pos = 2;
+  if (len === 126) {
+    if (bytes.length < 4) return null;
+    len = (bytes[2] << 8) | bytes[3];
+    pos = 4;
+  } else if (len === 127) {
+    if (bytes.length < 10) return null;
+    len = Number(new DataView(Uint8Array.from(bytes.slice(2, 10)).buffer).getBigUint64(0));
+    pos = 10;
+  }
+  if (bytes.length < pos + len) return null;
+  if ((bytes[0] & 0x0f) !== 0x8) return null;
+  const payload = bytes.slice(pos, pos + len);
+  bytes.splice(0, pos + len);
+  if (payload.length < 2) return 0;
+  return (payload[0] << 8) | payload[1];
+}
+
+// (#175) General raw-frame builder taking an explicit byte payload (rather
+// than a UTF-8 string) plus fin/mask/rsv knobs, needed to construct frames
+// that are invalid by construction (unmasked, reserved bits, bad UTF-8).
+function frameBytes(
+  opcode: number,
+  payload: Uint8Array,
+  opts: { fin?: boolean; masked?: boolean; rsv?: number } = {},
+): Uint8Array {
+  const { fin = true, masked = true, rsv = 0 } = opts;
   const header = payload.length < 126 ? 2 : payload.length <= 65535 ? 4 : 10;
-  const out = new Uint8Array(header + 4 + payload.length);
-  out[0] = (fin ? 0x80 : 0) | opcode;
+  const out = new Uint8Array(header + (masked ? 4 : 0) + payload.length);
+  out[0] = (fin ? 0x80 : 0) | (rsv & 0x70) | opcode;
+  const maskBit = masked ? 0x80 : 0;
   if (payload.length < 126) {
-    out[1] = 0x80 | payload.length;
+    out[1] = maskBit | payload.length;
   } else if (payload.length <= 65535) {
-    out[1] = 0x80 | 126;
+    out[1] = maskBit | 126;
     out[2] = payload.length >> 8;
     out[3] = payload.length & 0xff;
   } else {
-    out[1] = 0x80 | 127;
+    out[1] = maskBit | 127;
     new DataView(out.buffer).setBigUint64(2, BigInt(payload.length));
   }
-  out.set([1, 2, 3, 4], header);
-  for (let i = 0; i < payload.length; i++) out[header + 4 + i] = payload[i] ^ out[header + (i % 4)];
+  if (masked) {
+    out.set([1, 2, 3, 4], header);
+    for (let i = 0; i < payload.length; i++) out[header + 4 + i] = payload[i] ^ out[header + (i % 4)];
+  } else {
+    out.set(payload, header);
+  }
   return out;
+}
+
+function clientFrame(opcode: number, data: string, fin = true): Uint8Array {
+  return frameBytes(opcode, encoder.encode(data), { fin });
 }
 
 describe("websocket adversarial framing", () => {
@@ -157,6 +199,162 @@ describe("websocket adversarial framing", () => {
       ws.socket.flush();
       expect(await ws.readText()).toBe("hello ws");
       ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §5.1: a server MUST close on an unmasked client frame.
+  test("closes with 1002 on an unmasked client frame", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(frameBytes(0x1, encoder.encode("hi"), { masked: false }));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1002);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §5.2: RSV1-3 are reserved; we negotiate no extensions.
+  test("closes with 1002 when a client frame sets a reserved bit", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(frameBytes(0x1, encoder.encode("hi"), { rsv: 0x40 }));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1002);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §8.1: a text frame's payload must be valid UTF-8.
+  test("closes with 1007 on a text frame with invalid UTF-8", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(frameBytes(0x1, new Uint8Array([0xff, 0xfe, 0xfd])));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1007);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) UTF-8 validity is checked on the reassembled message, since a
+  // multi-byte codepoint can legitimately split across fragment boundaries —
+  // this fragmentation makes the reassembled result invalid regardless.
+  test("closes with 1007 on a fragmented message with invalid reassembled UTF-8", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(frameBytes(0x1, new Uint8Array([0x68, 0x65]), { fin: false })); // "he"
+      ws.socket.write(frameBytes(0x0, new Uint8Array([0xff]), { fin: true })); // invalid byte
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1007);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §5.5: control frames MUST NOT be fragmented.
+  test("closes with 1002 on a fragmented control frame", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x9, "hi", false)); // ping, FIN=0
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1002);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §5.5: control-frame payloads MUST be 125 bytes or fewer.
+  test("closes with 1002 on an oversized ping payload", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x9, "x".repeat(126)));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1002);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §7.4.1: a close code, if present, must be 2 bytes.
+  test("closes with 1002 on a close frame with a 1-byte payload", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x8, "A"));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1002);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) RFC 6455 §7.4.1: 1005 is reserved and MUST NOT appear on the wire.
+  test("closes with 1002 on a reserved close code", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      const payload = new Uint8Array(2);
+      new DataView(payload.buffer).setUint16(0, 1005);
+      ws.socket.write(frameBytes(0x8, payload));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1002);
+      ws.socket.end();
+    });
+  });
+
+  // (#175) Autobahn 7.5.1: the close reason (bytes after the 2-byte code)
+  // must be valid UTF-8.
+  test("closes with 1007 on a close frame with a non-UTF8 reason", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      const payload = new Uint8Array([0x03, 0xe8, 0xff, 0xfe]); // code 1000 + invalid UTF-8 reason
+      ws.socket.write(frameBytes(0x8, payload));
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1007);
+      ws.socket.end();
+    });
+  });
+});
+
+describe("websocket handshake validation (#175)", () => {
+  test("responds 426 with Sec-WebSocket-Version when the version is missing", async () => {
+    await withServer(async ({ port }) => {
+      const resp = await rawResponse(
+        port,
+        `GET /test/ws HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${port}\r\n` +
+          `Upgrade: websocket\r\n` +
+          `Connection: Upgrade\r\n` +
+          `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n`,
+      );
+      expect(resp.startsWith("HTTP/1.1 426")).toBe(true);
+      expect(resp.toLowerCase()).toContain("sec-websocket-version: 13");
+    });
+  });
+
+  test("responds 426 on an unsupported Sec-WebSocket-Version", async () => {
+    await withServer(async ({ port }) => {
+      const status = await rawStatus(
+        port,
+        `GET /test/ws HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${port}\r\n` +
+          `Upgrade: websocket\r\n` +
+          `Connection: Upgrade\r\n` +
+          `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n` +
+          `Sec-WebSocket-Version: 8\r\n\r\n`,
+      );
+      expect(status).toBe(426);
+    });
+  });
+
+  // The router only registers GET for /test/ws (tests/fixtures.lua), so a
+  // POST 404s before conn_ws.handleWsUpgrade's own method check ever runs —
+  // this still proves a non-GET request is never upgraded.
+  test("does not upgrade a non-GET request", async () => {
+    await withServer(async ({ port }) => {
+      const status = await rawStatus(
+        port,
+        `POST /test/ws HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${port}\r\n` +
+          `Upgrade: websocket\r\n` +
+          `Connection: Upgrade\r\n` +
+          `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n` +
+          `Sec-WebSocket-Version: 13\r\n\r\n`,
+      );
+      expect(status).toBe(404);
     });
   });
 });


### PR DESCRIPTION
Closes #175

Server-side RFC 6455 conformance in `src/protocol/ws.zig` / `src/core/conn_ws.zig`. Six sub-items, each independently small:

- **Masking** (§5.1): unmasked client frame → close **1002**.
- **UTF-8** (§8.1): reassembled text messages validated (`utf8ValidateSlice`) → **1007** on invalid; validated *after* fragment reassembly so a split codepoint isn't falsely rejected. Also validates the close-frame reason string (Autobahn 7.5.1).
- **Handshake**: require `GET`, `Sec-WebSocket-Version: 13` (else a self-sent **426** with the version header), `Upgrade: websocket` and `Connection: Upgrade` tokens.
- **RSV1-3** (§5.2): set with no extension negotiated → **1002**.
- **Control frames** (§5.5): must be `FIN==1` and ≤125 bytes → else **1002**; `sendWsFrame` now refuses an oversized control payload rather than truncating it.
- **Close codes** (§7.4.1): validated against the RFC/IANA valid set (`{1000-1003, 1007-1011, 3000-4999}`) → **1002** on a reserved code or a 1-byte payload, instead of echoing.

## Blocker caught in review

Every rejected-handshake path returned before the success path moves `on_message`/`on_close` into `ws_state`, and no `deinit` unrefs the exchange copies — so a client looping malformed handshakes (e.g. `Sec-WebSocket-Version: 8`) leaked **two Lua registry refs per request**. Fixed with a `defer` at the top of `handleWsUpgrade` that unrefs them on any path that doesn't zero them first (no-op on success). The registry has no network-reachable size signal, so this is covered by the reject-path integration tests + inspection rather than a manufactured leak assertion.

## Out of scope, flagged

`handleSseUpgrade` has the same reject-path ref-leak shape — separate follow-up (#192). The 426's `Connection: close` isn't honored (keep-alive) — same class as #180, noted there.

## Verify

- 2 unit tests (parser: unmasked, RSV) + 12 raw-socket integration tests (one per rule: masking→1002, bad UTF-8→1007, split-fragment UTF-8, missing/unsupported version→426, non-GET→404, RSV→1002, fragmented/oversized control→1002, 1-byte close→1002, reserved close code→1002, bad-UTF-8 reason→1007). A `readCloseCode` helper parses the server's close frame to assert the actual code.
- `zig build test` green; `bun run test:ci` **64 pass / 0 fail**.
- Autobahn suite noted as out of scope (no tooling in CI).
