### PR TITLE
fix(tls): fail loud when kernel kTLS is unavailable (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ No `send()`, no `write()`, no lifecycle calls — only state assignment. Zig com
 - **WebSocket** — upgrade via `ctx.upgrade = "websocket"`, frame encoding/decoding handled by Zig.
 - **SSE** — upgrade via `ctx.upgrade = "sse"`, cross-worker broadcast via `SseBroadcastBus`.
 - **Chunked streaming** — `ctx.upgrade = "stream"` with `coroutine.yield()` to flush chunks.
-- **TLS** — OpenSSL userspace handshake + optional kTLS kernel offload for the data path.
+- **TLS** — OpenSSL userspace handshake + kTLS kernel offload for the data path. kTLS is **required** (Linux ≥ 4.13 with the `tls` module): there is no userspace data path, so keyway refuses to start TLS when the module is absent rather than dropping every request.
 - **Radix router** — O(path-length) trie with `{param}` support, zero allocations per match.
 - **Middleware** — global and per-route chains with short-circuit support.
 - **Zero-copy parsing** — picohttpparser produces slices into the read buffer. No copies.

--- a/src/core/server.zig
+++ b/src/core/server.zig
@@ -5,7 +5,8 @@ const Connection = @import("handler.zig").Connection;
 const Router = @import("../http/router.zig").Router;
 const LuaState = @import("../lua/lua_state.zig").LuaState;
 const bpf_reuseport = @import("../io/bpf_reuseport.zig");
-const TlsContext = @import("../tls/tls.zig").TlsContext;
+const tls_mod = @import("../tls/tls.zig");
+const TlsContext = tls_mod.TlsContext;
 const castUserdata = @import("../util/helpers.zig").castUserdata;
 const helpers = @import("../util/helpers.zig");
 const sse = @import("../protocol/sse.zig");
@@ -126,8 +127,16 @@ pub const Server = struct {
             try tcp.listen(DEFAULT_BACKLOG);
         }
 
-        // Initialize TLS context if cert+key are configured
-        const tls_ctx: ?TlsContext = if (config.tls_cert_path != null and config.tls_key_path != null)
+        // Initialize TLS context if cert+key are configured. The data path is
+        // kTLS-only (no userspace SSL_read/SSL_write), so refuse to boot with TLS
+        // configured on a host where the kernel `tls` ULP is missing — otherwise
+        // every HTTPS request would handshake and then be silently dropped (#168).
+        const tls_configured = config.tls_cert_path != null and config.tls_key_path != null;
+        if (tls_configured and !tls_mod.probeKtlsAvailable()) {
+            log.err().string("msg", "TLS configured but kernel kTLS is unavailable — keyway's TLS data path is kTLS-only. Load the module ('modprobe tls', needs Linux >= 4.13) or start without --tls-cert/--tls-key.").log();
+            return error.KtlsUnavailable;
+        }
+        const tls_ctx: ?TlsContext = if (tls_configured)
             try TlsContext.init(config.tls_cert_path.?, config.tls_key_path.?)
         else
             null;

--- a/src/tls/conn_tls.zig
+++ b/src/tls/conn_tls.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const xev = @import("xev");
+const log = @import("../observability/log.zig");
 const tls_mod = @import("tls.zig");
 const TlsConn = tls_mod.TlsConn;
 const TlsContext = tls_mod.TlsContext;
@@ -37,7 +38,12 @@ pub fn handleTlsHandshake(self: *Connection, tc: *TlsConn) void {
 /// Handshake done: set up kTLS, free TLS state, start plaintext reads.
 fn completeHandshake(self: *Connection) void {
     const tc = &self.tls_state.tls_conn.?;
-    tc.setupKtls(self.socket) catch {
+    tc.setupKtls(self.socket) catch |err| {
+        // No userspace data-path fallback (#168): a fully-handshaked connection
+        // we can't offload to kTLS must be closed. Log loudly — the common cause
+        // (module absent) is refused at startup, so reaching here means an
+        // unsupported cipher/version on a host that otherwise has kTLS.
+        log.err().string("msg", "kTLS setup failed after handshake, closing connection").err(err).int("fd", self.socket).log();
         self.close();
         return;
     };

--- a/src/tls/tls.zig
+++ b/src/tls/tls.zig
@@ -355,7 +355,10 @@ pub const TlsConn = struct {
 
     /// After handshake completes, extract negotiated keys and configure kTLS.
     /// On success, the kernel handles all encrypt/decrypt — TlsConn can be freed.
-    /// On failure, returns error (caller should keep TlsConn for userspace TLS).
+    /// On failure there is no fallback: keyway has no userspace SSL_read/SSL_write
+    /// data path, so the caller closes the connection. The startup probe
+    /// (`probeKtlsAvailable`) makes the common cause — module absent — a boot-time
+    /// refusal instead of a per-request drop.
     pub fn setupKtls(self: *TlsConn, fd: std.posix.socket_t) !void {
         const ssl_version = c.SSL_version(self.ssl);
 
@@ -607,6 +610,27 @@ pub const TlsConn = struct {
         @memset(&key_block, 0);
     }
 };
+
+/// Probe once, at startup, whether the kernel TLS ULP is available.
+///
+/// keyway's data path is kTLS-only: the handshake runs in userspace over memory
+/// BIOs, but application data is handed to the kernel — there is no userspace
+/// SSL_read/SSL_write path. So if the `tls` module is absent, every HTTPS
+/// connection would handshake and then be dropped. Refuse at boot instead.
+///
+/// Setting TCP_ULP="tls" on a fresh socket returns ENOENT iff the module isn't
+/// loaded; any other outcome (success, or ENOTCONN because the socket isn't
+/// established) means the ULP is registered. Keying only on ENOENT is
+/// deliberately conservative — it never false-blocks a host where kTLS works.
+pub fn probeKtlsAvailable() bool {
+    const sock_rc = std.os.linux.socket(std.os.linux.AF.INET, std.os.linux.SOCK.STREAM | std.os.linux.SOCK.CLOEXEC, 0);
+    if (helpers.syscallErrno(sock_rc) != .SUCCESS) return false;
+    const fd: i32 = @intCast(sock_rc);
+    defer _ = std.os.linux.close(fd);
+    const ulp = [4]u8{ 't', 'l', 's', 0 };
+    const rc = std.os.linux.setsockopt(fd, std.posix.IPPROTO.TCP, c.TCP_ULP, &ulp, ulp.len);
+    return helpers.syscallErrno(rc) != .NOENT;
+}
 
 // ============================================================================
 // Tests


### PR DESCRIPTION
Closes #168

keyway's TLS data path is **kTLS-only**: the handshake runs in userspace over
memory BIOs, but application data is handed to the kernel — there is no
userspace `SSL_read`/`SSL_write` path. So when the kernel `tls` ULP is absent,
every HTTPS request completed its handshake and was then **silently dropped**.

## Change
- **Startup probe + fail-loud gate** (`src/tls/tls.zig`, `src/core/server.zig`):
  probe the ULP once at boot (`setsockopt(TCP_ULP,"tls")` on a throwaway socket;
  `ENOENT` iff the module is absent) and refuse to start with TLS configured on a
  host where kTLS can't work, with an actionable error — instead of accepting
  connections it can't serve. The probe is a faithful dry-run of `setupKtls`
  (same syscall, same process/privilege context), so it never disagrees with the
  real offload about availability.
- **No more silent runtime drop** (`src/tls/conn_tls.zig`): a `setupKtls` failure
  after the handshake (an unsupported cipher/version on a host that otherwise has
  kTLS) now logs an error before closing.
- **Docs** (`README.md`): correct the false "optional kTLS" claim — kTLS is
  required (Linux ≥ 4.13 + `tls` module).

## Why not the issue's `SSL_OP_ENABLE_KTLS` recipe
It's architecturally wrong here: OpenSSL is wired to `BIO_s_mem` memory BIOs, not
the socket fd, so that option engages neither kTLS nor a data path; handing
OpenSSL the fd to fix it would make it block the worker thread (proactor
violation). The ~400 LOC of manual key derivation is the *mechanism*, not dead
code. Full write-up in the #168 comment. The proper larger fix — a proactor-safe
userspace data path so TLS works without kTLS — is tracked as **#196**.

## Verification
- `zig build test` green; full bun integration suite 70/70 (harness spawns the
  server without TLS, so the gate doesn't affect CI).
- Booted the server with a self-signed cert on this host (where the `tls` module
  doesn't autoload for an unprivileged socket): it refuses at boot with the clear
  message and exits non-zero. Cross-checked the probe against an independent
  `setsockopt(TCP_ULP,"tls")` — both return `ENOENT`, confirming a true negative.
- Happy path (probe → boot → serve HTTPS) requires the module loaded, which needs
  root on this host; the probe is a byte-for-byte dry-run of the existing
  `setupKtls` syscall, and the post-probe path is unchanged.