### PR TITLE
fix(http): reject HTTP/1.1 requests missing or duplicating Host (#203)

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -209,10 +209,13 @@ pub const Parser = struct {
         // RFC 7230 §3.3.2 — the final coding is what determines chunked-ness).
         var content_length: ?usize = null;
         var transfer_encoding: ?[]const u8 = null;
+        var host_count: usize = 0;
         for (0..num_headers) |i| {
             const h = c_headers[i];
             const name = h.name[0..h.name_len];
-            if (std.ascii.eqlIgnoreCase(name, "content-length")) {
+            if (std.ascii.eqlIgnoreCase(name, "host")) {
+                host_count += 1;
+            } else if (std.ascii.eqlIgnoreCase(name, "content-length")) {
                 const val = h.value[0..h.value_len];
                 if (!isDigitsOnly(val)) {
                     self.allocator.free(headers);
@@ -233,6 +236,13 @@ pub const Parser = struct {
             } else if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) {
                 transfer_encoding = h.value[0..h.value_len];
             }
+        }
+
+        // RFC 9112 §3.2: an HTTP/1.1 request MUST have exactly one Host header.
+        // HTTP/1.0 has no such requirement.
+        if (minor_version == 1 and host_count != 1) {
+            self.allocator.free(headers);
+            return error.InvalidRequest;
         }
 
         // A request with both headers is the classic CL.TE/TE.CL smuggling
@@ -471,6 +481,25 @@ test "http parser - rejects Transfer-Encoding with non-chunked final coding" {
     const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked, gzip\r\n\r\n4\r\nping\r\n0\r\n\r\n";
     const result = parser.parseRequest(request);
     try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - rejects HTTP/1.1 request with no Host header" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.1\r\nUser-Agent: test\r\n\r\n";
+    const result = parser.parseRequest(request);
+    try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - HTTP/1.0 request with no Host header parses OK" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.0\r\nUser-Agent: test\r\n\r\n";
+    const request_result = try parser.parseRequest(request);
+    defer allocator.free(request_result.headers);
+    try std.testing.expectEqualStrings("/test", request_result.path);
 }
 
 test "serialize no longer special-cases 101 — a tenant ctx.status=101 is framed, not desynced (#194)" {

--- a/tests/integration/http_conformance.test.ts
+++ b/tests/integration/http_conformance.test.ts
@@ -246,3 +246,43 @@ describe("static sibling-prefix traversal boundary (#176)", () => {
     expect(status).toBe(403);
   });
 });
+
+describe("Host header enforcement (#203)", () => {
+  // RFC 9112 §3.2: a server MUST respond 400 to any HTTP/1.1 request that
+  // does not have exactly one Host header. HTTP/1.0 has no such requirement.
+  test("(#203) HTTP/1.1 request with no Host header is rejected with 400", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET /health HTTP/1.1\r\nConnection: close\r\n\r\n`,
+    );
+    expect(status).toBe(400);
+  });
+
+  test("(#203) HTTP/1.1 request with two differing Host headers is rejected with 400", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET /health HTTP/1.1\r\nHost: a.example\r\nHost: b.example\r\nConnection: close\r\n\r\n`,
+    );
+    expect(status).toBe(400);
+  });
+
+  // Control: HTTP/1.0 has no Host requirement — a Host-less 1.0 request must
+  // still be served, not rejected.
+  test("(#203) HTTP/1.0 request with no Host header is still served (control)", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET /health HTTP/1.0\r\nConnection: close\r\n\r\n`,
+    );
+    expect(status).toBe(200);
+  });
+
+  // Control: a well-formed HTTP/1.1 request with exactly one Host is
+  // unaffected by the new check.
+  test("(#203) HTTP/1.1 request with exactly one Host header is served (control)", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET /health HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`,
+    );
+    expect(status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Problem
An HTTP/1.1 request lacking a `Host` header (or carrying more than one) was accepted and routed. RFC 9112 §3.2: a server MUST respond 400 to an HTTP/1.1 request that lacks exactly one Host header.

## Fix
`Parser.parseRequest` (`src/http/http.zig`) already walks all headers once for Content-Length/Transfer-Encoding — count `Host` headers in that same pass, and after the loop reject (`error.InvalidRequest` → existing 400 path) when `minor_version == 1 and host_count != 1`. Covers both missing (count 0) and duplicate (count > 1). HTTP/1.0 (minor_version 0) is exempt. No handler change — `error.InvalidRequest` already routes to a 400.

## Tests
- Zig parser units: HTTP/1.1 no Host → `error.InvalidRequest`; HTTP/1.0 no Host → parses OK.
- Integration (`http_conformance.test.ts`): 1.1 no-Host → 400; 1.1 two differing Hosts → 400; 1.0 no-Host → 200 (control); 1.1 one Host → 200 (control).

Red-first confirmed (Zig test red pre-fix; integration 200→400). `zig build test` (125) + full bun suite (79/79) green.

Closes #203
