### PR TITLE
fix(http): raw WS handshake, drop serialize 101 special-cases (#194)

### DIFF
--- a/src/core/conn_ws.zig
+++ b/src/core/conn_ws.zig
@@ -58,12 +58,11 @@ pub fn handleWsUpgrade(conn: *Connection, exchange: *HttpExchange, request: *con
     const version_hdr = http.Parser.getHeader(request, "Sec-WebSocket-Version");
     const version = if (version_hdr) |v| std.mem.trim(u8, v, " \t") else null;
     if (version == null or !std.mem.eql(u8, version.?, "13")) {
-        var resp = http.Response.init(alloc);
-        resp.status = 426;
-        try resp.addHeader("Sec-WebSocket-Version", "13");
-        try resp.addHeader("Connection", "close");
+        // Raw response: the engine authors this handshake reply and it carries an
+        // engine-owned Connection header that Response.serialize strips from
+        // tenant output — so emit it verbatim here (#194).
         conn.logAccess(426);
-        try conn.writeResponseDirect(&resp);
+        conn.sendRawResponse("HTTP/1.1 426 Upgrade Required\r\nSec-WebSocket-Version: 13\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
         return;
     }
 
@@ -90,12 +89,11 @@ pub fn handleWsUpgrade(conn: *Connection, exchange: *HttpExchange, request: *con
     ws.computeAcceptKey(sec_key_trimmed, &accept_key);
     log.debug().string("msg", "ws accept_key").string("val", &accept_key).log();
 
-    // Build 101 response
-    var resp = http.Response.init(alloc);
-    resp.status = 101;
-    try resp.addHeader("Upgrade", "websocket");
-    try resp.addHeader("Connection", "Upgrade");
-    try resp.addHeader("Sec-WebSocket-Accept", &accept_key);
+    // Build the 101 handshake as a raw response. It carries engine-owned
+    // Upgrade/Connection headers that Response.serialize strips from tenant
+    // output, so serialize must not see it — which also lets serialize drop its
+    // status==101 special-cases entirely (#194).
+    const raw_101 = try std.fmt.allocPrint(alloc, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {s}\r\n\r\n", .{&accept_key});
 
     // Store WsState on connection (copy refs from exchange)
     conn.ws_state = .{
@@ -108,9 +106,9 @@ pub fn handleWsUpgrade(conn: *Connection, exchange: *HttpExchange, request: *con
 
     conn.logAccess(101);
 
-    // Send 101 — writeResponseDirect sets state to .writing, so we set .websocket
-    // AFTER so onWrite dispatches to handleWsPostWrite (starts WS frame read loop).
-    try conn.writeResponseDirect(&resp);
+    // sendRawResponse sets state to .writing; set .websocket AFTER so onWrite
+    // dispatches to handleWsPostWrite (starts the WS frame read loop).
+    conn.sendRawResponse(raw_101);
     conn.state = .websocket;
 }
 

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -92,24 +92,18 @@ pub const Response = struct {
         // Headers (only if ArrayList was initialized)
         if (self.headers) |h| {
             for (h.items) |header| {
-                // A 101 handshake (conn_ws.zig) carries an engine-authored
-                // "Connection: Upgrade" that RFC 6455 §4.2.2 requires — exempt
-                // Connection at 101 the same way Content-Length is exempted below.
-                // A Lua handler that sets ctx.status=101 itself also routes here;
-                // that degenerate 101+body framing case is tracked as a follow-up,
-                // not resolved by this header-safety pass.
-                const is_protected_connection = self.status == 101 and std.ascii.eqlIgnoreCase(header.name, "connection");
-                if (isEngineOwnedHeader(header.name) and !is_protected_connection) continue;
+                if (isEngineOwnedHeader(header.name)) continue;
                 if (std.mem.indexOfAny(u8, header.name, "\r\n") != null) continue;
                 if (std.mem.indexOfAny(u8, header.value, "\r\n") != null) continue;
                 try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
             }
         }
 
-        // Content-Length (skip for 101 Switching Protocols — no body follows)
-        if (self.status != 101) {
-            try writer.print("Content-Length: {d}\r\n", .{self.body.len});
-        }
+        // Content-Length. The 101 handshake is emitted as a raw response by
+        // conn_ws (not via serialize), so serialize has no status==101 special
+        // case: every response it produces is framed with an explicit length —
+        // a tenant that sets ctx.status=101 can no longer desync framing (#194).
+        try writer.print("Content-Length: {d}\r\n", .{self.body.len});
 
         // Blank line
         try writer.writeAll("\r\n");
@@ -479,22 +473,33 @@ test "http parser - rejects Transfer-Encoding with non-chunked final coding" {
     try std.testing.expectError(error.InvalidRequest, result);
 }
 
-test "101 switching protocols serialization" {
+test "serialize no longer special-cases 101 — a tenant ctx.status=101 is framed, not desynced (#194)" {
+    // The real WebSocket 101 handshake is now emitted as a raw response by
+    // conn_ws (verified end-to-end by the WS integration tests), so serialize
+    // only ever sees a 101 from a misused Lua handler. That must be well-framed:
+    // an explicit Content-Length, and the engine-owned Connection header stripped
+    // — no framing desync, no Connection leak.
     const allocator = std.testing.allocator;
 
     var resp = Response.init(allocator);
     defer resp.deinit();
     resp.status = 101;
-    try resp.addHeader("Upgrade", "websocket");
-    try resp.addHeader("Connection", "Upgrade");
-    try resp.addHeader("Sec-WebSocket-Accept", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    resp.body = "oops";
+    try resp.addHeader("Connection", "Upgrade"); // engine-owned → stripped
+    try resp.addHeader("X-Keep", "1");
 
     var buf: std.Io.Writer.Allocating = .init(allocator);
     defer buf.deinit();
     try resp.serialize(&buf.writer);
 
-    const expected = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n";
-    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
+    const out = buf.writer.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 101 Switching Protocols\r\n"));
+    // Content-Length now present (no 101 skip) → framing intact.
+    try std.testing.expect(std.mem.indexOf(u8, out, "Content-Length: 4\r\n") != null);
+    // Engine-owned Connection stripped even at 101 (exemption removed).
+    try std.testing.expect(std.mem.indexOf(u8, out, "Connection:") == null);
+    // A non-engine tenant header is still emitted.
+    try std.testing.expect(std.mem.indexOf(u8, out, "X-Keep: 1\r\n") != null);
 }
 
 test "picohttpparser websocket upgrade headers" {


### PR DESCRIPTION
Closes #194

`Response.serialize` was doing double duty — framing normal responses **and** the
engine's own 101 handshake — which forced two `status == 101` special-cases:
skip `Content-Length`, and exempt `Connection` from the engine-owned-header strip
(#176). Both were reachable by a misused Lua `ctx.status = 101`: a 101 with a body
went out with **no Content-Length** (framing desync), and a tenant `Connection`
header rode through the exemption.

## Change
- **conn_ws** builds the 101 (and the 426 reject) as **raw responses** — they
  legitimately carry engine-owned `Upgrade`/`Connection` headers that serialize
  strips from tenant output.
- With no path handing a 101 to serialize, **both special-cases are deleted**:
  serialize always frames with `Content-Length` and always strips engine-owned
  headers. Its header loop is now identical to `serializeChunkedHeaders`.
- A tenant `ctx.status=101` is now well-framed (Content-Length present, Connection
  stripped) instead of desynced. Unit test rewritten to assert exactly that.

## Verification
- Real WS upgrade handshake is byte-correct: `Sec-WebSocket-Accept:
  s3pPLMBiTxaQ9kYGzzhZRbK+xOo=` for the RFC example key, `Connection: Upgrade`
  preserved, no `Content-Length` (raw path).
- `GET /test/status/101` → `HTTP/1.1 101 Switching Protocols\r\nContent-Length:
  10\r\n\r\nstatus 101` (was an unframed body).
- `zig build test` green; full integration suite 70/70 (ws_framing, dashboard-ws
  exercise real upgrades).