### PR TITLE
fix(http): close after error responses instead of keep-alive recycle (#180)

### DIFF
--- a/src/core/conn_ws.zig
+++ b/src/core/conn_ws.zig
@@ -62,6 +62,9 @@ pub fn handleWsUpgrade(conn: *Connection, exchange: *HttpExchange, request: *con
         // engine-owned Connection header that Response.serialize strips from
         // tenant output — so emit it verbatim here (#194).
         conn.logAccess(426);
+        // Advertises Connection: close; flag so onWrite actually closes
+        // instead of recycling the socket (#180).
+        conn.close_after_write = true;
         conn.sendRawResponse("HTTP/1.1 426 Upgrade Required\r\nSec-WebSocket-Version: 13\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
         return;
     }

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -136,6 +136,11 @@ pub const Connection = struct {
     timer_cancel_completion: xev.Completion = .{},
     timed_out: bool = false,
     timer_armed: bool = false,
+    // Set by an error/reject response funnel (error_response.zig, WS 426) whose
+    // canned response advertises `Connection: close`. onWrite closes instead of
+    // recycling the socket once this write completes, so the header isn't a
+    // protocol lie (#180). Never reset — a set flag always leads to close().
+    close_after_write: bool = false,
     // In-flight timer completions (timer + timer_remove). Guards maybeFinishClose
     // so Connection outlives all armed timer CQEs — prevents use-after-free.
     pending_timer_ops: u8 = 0,
@@ -950,10 +955,14 @@ pub const Connection = struct {
         if (self.proxy_state != null) {
             proxy_mod.cleanupProxy(self);
         }
-        // If this write was the 504 timeout response, close instead of recycling.
-        // pending_timer_ops/pending_io_ops may still be non-zero (in-flight
-        // completions), so close() -> maybeFinishClose() defers deinit until they drain.
-        if (self.timed_out) {
+        // If this write was the 504 timeout response, or any other error/reject
+        // response whose canned reply advertises `Connection: close`, close
+        // instead of recycling (#180). pending_timer_ops/pending_io_ops may
+        // still be non-zero (in-flight completions), so close() ->
+        // maybeFinishClose() defers deinit until they drain.
+        // (Honoring the *client's* Connection: close request header on success
+        // responses is separate — deferred to #204.)
+        if (self.timed_out or self.close_after_write) {
             self.close();
             return .disarm;
         }

--- a/src/http/error_response.zig
+++ b/src/http/error_response.zig
@@ -105,16 +105,22 @@ pub fn logError(
 }
 
 /// Send an error response for a category. Logs the error and sends the pre-serialized response.
+/// The response advertises `Connection: close` (comptimeErrorResponse); flag
+/// the connection so onWrite actually closes instead of recycling it (#180).
 pub fn sendError(conn: *Connection, category: ErrorCategory, internal_msg: []const u8) void {
     logError(category, category.defaultStatus(), conn.http_state.request_method, conn.http_state.request_path, internal_msg);
+    conn.close_after_write = true;
     conn.sendRawResponse(statusResponse(category.defaultStatus()).?);
 }
 
 /// Send an error response for a specific status code.
 /// Uses pre-serialized response for known statuses, falls back to category default.
+/// The response advertises `Connection: close`; flag the connection so onWrite
+/// actually closes instead of recycling it (#180).
 pub fn sendErrorStatus(conn: *Connection, status: u16, internal_msg: []const u8) void {
     const category: ErrorCategory = if (status >= 500) .server_error else .client_error;
     logError(category, status, conn.http_state.request_method, conn.http_state.request_path, internal_msg);
+    conn.close_after_write = true;
     if (statusResponse(status)) |resp| {
         conn.sendRawResponse(resp);
     } else {
@@ -124,8 +130,11 @@ pub fn sendErrorStatus(conn: *Connection, status: u16, internal_msg: []const u8)
 
 /// Send 405 Method Not Allowed with an Allow header (RFC 7231 §6.5.5).
 /// `allow` is the header value, e.g. "GET, HEAD".
+/// The response advertises `Connection: close`; flag the connection so
+/// onWrite actually closes instead of recycling it (#180).
 pub fn send405(conn: *Connection, allow: []const u8) void {
     logError(.client_error, 405, conn.http_state.request_method, conn.http_state.request_path, "method not allowed");
+    conn.close_after_write = true;
     const body = "Method Not Allowed";
     const resp = std.fmt.allocPrint(conn.arena.allocator(), "HTTP/1.1 405 Method Not Allowed\r\nAllow: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{ allow, body.len, body }) catch {
         conn.sendRawResponse(statusResponse(400).?);

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -44,6 +44,52 @@ export async function rawStatus(port: number, request: string): Promise<number> 
   return Number(resp.split(" ")[1]);
 }
 
+/// Send a raw request on its own socket and observe whether the SERVER closes
+/// the connection (FIN/EOF) after responding, as opposed to keeping it open
+/// for keep-alive. Unlike `rawResponse` (which closes the socket itself on
+/// seeing the header terminator), this waits for the response headers, then
+/// watches a short quiet window for the socket's `close` callback to fire.
+/// See #180 (error responses advertise `Connection: close` but must also
+/// actually close the socket).
+export async function rawResponseAndClose(
+  port: number,
+  request: string,
+  waitMs = 500,
+): Promise<{ response: string; serverClosed: boolean }> {
+  let buf = "";
+  const { promise: headersPromise, resolve: resolveHeaders } = Promise.withResolvers<void>();
+  const { promise: closedPromise, resolve: resolveClosed } = Promise.withResolvers<void>();
+  let headersSeen = false;
+  const socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    socket: {
+      data(_s, data) {
+        buf += data.toString();
+        if (!headersSeen && buf.includes("\r\n\r\n")) {
+          headersSeen = true;
+          resolveHeaders();
+        }
+      },
+      close() {
+        resolveClosed();
+      },
+      error() {
+        resolveClosed();
+      },
+    },
+  });
+  socket.write(request);
+  socket.flush();
+  await Promise.race([headersPromise, Bun.sleep(1500).then(() => {})]);
+  const serverClosed = await Promise.race([
+    closedPromise.then(() => true),
+    Bun.sleep(waitMs).then(() => false),
+  ]);
+  socket.end();
+  return { response: buf, serverClosed };
+}
+
 export async function withServer(fn: (server: { base: string; port: number }) => Promise<void>) {
   const port = 10000 + Math.floor(Math.random() * 50000);
   const proc = Bun.spawn(

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { rawStatus, withServer } from "../harness";
+import { rawResponseAndClose, rawStatus, withServer } from "../harness";
 
 describe("worker resilience regressions", () => {
   // (#172)
@@ -36,6 +36,47 @@ describe("worker resilience regressions", () => {
       const res = await fetch(`${base}/test/echo`, { method: "POST", body });
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(body);
+    });
+  });
+});
+
+describe("connection close after error responses (#180)", () => {
+  // Every error response is served with `Connection: close`, but the server
+  // must actually close the socket after writing it — otherwise the header
+  // is a protocol lie and the connection gets recycled for keep-alive.
+  // Duplicate Content-Length is a known-good 400 trigger (see
+  // smuggling.test.ts, #169) that doesn't depend on any not-yet-shipped
+  // behavior (#203 is not done yet).
+  test("a malformed request (400) closes the socket after the response", async () => {
+    await withServer(async ({ port }) => {
+      const request =
+        `POST /test/echo HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port}\r\n` +
+        `Content-Length: 4\r\n` +
+        `Content-Length: 5\r\n\r\n` +
+        `hello`;
+      const { response, serverClosed } = await rawResponseAndClose(port, request);
+      expect(response.split(" ")[1]).toBe("400");
+      expect(serverClosed).toBe(true);
+    });
+  });
+
+  // Mid-stream framing desync: an oversized body (413) leaves the client's
+  // in-flight bytes unread. If the server recycled the socket for keep-alive
+  // (the pre-#180 bug), those leftover body bytes plus the pipelined second
+  // request would get parsed as a new request on the same connection. The
+  // server closing the socket after the 413 is what prevents that: the
+  // pipelined GET must never be served.
+  test("mid-stream desync: an oversized-body 413 closes before a pipelined request can be served", async () => {
+    await withServer(async ({ port }) => {
+      const oversized = "x".repeat(100 * 1024); // exceeds the 64KB read buffer
+      const pipelined =
+        `POST /test/echo HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nContent-Length: ${oversized.length}\r\n\r\n${oversized}` +
+        `GET /test/hello HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`;
+      const { response, serverClosed } = await rawResponseAndClose(port, pipelined);
+      expect(response.split(" ")[1]).toBe("413");
+      expect(response).not.toContain("200 OK");
+      expect(serverClosed).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem
Every error/reject response advertises `Connection: close`, but `onWrite` → `handleHttpPostWrite` recycled the socket for keep-alive. The header was a protocol lie, and it caused two real defects:

1. **Mid-stream framing desync** — for a 413 (oversized body) or a parse error while the client is still transmitting, the buffer reset only discards bytes already received; the client's remaining in-flight bytes land after the reset and get parsed as a *fresh request* on the same socket.
2. **Dangling header timer** — the error path never ran `cancelHeaderTimer`; `handleHttpPostWrite` flipped `header_timer_armed = false` without cancelling, so the next `startRead` re-armed a still-live completion.

## Fix
Generalize the existing 504-timeout close path. Add a `close_after_write` flag, set it in the error funnels (`sendError`/`sendErrorStatus`/`send405`) and the WS 426 reject, and have `onWrite` close instead of recycling when it's set. `close()` already cancels both timers and closes the fd — so one mechanism fixes the protocol lie, the desync, and the dangling timer.

## Scope
Honoring the *client's* `Connection: close` request header on success responses is separate (HTTP/1.0/1.1 keep-alive semantics) and deferred to #204; noted in a code comment.

## Tests
Two integration tests (`resilience.test.ts`, #180 block) + a `rawResponseAndClose` harness helper that observes server-initiated FIN:
- malformed request (dup Content-Length) → 400 and socket closes.
- oversized-body 413 → closes before a pipelined GET can be served (the desync primitive).

Red-first confirmed (fail on the behavioral line only); `zig build test` + full bun suite (72/72) green.

Closes #180
