### PR TITLE
fix(http): conformance + response-header safety (#176)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -764,7 +764,8 @@ pub const Connection = struct {
         // Static file routes: handled before Lua routing (zero Lua overhead)
         if (self.router.matchStatic(clean_path)) |match| {
             if (!std.mem.eql(u8, request.method, "GET") and !std.mem.eql(u8, request.method, "HEAD")) {
-                error_response.sendErrorStatus(self, 405, "method not allowed for static file");
+                self.logAccess(405);
+                error_response.send405(self, "GET, HEAD");
                 return null;
             }
             static_mod.serveStaticFile(self, request, match.route, match.suffix);
@@ -777,6 +778,19 @@ pub const Connection = struct {
         };
 
         if (route_match == null) {
+            if (self.router.methodsForPath(clean_path)) |methods| {
+                var allow: std.ArrayListUnmanaged(u8) = .empty;
+                var it = methods.keyIterator();
+                var first = true;
+                while (it.next()) |k| {
+                    if (!first) allow.appendSlice(self.arena.allocator(), ", ") catch break;
+                    allow.appendSlice(self.arena.allocator(), k.*) catch break;
+                    first = false;
+                }
+                self.logAccess(405);
+                error_response.send405(self, allow.items);
+                return null;
+            }
             self.logAccess(404);
             self.send404NotFound();
         }

--- a/src/http/error_response.zig
+++ b/src/http/error_response.zig
@@ -122,6 +122,18 @@ pub fn sendErrorStatus(conn: *Connection, status: u16, internal_msg: []const u8)
     }
 }
 
