### PR TITLE
fix(http): support HEAD everywhere GET is supported (#202)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -790,10 +790,24 @@ pub const Connection = struct {
             return null;
         }
 
-        const route_match = self.router.match(request.method, clean_path, &self.param_cache) catch {
+        var route_match = self.router.match(request.method, clean_path, &self.param_cache) catch {
             error_response.sendError(self, .client_error, "route match error");
             return error.RouteMatchFailed;
         };
+
+        // RFC 9110 §9.1: HEAD must be supported wherever GET is. Fall back to
+        // the GET handler when no explicit HEAD route matched. `match` already
+        // populated param_cache while walking the trie above (regardless of
+        // the method miss), and `put` APPENDS rather than overwriting by key
+        // (src/http/params.zig) — clear before the retry or a parameterized
+        // route ends up with duplicate param entries.
+        if (route_match == null and std.mem.eql(u8, request.method, "HEAD")) {
+            self.param_cache.clear();
+            route_match = self.router.match("GET", clean_path, &self.param_cache) catch {
+                error_response.sendError(self, .client_error, "route match error");
+                return error.RouteMatchFailed;
+            };
+        }
 
         if (route_match == null) {
             if (self.router.methodsForPath(clean_path)) |methods| {
@@ -849,7 +863,19 @@ pub const Connection = struct {
             log.debug().string("msg", "ws response buf").int("len", response_bytes.len).string("content", response_bytes).log();
         }
 
-        self.submitSend(response_bytes, onWrite, false);
+        self.submitSend(self.stripBodyForHead(response_bytes), onWrite, false);
+    }
+
+    /// A HEAD response carries the headers (incl. Content-Length) a GET would
+    /// have sent, but no body (RFC 9110 §8.6, §9.3.2). Truncate an
+    /// already-serialized response right after its header block when the
+    /// request was HEAD; otherwise return it unchanged. Not folded into
+    /// submitSend: that function also carries WS/SSE/streaming frames and the
+    /// proxy relay, where a blanket strip would corrupt the payload.
+    fn stripBodyForHead(self: *Connection, bytes: []const u8) []const u8 {
+        if (!std.mem.eql(u8, self.http_state.request_method, "HEAD")) return bytes;
+        const header_end = std.mem.indexOf(u8, bytes, "\r\n\r\n") orelse return bytes;
+        return bytes[0 .. header_end + 4];
     }
 
     /// Submit a send on this connection's socket.
@@ -872,7 +898,7 @@ pub const Connection = struct {
 
     pub fn sendRawResponse(self: *Connection, text: []const u8) void {
         self.state = .writing;
-        self.submitSend(text, onWrite, true);
+        self.submitSend(self.stripBodyForHead(text), onWrite, true);
     }
 
     pub fn send400BadRequest(self: *Connection) void {

--- a/tests/integration/http_conformance.test.ts
+++ b/tests/integration/http_conformance.test.ts
@@ -25,62 +25,151 @@ describe("405 Method Not Allowed (#176)", () => {
   });
 });
 
+// fetch()/undici discard the body of a HEAD response regardless of what the
+// server actually sent, so verifying "no body on the wire" needs the literal
+// bytes from a raw socket. The response can arrive across multiple send()
+// calls (e.g. static's headers-then-pread-loop), and not every response
+// closes the connection afterward, so we can't rely on a socket close
+// either. Instead debounce on a quiet period: resolve once no new bytes have
+// arrived for a short window. Shared by (#176) static HEAD and (#202)
+// HEAD-on-Lua-route/HEAD-on-canned-error.
+async function rawHead(method: string, path: string): Promise<{ status: number; contentLength: number | null; bodyBytes: number }> {
+  const request = `${method} ${path} HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`;
+  const chunks: Buffer[] = [];
+  const { promise, resolve: settle } = Promise.withResolvers<void>();
+  let quietTimer: ReturnType<typeof setTimeout>;
+  const armQuiet = () => {
+    clearTimeout(quietTimer);
+    quietTimer = setTimeout(settle, 250);
+  };
+  const socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: port(),
+    socket: {
+      data(_s, data) {
+        chunks.push(Buffer.from(data));
+        armQuiet();
+      },
+      close() {
+        clearTimeout(quietTimer);
+        settle();
+      },
+      error() {
+        clearTimeout(quietTimer);
+        settle();
+      },
+    },
+  });
+  socket.write(request);
+  socket.flush();
+  armQuiet();
+  await Promise.race([promise, Bun.sleep(3000).then(() => {})]);
+  socket.end();
+
+  const buf = Buffer.concat(chunks);
+  const sep = buf.indexOf("\r\n\r\n");
+  const headerText = (sep === -1 ? buf : buf.subarray(0, sep)).toString("latin1");
+  const bodyBytes = sep === -1 ? 0 : buf.length - (sep + 4);
+  const status = Number(headerText.split("\r\n")[0]?.split(" ")[1]);
+  const clMatch = headerText.match(/content-length:\s*(\d+)/i);
+  return { status, contentLength: clMatch ? Number(clMatch[1]) : null, bodyBytes };
+}
+
 describe("HEAD on static files (#176)", () => {
-  // fetch()/undici discard the body of a HEAD response regardless of what
-  // the server actually sent, so this needs the literal bytes on the wire.
-  // The response arrives across multiple send() calls (headers, then a
-  // pread+send loop per chunk — see src/http/static.zig), and the server
-  // does not close the connection afterward (no Connection: close support),
-  // so we can't wait for a socket close either. Instead debounce on a quiet
-  // period: resolve once no new bytes have arrived for a short window.
-  async function rawHead(path: string): Promise<{ status: number; contentLength: number | null; bodyBytes: number }> {
-    const request = `HEAD ${path} HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`;
-    const chunks: Buffer[] = [];
-    const { promise, resolve: settle } = Promise.withResolvers<void>();
+  test("(#176) HEAD on a static file returns Content-Length but no body", async () => {
+    const want = await Bun.file(resolve(PUBLIC, "index.html")).arrayBuffer();
+    const { status, contentLength, bodyBytes } = await rawHead("HEAD", "/__keyway/dashboard/index.html");
+    expect(status).toBe(200);
+    expect(contentLength).toBe(want.byteLength);
+    expect(bodyBytes).toBe(0);
+  });
+});
+
+describe("HEAD support everywhere else (#202)", () => {
+  // #176 fixed HEAD for static files only; Lua routes and canned/built-in
+  // responses still 405'd or leaked a body. RFC 9110 §9.1 requires HEAD
+  // wherever GET is supported, and §9.3.2/§8.6 says a HEAD response carries
+  // the Content-Length GET would have produced but no body.
+
+  test("(#202) HEAD on a GET-only Lua route returns 200 with GET's Content-Length and no body", async () => {
+    const want = await fetch(`${base()}/test/hello`).then((r) => r.arrayBuffer());
+    const { status, contentLength, bodyBytes } = await rawHead("HEAD", "/test/hello");
+    expect(status).toBe(200);
+    expect(contentLength).toBe(want.byteLength);
+    expect(bodyBytes).toBe(0);
+  });
+
+  test("(#202) HEAD on a canned error (404) returns zero body bytes", async () => {
+    const { status, bodyBytes } = await rawHead("HEAD", "/test/does-not-exist-202");
+    expect(status).toBe(404);
+    expect(bodyBytes).toBe(0);
+  });
+
+  // A compliant client that sent HEAD does not expect a body and stops
+  // reading after the header block. If the server actually put body bytes
+  // on the wire, those bytes sit unread until the client's *next* response
+  // read (for a subsequent request on the same keep-alive connection),
+  // corrupting that parse. /health is a success response, so it stays
+  // keep-alive (#180 only closes after errors) — this reproduces the
+  // desync directly: read only through HEAD's header block (mimicking a
+  // compliant client), fire the next request immediately, then verify
+  // everything that follows on the wire is GET's response and nothing else.
+  test("(#202) HEAD /health then GET /health on one socket: HEAD leaves no stray body bytes", async () => {
+    let wire = Buffer.alloc(0);
+    let headerEnd = -1;
+    let sentSecond = false;
+    const { promise: donePromise, resolve: settleDone } = Promise.withResolvers<void>();
     let quietTimer: ReturnType<typeof setTimeout>;
     const armQuiet = () => {
       clearTimeout(quietTimer);
-      quietTimer = setTimeout(settle, 250);
+      quietTimer = setTimeout(settleDone, 250);
     };
     const socket = await Bun.connect({
       hostname: "127.0.0.1",
       port: port(),
       socket: {
-        data(_s, data) {
-          chunks.push(Buffer.from(data));
+        data(s, data) {
+          wire = Buffer.concat([wire, Buffer.from(data)]);
+          if (!sentSecond) {
+            const sep = wire.indexOf("\r\n\r\n");
+            if (sep !== -1) {
+              headerEnd = sep + 4;
+              sentSecond = true;
+              s.write(`GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`);
+              s.flush();
+            }
+          }
           armQuiet();
         },
         close() {
           clearTimeout(quietTimer);
-          settle();
+          settleDone();
         },
         error() {
           clearTimeout(quietTimer);
-          settle();
+          settleDone();
         },
       },
     });
-    socket.write(request);
+    socket.write(`HEAD /health HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`);
     socket.flush();
     armQuiet();
-    await Promise.race([promise, Bun.sleep(3000).then(() => {})]);
+    await Promise.race([donePromise, Bun.sleep(3000).then(() => {})]);
     socket.end();
 
-    const buf = Buffer.concat(chunks);
-    const sep = buf.indexOf("\r\n\r\n");
-    const headerText = (sep === -1 ? buf : buf.subarray(0, sep)).toString("latin1");
-    const bodyBytes = sep === -1 ? 0 : buf.length - (sep + 4);
-    const status = Number(headerText.split("\r\n")[0]?.split(" ")[1]);
-    const clMatch = headerText.match(/content-length:\s*(\d+)/i);
-    return { status, contentLength: clMatch ? Number(clMatch[1]) : null, bodyBytes };
-  }
-
-  test("(#176) HEAD on a static file returns Content-Length but no body", async () => {
-    const want = await Bun.file(resolve(PUBLIC, "index.html")).arrayBuffer();
-    const { status, contentLength, bodyBytes } = await rawHead("/__keyway/dashboard/index.html");
-    expect(status).toBe(200);
-    expect(contentLength).toBe(want.byteLength);
-    expect(bodyBytes).toBe(0);
+    expect(headerEnd).toBeGreaterThan(-1);
+    const rest = wire.subarray(headerEnd).toString("latin1");
+    // The bytes right after HEAD's header block must be GET's response —
+    // nothing else. A stray leading body byte from HEAD fails this first.
+    expect(rest.startsWith("HTTP/1.1 200")).toBe(true);
+    const sep2 = rest.indexOf("\r\n\r\n");
+    expect(sep2).toBeGreaterThan(-1);
+    const clMatch = rest.slice(0, sep2).match(/content-length:\s*(\d+)/i);
+    expect(clMatch).toBeTruthy();
+    const contentLength = Number(clMatch![1]);
+    const body = rest.slice(sep2 + 4);
+    expect(body.length).toBe(contentLength);
+    expect(JSON.parse(body)).toEqual({ status: "ok" });
   });
 });
 


### PR DESCRIPTION
## Problem
#176 fixed HEAD for static files only. Everywhere else HEAD was broken:
- HEAD on a GET-only Lua route → 405 (RFC 9110 §9.1 requires HEAD wherever GET is supported).
- `HEAD /health`, `HEAD /metrics` → 200 **with a body**; canned errors (404 etc.) likewise. A HEAD response must carry no body — a keep-alive client reads those bytes as the start of the next response (framing desync).

## Fix
Two central changes in `src/core/handler.zig`, no per-endpoint hacks:
1. **GET fallback at route match** — when the method is HEAD and no explicit HEAD route matched, retry the lookup with GET. `router.match` populates `param_cache` via an appending `put`, so the retry clears it first (else a parameterized route gets duplicate params).
2. **Body-strip in the write path** — a `stripBodyForHead` helper truncates an already-serialized response at the end of the header block when `request_method == "HEAD"`, keeping the Content-Length GET would have sent (RFC 9110 §8.6/§9.3.2). Called at the two HTTP-response chokepoints (`sendRawResponse`, `writeResponseDirect`) — deliberately not in `submitSend` (which also carries WS/SSE/streaming frames and the proxy relay), and not in `static.zig` (already does HEAD) or `proxy.zig` (a relay).

Covers Lua routes, built-ins (`/health`, `/metrics`), and canned errors in one change.

## Tests
`http_conformance.test.ts` (#202 block), reusing a generalized `rawHead(method, path)` helper:
- HEAD on a GET-only Lua route → 200, Content-Length == GET body length, zero body bytes.
- HEAD on a canned 404 → zero body bytes.
- `HEAD /health` then `GET /health` on one keep-alive socket → the GET response parses cleanly (no stray HEAD body bytes).

Red-first confirmed (405→200, 9→0 body bytes, desync); `zig build test` (123) + full bun suite (75/75) green.

Closes #202
