### PR TITLE
fix(sse): unref on_message/on_close on every SSE upgrade return (#192)

### DIFF
--- a/src/core/conn_sse.zig
+++ b/src/core/conn_sse.zig
@@ -6,6 +6,7 @@ const castUserdata = @import("../util/helpers.zig").castUserdata;
 const HttpExchange = @import("../http/http_exchange.zig").HttpExchange;
 const SseRegistry = @import("../protocol/sse.zig").SseRegistry;
 const config = @import("../util/config.zig");
+const Lua = @import("luajit").Lua;
 
 /// SSE connection state — set after successful SSE upgrade.
 /// Holds all SSE-specific fields; Connection.sse_state is ?SseState = null.
@@ -38,6 +39,18 @@ pub const SseState = struct {
 
 /// Handle SSE upgrade: send headers, set state, subscribe to registry.
 pub fn handleSseUpgrade(self: *Connection, exchange: *HttpExchange) void {
+    // ctx.on_message/on_close are ref'd into the Lua registry before this
+    // runs (lua_api.zig), but SSE never uses them — SseState has no callback
+    // fields (#175 is WS's twin: it moves the refs into WsState on success).
+    // Free them here on every return from this function so a handler that
+    // sets both then upgrades to SSE doesn't pin them in the registry
+    // forever (#192).
+    const lua = self.lua_state.lua;
+    defer {
+        if (exchange.ws_on_message_ref != 0) lua.unref(Lua.PseudoIndex.Registry, exchange.ws_on_message_ref);
+        if (exchange.ws_on_close_ref != 0) lua.unref(Lua.PseudoIndex.Registry, exchange.ws_on_close_ref);
+    }
+
     const room = exchange.sse_room;
     if (room.len == 0) {
         self.logAccess(400);

--- a/tests/fixtures.lua
+++ b/tests/fixtures.lua
@@ -79,6 +79,17 @@ keyway.routes["/test/sse"] = {
     end,
 }
 
+-- (#192) Sets on_message/on_close (like a WS handler would) but leaves
+-- sse_room unset, so the SSE upgrade is rejected with 400 — exercises the
+-- Lua-registry-ref cleanup on the SSE reject path.
+keyway.routes["/test/sse-no-room"] = {
+    GET = function(ctx)
+        ctx.on_message = function() end
+        ctx.on_close = function() end
+        ctx.upgrade = "sse"
+    end,
+}
+
 keyway.routes["/test/ws"] = {
     GET = function(ctx)
         ctx.upgrade = "websocket"

--- a/tests/integration/sse.test.ts
+++ b/tests/integration/sse.test.ts
@@ -102,4 +102,24 @@ describe("sse", () => {
       socket.terminate();
     }
   }, 20000);
+
+  // (#192) ctx.on_message/on_close ref the handler into the Lua registry
+  // before the upgrade runs (lua_api.zig); the SSE reject path (missing
+  // sse_room -> 400) never frees them unless conn_sse.handleSseUpgrade
+  // unrefs on every return, mirroring the WS twin (#175). There's no
+  // network-reachable signal for Lua registry size, so this can't assert
+  // the leak is fixed directly — it only proves the reject path keeps
+  // working (and doesn't wedge/crash) across many upgrade attempts that
+  // each ref two callbacks. The fix itself is inspection-verified.
+  test("repeated rejected SSE upgrades with on_message/on_close set stay healthy", async () => {
+    for (let i = 0; i < 50; i++) {
+      const res = await fetch(`${base()}/test/sse-no-room`);
+      expect(res.status).toBe(400);
+      await res.arrayBuffer();
+    }
+
+    // Server is still serving requests normally after the loop.
+    const health = await fetch(`${base()}/test/hello`);
+    expect(health.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Problem
`ctx.on_message`/`ctx.on_close` are ref'd into the Lua registry (stored in `exchange.ws_on_message_ref`/`ws_on_close_ref` — the only registry-ref fields, used by both upgrade types). The WS path frees them (#175); the SSE path (`handleSseUpgrade`) never did. A handler that set them then requested an SSE upgrade — on the reject paths (missing room → 400, OOM/subscribe → 500) *and* on success — pinned those refs in the registry forever.

## Fix
Mirror #175's guard: a `defer` at the top of `handleSseUpgrade` (`src/core/conn_sse.zig`) unrefs both refs if non-zero, on every return. SSE never moves these into `SseState` (it has no callback fields) and no SSE path reads them post-upgrade, so unconditional unref is safe on all paths, success included. ~7 lines.

## Tests
`tests/fixtures.lua` adds `/test/sse-no-room` (sets on_message/on_close, omits sse_room → 400 reject). `sse.test.ts` loops that reject 50× and confirms the server stays healthy. Note: there is no network-reachable Lua-registry-size signal, so this exercises the path but cannot assert the leak directly (verified it passes identically pre/post-fix) — the fix is inspection-verified, matching the issue's stated caveat and #175's precedent (which also shipped without a registry-size unit test).

`zig build test` (green) + full bun suite (76/76) green.

Closes #192