+/// Send 405 Method Not Allowed with an Allow header (RFC 7231 §6.5.5).
+/// `allow` is the header value, e.g. "GET, HEAD".
+pub fn send405(conn: *Connection, allow: []const u8) void {
+    logError(.client_error, 405, conn.http_state.request_method, conn.http_state.request_path, "method not allowed");
+    const body = "Method Not Allowed";
+    const resp = std.fmt.allocPrint(conn.arena.allocator(), "HTTP/1.1 405 Method Not Allowed\r\nAllow: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{ allow, body.len, body }) catch {
+        conn.sendRawResponse(statusResponse(400).?);
+        return;
+    };
+    conn.sendRawResponse(resp);
+}
+
 // =============================================================================
 // Tests
 // =============================================================================

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -73,6 +73,9 @@ pub const Response = struct {
 
         if (self.headers) |h| {
             for (h.items) |header| {
+                if (isEngineOwnedHeader(header.name)) continue;
+                if (std.mem.indexOfAny(u8, header.name, "\r\n") != null) continue;
+                if (std.mem.indexOfAny(u8, header.value, "\r\n") != null) continue;
                 try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
             }
         }
@@ -89,6 +92,16 @@ pub const Response = struct {
         // Headers (only if ArrayList was initialized)
         if (self.headers) |h| {
             for (h.items) |header| {
+                // A 101 handshake (conn_ws.zig) carries an engine-authored
+                // "Connection: Upgrade" that RFC 6455 §4.2.2 requires — exempt
+                // Connection at 101 the same way Content-Length is exempted below.
+                // A Lua handler that sets ctx.status=101 itself also routes here;
+                // that degenerate 101+body framing case is tracked as a follow-up,
+                // not resolved by this header-safety pass.
+                const is_protected_connection = self.status == 101 and std.ascii.eqlIgnoreCase(header.name, "connection");
+                if (isEngineOwnedHeader(header.name) and !is_protected_connection) continue;
+                if (std.mem.indexOfAny(u8, header.name, "\r\n") != null) continue;
+                if (std.mem.indexOfAny(u8, header.value, "\r\n") != null) continue;
                 try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
             }
         }
@@ -111,6 +124,17 @@ pub const Header = struct {
     name: []const u8,
     value: []const u8,
 };
+
+/// Headers the engine owns and emits itself — a tenant setting these could
+/// desync framing (request smuggling) or hijack keep-alive. Case-insensitive,
+/// and whitespace-trimmed so "Content-Length " (a lenient-intermediary
+/// smuggling obfuscation) is still recognized and stripped.
+fn isEngineOwnedHeader(name: []const u8) bool {
+    const n = std.mem.trim(u8, name, " \t");
+    return std.ascii.eqlIgnoreCase(n, "content-length") or
+        std.ascii.eqlIgnoreCase(n, "transfer-encoding") or
+        std.ascii.eqlIgnoreCase(n, "connection");
+}
 
 /// True if `s` is a valid HTTP field-value integer: 1*DIGIT, nothing else.
 /// `std.fmt.parseInt` alone also accepts a leading '+', '-', and Zig's '_'
@@ -299,6 +323,43 @@ test "response serialization" {
 
     const expected = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
     try std.testing.expectEqualStrings(expected, buf.writer.buffered());
+}
+
+test "isEngineOwnedHeader matches content-length, transfer-encoding, connection case-insensitively" {
+    try std.testing.expect(isEngineOwnedHeader("Content-Length"));
+    try std.testing.expect(isEngineOwnedHeader("content-length"));
+    try std.testing.expect(isEngineOwnedHeader("CONTENT-LENGTH"));
+    try std.testing.expect(isEngineOwnedHeader("Transfer-Encoding"));
+    try std.testing.expect(isEngineOwnedHeader("transfer-encoding"));
+    try std.testing.expect(isEngineOwnedHeader("Connection"));
+    try std.testing.expect(isEngineOwnedHeader("connection"));
+    try std.testing.expect(!isEngineOwnedHeader("X-Foo"));
+    // Whitespace-padded framing names are the classic smuggling obfuscation —
+    // still recognized so they can't ride alongside the engine's own header.
+    try std.testing.expect(isEngineOwnedHeader("Content-Length "));
+    try std.testing.expect(isEngineOwnedHeader(" content-length"));
+    try std.testing.expect(isEngineOwnedHeader("\tTransfer-Encoding"));
+}
+
+test "serialize drops a tenant-set Content-Length and a CRLF-injected header" {
+    const allocator = std.testing.allocator;
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    response.status = 200;
+    response.body = "ok";
+    try response.addHeader("Content-Length", "999");
+    try response.addHeader("X-Bad", "a\r\nX-Injected: evil");
+
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
+    try response.serialize(&buf.writer);
+
+    const result = buf.writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, result, "X-Injected") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "Content-Length: 999") == null);
+    // Engine's own Content-Length for the real 2-byte body is still present.
+    try std.testing.expect(std.mem.indexOf(u8, result, "Content-Length: 2\r\n") != null);
 }
 
 test "status_lines: known phrase and unmapped-code fallback" {

--- a/src/http/http_exchange.zig
+++ b/src/http/http_exchange.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const http = @import("http.zig");
 const params_mod = @import("params.zig");
+const log = @import("../observability/log.zig");
 
 /// HttpExchange - The ONLY object Lua touches
 /// Represents a complete HTTP request/response exchange
@@ -72,6 +73,13 @@ pub const HttpExchange = struct {
     /// them immediately after this returns. The copies live for the exchange's
     /// lifetime (freed via `toResponse` transfer or `deinit`).
     pub fn addResponseHeader(self: *HttpExchange, name: []const u8, value: []const u8) !void {
+        // CRLF in a header name/value would split into forged response headers
+        // (response-splitting). Drop + log rather than raise. Tenant bug, not a crash.
+        if (containsCrlf(name) or containsCrlf(value)) {
+            log.warn().stringSafe("scope", "http_exchange").string("header", name).string("msg", "dropped response header with CR/LF in name or value").log();
+            return;
+        }
+
         // Copy strings from Lua memory into arena (Lua strings are temporary)
         const name_copy = try self.allocator.dupe(u8, name);
         const value_copy = try self.allocator.dupe(u8, value);
@@ -102,3 +110,7 @@ pub const HttpExchange = struct {
         self.response_headers.deinit(self.allocator);
     }
 };
+
+fn containsCrlf(s: []const u8) bool {
+    return std.mem.indexOfAny(u8, s, "\r\n") != null;
+}

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -390,6 +390,31 @@ pub const Router = struct {
         return null;
     }
 
+    /// Cold-path 405 helper: after `match` returns null, report whether `path`
+    /// resolves to a routed node that has *some* method registered (→ 405 + Allow)
+    /// vs no such path (→ 404). Walks the trie again — only on the miss path, so
+    /// `match`'s hot path is untouched. Returns the leaf's method map, or null.
+    pub fn methodsForPath(self: *Router, path: []const u8) ?*const std.StringHashMap(i32) {
+        var node = self.root;
+        var start: usize = 1; // skip leading '/'
+        while (start < path.len) {
+            const end = std.mem.indexOfScalarPos(u8, path, start, '/') orelse path.len;
+            const segment = path[start..end];
+            if (node.children.get(segment)) |child| {
+                node = child;
+            } else if (node.param_child) |param| {
+                node = param.node;
+            } else {
+                return null;
+            }
+            start = end + 1;
+        }
+        if (node.methods) |*mt| {
+            if (mt.count() > 0) return mt;
+        }
+        return null;
+    }
+
     /// Collect all lua_ref values from the trie (for unreffing before reset).
     pub fn collectLuaRefs(self: *const Router, alloc: std.mem.Allocator, refs: *std.ArrayListUnmanaged(i32)) !void {
         try collectNodeRefs(self.root, alloc, refs);

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -97,6 +97,39 @@ fn formatHttpDate(buf: *[29]u8, epoch_secs: i64) void {
     }) catch {};
 }
 
+/// Parse an RFC 7231 IMF-fixdate ("Sun, 06 Nov 1994 08:49:37 GMT") to epoch
+/// seconds. Returns null on any deviation (caller then serves 200).
+// ponytail: IMF-fixdate only (the format we emit); other HTTP-date forms fall through to 200
+fn parseHttpDate(s: []const u8) ?i64 {
+    // "Www, DD Mon YYYY HH:MM:SS GMT"
+    if (s.len < 29) return null;
+    const day = std.fmt.parseInt(u32, std.mem.trim(u8, s[5..7], " "), 10) catch return null;
+    const month = monthIndex(s[8..11]) orelse return null;
+    const year = std.fmt.parseInt(i64, s[12..16], 10) catch return null;
+    const hour = std.fmt.parseInt(i64, s[17..19], 10) catch return null;
+    const min = std.fmt.parseInt(i64, s[20..22], 10) catch return null;
+    const sec = std.fmt.parseInt(i64, s[23..25], 10) catch return null;
+    const days = daysFromCivil(year, month, day);
+    return days * 86400 + hour * 3600 + min * 60 + sec;
+}
+
+fn monthIndex(m: []const u8) ?u32 {
+    const names = [_][]const u8{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    for (names, 1..) |name, i| if (std.mem.eql(u8, m, name)) return @intCast(i);
+    return null;
+}
+
+/// Days since 1970-01-01 for a civil date (Howard Hinnant's algorithm).
+fn daysFromCivil(y_in: i64, m: u32, d: u32) i64 {
+    const y = y_in - @as(i64, if (m <= 2) 1 else 0);
+    const era = @divFloor(if (y >= 0) y else y - 399, 400);
+    const yoe = y - era * 400; // [0, 399]
+    const mp: i64 = @intCast((m + (if (m > 2) @as(u32, 0) else 12) - 3)); // Mar=0..Feb=11
+    const doy = @divTrunc(153 * mp + 2, 5) + @as(i64, d) - 1; // [0, 365]
+    const doe = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy; // [0, 146096]
+    return era * 146097 + doe - 719468;
+}
+
 /// Map a static-file I/O error to an HTTP response.
 /// A missing entry is the client's problem (404); permissions, I/O, fd
 /// exhaustion, etc. are the server failing to read its own files (500).
@@ -122,6 +155,13 @@ const StaticPath = struct {
     /// Symlink-resolved absolute path — used to open the file.
     real: []const u8,
 };
+
+/// True if `path` is `root` itself or a descendant — startsWith plus a segment
+/// boundary, so "/x/public-secret" is NOT within "/x/public".
+fn isWithinRoot(path: []const u8, root: []const u8) bool {
+    if (!std.mem.startsWith(u8, path, root)) return false;
+    return path.len == root.len or path[root.len] == std.fs.path.sep;
+}
 
 /// Resolve `suffix` against `route` to an absolute, symlink-resolved path
 /// verified to stay within the route root. Returns null after sending an
@@ -163,7 +203,7 @@ fn resolveStaticPath(
         self.send500InternalError();
         return null;
     };
-    if (!std.mem.startsWith(u8, resolved, root_resolved)) {
+    if (!isWithinRoot(resolved, root_resolved)) {
         self.logAccess(403);
         error_response.sendErrorStatus(self, 403, "path traversal blocked");
         return null;
@@ -186,7 +226,7 @@ fn resolveStaticPath(
             return null;
         };
     };
-    if (!std.mem.startsWith(u8, real_resolved, route.real_root)) {
+    if (!isWithinRoot(real_resolved, route.real_root)) {
         self.logAccess(403);
         error_response.sendErrorStatus(self, 403, "symlink traversal blocked");
         return null;
@@ -276,13 +316,24 @@ pub fn serveStaticFile(
         file_size,
     }) catch "";
 
-    // Check If-None-Match (use already-parsed headers, not raw buffer)
+    // Check If-None-Match (use already-parsed headers, not raw buffer).
+    // If-None-Match takes precedence over If-Modified-Since (RFC 7232 §6):
+    // when present but not matching, serve full — do not consult IMS.
     if (http.Parser.getHeader(request, "If-None-Match")) |inm| {
         if (std.mem.eql(u8, inm, etag)) {
             helpers.closeFd(fd);
             self.logAccess(304);
             self.sendRawResponse("HTTP/1.1 304 Not Modified\r\nContent-Length: 0\r\n\r\n");
             return;
+        }
+    } else if (http.Parser.getHeader(request, "If-Modified-Since")) |ims| {
+        if (parseHttpDate(ims)) |ims_secs| {
+            if (mtime_sec <= ims_secs) {
+                helpers.closeFd(fd);
+                self.logAccess(304);
+                self.sendRawResponse("HTTP/1.1 304 Not Modified\r\nContent-Length: 0\r\n\r\n");
+                return;
+            }
         }
     }
 
@@ -296,8 +347,8 @@ pub fn serveStaticFile(
 
     self.logAccess(200);
 
-    if (file_size == 0) {
-        // Empty file — just send headers
+    if (std.mem.eql(u8, request.method, "HEAD") or file_size == 0) {
+        // HEAD: RFC 7231 §4.3.2 — identical headers to GET, no message body.
         helpers.closeFd(fd);
         self.sendRawResponse(headers_text);
         return;
@@ -461,4 +512,25 @@ test "buildStaticHeaders formats status line and cache headers" {
     try std.testing.expect(std.mem.indexOf(u8, headers, "Content-Length: 42\r\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, headers, "ETag: \"abc\"\r\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, headers, "Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT\r\n") != null);
+}
+
+test "isWithinRoot enforces a segment boundary, not just a string prefix" {
+    try std.testing.expect(isWithinRoot("/x/public", "/x/public"));
+    try std.testing.expect(isWithinRoot("/x/public/a.css", "/x/public"));
+    try std.testing.expect(!isWithinRoot("/x/public-secret/s.txt", "/x/public"));
+    try std.testing.expect(!isWithinRoot("/x/pub", "/x/public"));
+}
+
+test "parseHttpDate round-trips formatHttpDate" {
+    // 784111777 = Sun, 06 Nov 1994 08:49:37 GMT
+    var buf: [29]u8 = undefined;
+    formatHttpDate(&buf, 784111777);
+    try std.testing.expectEqualStrings("Sun, 06 Nov 1994 08:49:37 GMT", &buf);
+    try std.testing.expectEqual(@as(?i64, 784111777), parseHttpDate(&buf));
+
+    var epoch_buf: [29]u8 = undefined;
+    formatHttpDate(&epoch_buf, 0);
+    try std.testing.expectEqual(@as(?i64, 0), parseHttpDate(&epoch_buf));
+
+    try std.testing.expectEqual(@as(?i64, null), parseHttpDate("not a date"));
 }

--- a/tests/fixtures.lua
+++ b/tests/fixtures.lua
@@ -111,6 +111,20 @@ keyway.routes["/test/broadcast"] = {
     end,
 }
 
+-- (#176) Response header CRLF injection regression: a response header value
+-- containing a literal CRLF + a fake header name must not split into a
+-- second, real response header at serialize time (src/http/http.zig
+-- Response.serialize). Set directly here rather than via a request header,
+-- since fetch()/picohttpparser both refuse literal CRLF in a header value
+-- before it would ever reach Lua as a single value.
+keyway.routes["/test/header-injection"] = {
+    GET = function(ctx)
+        ctx.status = 200
+        ctx.headers["X-Bad"] = "a\r\nX-Injected: evil"
+        ctx.body = "ok"
+    end,
+}
+
 keyway.routes["/test/mw"] = {
     middleware = { mw_before, mw_after },
     GET = function(ctx)

--- a/tests/integration/http_conformance.test.ts
+++ b/tests/integration/http_conformance.test.ts
@@ -1,0 +1,159 @@
+// HTTP conformance regressions (#176): method-not-allowed semantics, HEAD on
+// static files, conditional GET via If-Modified-Since, response header
+// injection, and the static-mount sibling-prefix traversal boundary.
+//
+// Black-box only — these drive the running server over real HTTP/raw
+// sockets and assert the RFC-correct outcome. No Zig symbols referenced.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve } from "path";
+import { rawStatus } from "../harness";
+
+const base = () => globalThis.__KEYWAY_BASE;
+const port = () => globalThis.__KEYWAY_PORT;
+const PUBLIC = resolve(import.meta.dir, "../../dashboard/public");
+
+describe("405 Method Not Allowed (#176)", () => {
+  // /test/headers registers only GET (tests/fixtures.lua). Hitting it with an
+  // unregistered method must be a 405 + Allow, not a bare 404 — the router
+  // knows the path exists, it just doesn't have this method at that node.
+  test("(#176) POST to a GET-only Lua route returns 405 with Allow: GET", async () => {
+    const res = await fetch(`${base()}/test/headers`, { method: "POST" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toContain("GET");
+  });
+});
+
+describe("HEAD on static files (#176)", () => {
+  // fetch()/undici discard the body of a HEAD response regardless of what
+  // the server actually sent, so this needs the literal bytes on the wire.
+  // The response arrives across multiple send() calls (headers, then a
+  // pread+send loop per chunk — see src/http/static.zig), and the server
+  // does not close the connection afterward (no Connection: close support),
+  // so we can't wait for a socket close either. Instead debounce on a quiet
+  // period: resolve once no new bytes have arrived for a short window.
+  async function rawHead(path: string): Promise<{ status: number; contentLength: number | null; bodyBytes: number }> {
+    const request = `HEAD ${path} HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`;
+    const chunks: Buffer[] = [];
+    const { promise, resolve: settle } = Promise.withResolvers<void>();
+    let quietTimer: ReturnType<typeof setTimeout>;
+    const armQuiet = () => {
+      clearTimeout(quietTimer);
+      quietTimer = setTimeout(settle, 250);
+    };
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: port(),
+      socket: {
+        data(_s, data) {
+          chunks.push(Buffer.from(data));
+          armQuiet();
+        },
+        close() {
+          clearTimeout(quietTimer);
+          settle();
+        },
+        error() {
+          clearTimeout(quietTimer);
+          settle();
+        },
+      },
+    });
+    socket.write(request);
+    socket.flush();
+    armQuiet();
+    await Promise.race([promise, Bun.sleep(3000).then(() => {})]);
+    socket.end();
+
+    const buf = Buffer.concat(chunks);
+    const sep = buf.indexOf("\r\n\r\n");
+    const headerText = (sep === -1 ? buf : buf.subarray(0, sep)).toString("latin1");
+    const bodyBytes = sep === -1 ? 0 : buf.length - (sep + 4);
+    const status = Number(headerText.split("\r\n")[0]?.split(" ")[1]);
+    const clMatch = headerText.match(/content-length:\s*(\d+)/i);
+    return { status, contentLength: clMatch ? Number(clMatch[1]) : null, bodyBytes };
+  }
+
+  test("(#176) HEAD on a static file returns Content-Length but no body", async () => {
+    const want = await Bun.file(resolve(PUBLIC, "index.html")).arrayBuffer();
+    const { status, contentLength, bodyBytes } = await rawHead("/__keyway/dashboard/index.html");
+    expect(status).toBe(200);
+    expect(contentLength).toBe(want.byteLength);
+    expect(bodyBytes).toBe(0);
+  });
+});
+
+describe("If-Modified-Since (#176)", () => {
+  test("(#176) If-Modified-Since with the file's own Last-Modified returns 304", async () => {
+    const first = await fetch(`${base()}/__keyway/dashboard/index.html`);
+    expect(first.status).toBe(200);
+    await first.arrayBuffer();
+    const lastModified = first.headers.get("last-modified");
+    expect(lastModified).toBeTruthy();
+
+    const second = await fetch(`${base()}/__keyway/dashboard/index.html`, {
+      headers: { "If-Modified-Since": lastModified! },
+    });
+    expect(second.status).toBe(304);
+    expect((await second.text()).length).toBe(0);
+  });
+
+  // Control: a date safely before the file's mtime must NOT short-circuit to
+  // 304 — this already passes today (If-Modified-Since is simply ignored),
+  // and must keep passing once the header is honored.
+  test("(#176) If-Modified-Since with a date before the file's mtime returns 200 (control)", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/index.html`, {
+      headers: { "If-Modified-Since": "Thu, 01 Jan 1970 00:00:00 GMT" },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("response header CRLF injection (#176)", () => {
+  // /test/header-injection (tests/fixtures.lua) sets a response header value
+  // containing a literal CRLF + a fake header line. From the wire's
+  // perspective "X-Bad: a\r\nX-Injected: evil\r\n" is indistinguishable from
+  // two genuine header lines, so a plain fetch() is enough to observe the
+  // split — no raw socket needed, since we're not fighting fetch's
+  // request-side header validation here, only reading whatever the server
+  // actually sent back.
+  test("(#176) a CRLF-containing header value cannot smuggle a second response header", async () => {
+    const res = await fetch(`${base()}/test/header-injection`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Injected")).toBeNull();
+  });
+});
+
+describe("static sibling-prefix traversal boundary (#176)", () => {
+  // resolveStaticPath (src/http/static.zig) checks
+  // std.mem.startsWith(resolved, root_resolved) with no trailing separator,
+  // so a sibling directory whose name has the mount root as a *string*
+  // prefix ("public-secret" vs "public") satisfies the check even though it
+  // resolves outside the mount. Fixture created/removed around the test so
+  // no stray directory is left in the repo.
+  const SIBLING_DIR = resolve(PUBLIC, "../public-secret");
+  const SIBLING_FILE = resolve(SIBLING_DIR, "secret.txt");
+
+  beforeAll(async () => {
+    await mkdir(SIBLING_DIR, { recursive: true });
+    await writeFile(SIBLING_FILE, "top secret\n");
+  });
+
+  afterAll(async () => {
+    await rm(SIBLING_DIR, { recursive: true, force: true });
+  });
+
+  // fetch()/the WHATWG URL parser collapse ".." before the request is sent
+  // (see static.test.ts), so this needs a raw socket to get the literal
+  // dot-segment onto the wire.
+  test("(#176) a sibling dir sharing the mount root's name prefix is blocked (403)", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET /__keyway/dashboard/../public-secret/secret.txt HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Connection: close\r\n\r\n`,
+    );
+    expect(status).toBe(403);
+  });
+});

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -341,8 +341,9 @@ describe("websocket handshake validation (#175)", () => {
   });
 
   // The router only registers GET for /test/ws (tests/fixtures.lua), so a
-  // POST 404s before conn_ws.handleWsUpgrade's own method check ever runs —
-  // this still proves a non-GET request is never upgraded.
+  // POST hits the router's 405 Method Not Allowed path (#176) before
+  // conn_ws.handleWsUpgrade's own method check ever runs — this still
+  // proves a non-GET request is never upgraded.
   test("does not upgrade a non-GET request", async () => {
     await withServer(async ({ port }) => {
       const status = await rawStatus(
@@ -354,7 +355,7 @@ describe("websocket handshake validation (#175)", () => {
           `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n` +
           `Sec-WebSocket-Version: 13\r\n\r\n`,
       );
-      expect(status).toBe(404);
+      expect(status).toBe(405);
     });
   });
 });


### PR DESCRIPTION
Closes #176

HTTP conformance + response-header safety hardening. Written red-first (the
integration suite `tests/integration/http_conformance.test.ts` was authored and
verified failing against `main` before any implementation), then implemented to
green.

## What changed
- **405 Method Not Allowed + Allow** — a known path hit with an unregistered
  method returns `405` + `Allow` (RFC 7231 §6.5.5) instead of a bare 404. New
  cold-path `Router.methodsForPath` (zero-alloc hot-path `match` untouched). Also
  fixes the static-mount 405 that silently fell back to 400 (no canned 405 row).
- **HEAD on static files** — identical headers to GET (Content-Length included),
  zero body bytes (RFC 7231 §4.3.2).
- **If-Modified-Since → 304** — honored only when If-None-Match is absent
  (RFC 7232 §6 precedence). Adds an IMF-fixdate parser gated by a
  `formatHttpDate` round-trip unit test.
- **Response header CRLF / framing injection** — two layers: `addResponseHeader`
  (the Lua `ctx.headers` funnel) drops + logs CR/LF-bearing headers with no Lua
  raise; `serialize`/`serializeChunkedHeaders` additionally skip engine-owned
  framing headers (Content-Length / Transfer-Encoding / Connection, whitespace-
  trimmed) and any residual CR/LF header — so proxy/static paths that bypass the
  Lua funnel can't smuggle framing either. `Connection` stays exempt only on the
  101 handshake serialize path.
- **Static traversal boundary** — segment-boundary check, not a bare string
  prefix, at both the pre- and post-symlink sites, so a sibling dir sharing the
  mount root's name (`public-secret` vs `public`) is blocked.

## Tests
- New red-first integration suite (6 tests; 5 formerly-red + 1 control), all green.
- Zig unit tests: `isWithinRoot`, `parseHttpDate` round-trip, `isEngineOwnedHeader`
  (incl. the whitespace-obfuscation cases), and a `serialize` framing/CRLF drop test.
- `ws_framing`'s non-GET-upgrade check now expects 405 (was 404) — same
  "never upgraded" assertion, via the now-correct status.
- Gate: `zig build test` 123/123, full bun integration suite 70/70.

## Follow-up filed
- #194 — pre-existing 101-with-body framing desync + the 101 serialize special-cases
  (root-cause: build the WS handshake as a raw response so `serialize` needs no
  101 branch). Kept out of this pass to stay surgical.

Adversarially reviewed (date arithmetic verified over ~2M samples; traversal,
CRLF, and smuggling boundaries probed) — no attacker-reachable defect found.