### PR TITLE
fix(tls): stop logging kTLS control-record teardown as an error (#198)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -66,6 +66,7 @@ pub const TlsState = struct {
     tls_conn: ?tls_mod.TlsConn = null,
     ciphertext_buffer: ?LinearBuffer = null, // recv target for TLS connections
     tls_handshake_complete: bool = false, // flag for sendTlsData -> onTlsHandshakeWrite
+    ktls_active: bool = false, // true after kTLS offload; marks a plaintext-socket recv as TLS
 
     pub fn deinit(self: *TlsState, alloc: std.mem.Allocator) void {
         if (self.tls_conn) |*tc| tc.deinit(alloc);
@@ -475,7 +476,19 @@ pub const Connection = struct {
                 return .disarm;
             }
             if (err != error.EOF) {
-                log.err().string("msg", "recv failed").int("fd", self.socket).err(err).log();
+                // On a kTLS socket a control record — typically the peer's
+                // close_notify at teardown — surfaces to recv as EIO, which
+                // libxev maps to error.Unexpected, not EOF. That's a normal TLS
+                // close, not a failure: log it at debug instead of a spurious
+                // ERROR on every HTTPS connection. We can't process a
+                // post-handshake record here regardless (the SSL object was
+                // freed after the handshake) — surviving a KeyUpdate needs the
+                // userspace data path (#196).
+                if (self.tls_state.ktls_active) {
+                    log.debug().string("msg", "kTLS connection closed by peer (control record)").int("fd", self.socket).log();
+                } else {
+                    log.err().string("msg", "recv failed").int("fd", self.socket).err(err).log();
+                }
             }
             self.close();
             return .disarm;

--- a/src/tls/conn_tls.zig
+++ b/src/tls/conn_tls.zig
@@ -47,7 +47,10 @@ fn completeHandshake(self: *Connection) void {
         self.close();
         return;
     };
-    // Free TLS state — kernel handles crypto now
+    // Free TLS state — kernel handles crypto now. Mark kTLS active so the
+    // plaintext-socket recv path can recognize a control-record teardown
+    // (close_notify → EIO → error.Unexpected) as a normal TLS close (#198).
+    self.tls_state.ktls_active = true;
     tc.deinit(self.base_allocator);
     self.tls_state.tls_conn = null;
     if (self.tls_state.ciphertext_buffer) |*cb| {


### PR DESCRIPTION
Closes #198

On a kTLS socket the peer's `close_notify` (and any post-handshake control
record) surfaces to `recv` as `EIO`, which libxev's `readResult` maps to
`error.Unexpected` — not `EOF` (only `CANCELED`/`CONNRESET` are named;
`io_uring.zig:832-836`). `onRead` treated that as a hard failure and logged
`ERROR "recv failed"` on essentially every HTTPS connection close.

## Change
- Mark the connection kTLS-active once offload succeeds (`TlsState.ktls_active`,
  set in `completeHandshake`).
- In `onRead`, a non-EOF recv error on a kTLS-active connection is the normal TLS
  close it is → `debug` log, not `ERROR`. The plaintext path is unchanged
  (`ktls_active` defaults false).

## Verification
- Live TLS boot (module loaded): 3 HTTPS requests, **0** `recv failed` errors
  (was 1 per connection), responses correct, `ktls enabled` as before.
- In ReleaseFast the teardown is fully quiet; in Debug, std's own
  `unexpectedErrno` stack dump still fires (runtime-safety only) — harmless dev
  noise, gated by `builtin.mode == .Debug`.
- `zig build test` green; full integration suite 70/70 (non-TLS path untouched).

## Out of scope (bounded by design)
Surviving a post-handshake **KeyUpdate** on a long-lived kTLS connection: keyway
frees the SSL object after the handshake, so it can't re-derive RX keys. Full
control-record handling (recvmsg + `TLS_GET_RECORD_TYPE`) belongs with the
userspace data path in #196. Noted in #198.