### PR TITLE
fix(proxy): strip hop-by-hop headers from upstream responses, re-frame as Content-Length (#182)

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -309,6 +309,70 @@ pub const Parser = struct {
         }
         return null;
     }
+
+    /// Parse an HTTP response's status line + headers from a buffer via
+    /// picohttpparser. Mirrors parseRequest, but for responses — used by the
+    /// reverse-proxy response path (proxy.zig's forwardProxyResponse) to
+    /// parse the buffered upstream response before stripping hop-by-hop
+    /// headers and re-emitting it to the client (#182). Body framing is the
+    /// caller's job: `head_len` is where the body starts in `buf`.
+    pub fn parseResponseHead(self: *Parser, buf: []const u8) !ResponseHead {
+        var minor_version: c_int = 0;
+        var status: c_int = 0;
+        var msg_ptr: [*c]const u8 = undefined;
+        var msg_len: usize = 0;
+
+        const max_headers: usize = config.MAX_HEADERS;
+        var c_headers: [max_headers]c.struct_phr_header = undefined;
+        var num_headers: usize = max_headers;
+
+        const result = c.phr_parse_response(
+            buf.ptr,
+            buf.len,
+            &minor_version,
+            &status,
+            @ptrCast(&msg_ptr),
+            &msg_len,
+            &c_headers,
+            &num_headers,
+            0, // last_len (0 for first parse)
+        );
+
+        if (result == -2) {
+            return error.Incomplete;
+        }
+        if (result == -1) {
+            return error.InvalidRequest;
+        }
+
+        const reason = msg_ptr[0..msg_len];
+
+        var headers = try self.allocator.alloc(Header, num_headers);
+        for (0..num_headers) |i| {
+            const h = c_headers[i];
+            headers[i] = Header{
+                .name = h.name[0..h.name_len],
+                .value = h.value[0..h.value_len],
+            };
+        }
+
+        return ResponseHead{
+            .status = @intCast(status),
+            .reason = reason,
+            .minor_version = minor_version,
+            .headers = headers,
+            .head_len = @intCast(result),
+        };
+    }
+};
+
+/// Parsed HTTP response status line + headers (see Parser.parseResponseHead).
+pub const ResponseHead = struct {
+    status: u16,
+    reason: []const u8, // slice into buf
+    minor_version: c_int,
+    headers: []Header, // caller frees with the allocator passed to Parser.init
+    head_len: usize, // byte offset in buf where the body begins
 };
 
 test "response serialization" {
@@ -566,15 +630,17 @@ pub fn encodeChunk(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
 pub const terminal_chunk = "0\r\n\r\n";
 
 /// Result of decoding a chunked transfer-encoded body.
-const ChunkedResult = struct {
+pub const ChunkedResult = struct {
     body: []const u8,
     total_consumed: usize,
 };
 
 /// Decode a chunked transfer-encoded body.
-/// Returns the reassembled body (arena-allocated) and total bytes consumed.
-/// Returns error.Incomplete if the terminal chunk hasn't been received yet.
-fn decodeChunkedBody(data: []const u8, allocator: std.mem.Allocator) !ChunkedResult {
+/// Returns the reassembled body (allocated with the passed allocator) and
+/// total bytes consumed. Returns error.Incomplete if the terminal chunk
+/// hasn't been received yet. Public: also used by proxy.zig to decode a
+/// chunked upstream response body (#182).
+pub fn decodeChunkedBody(data: []const u8, allocator: std.mem.Allocator) !ChunkedResult {
     var body_buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer body_buf.deinit(allocator);
     var pos: usize = 0;
@@ -698,6 +764,29 @@ test "decodeChunkedBody returns Incomplete for trailer missing final blank line"
     const allocator = std.testing.allocator;
     const data = "5\r\nHello\r\n0\r\nX-Trailer: v\r\n";
     try std.testing.expectError(error.Incomplete, decodeChunkedBody(data, allocator));
+}
+
+test "parseResponseHead parses status, reason, headers, and head_len" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+    const buf = "HTTP/1.1 200 OK\r\nX-Foo: bar\r\nContent-Length: 5\r\n\r\nhello";
+    const head = try parser.parseResponseHead(buf);
+    defer allocator.free(head.headers);
+
+    try std.testing.expectEqual(@as(u16, 200), head.status);
+    try std.testing.expectEqualStrings("OK", head.reason);
+    try std.testing.expectEqual(@as(usize, 2), head.headers.len);
+    try std.testing.expectEqualStrings("X-Foo", head.headers[0].name);
+    try std.testing.expectEqualStrings("bar", head.headers[0].value);
+    try std.testing.expectEqualStrings("Content-Length", head.headers[1].name);
+    try std.testing.expectEqualStrings("hello", buf[head.head_len..]);
+}
+
+test "parseResponseHead rejects a malformed status line" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+    const buf = "not an http response at all\r\n\r\n";
+    try std.testing.expectError(error.InvalidRequest, parser.parseResponseHead(buf));
 }
 
 test "serializeChunkedHeaders omits Content-Length" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -5,9 +5,12 @@
 //! (io_uring) and never blocks it.
 //!
 //! Response framing: we send `Connection: close` upstream and read until EOF,
-//! buffering the whole response before relaying it (no Content-Length/chunked
-//! parsing). Upstream hosts are pre-resolved to an address at route
-//! registration, so the data path never does DNS.
+//! buffering the whole response, then parse it (picohttpparser) to strip
+//! hop-by-hop headers and regenerate Content-Length before relaying it to the
+//! client (#182) — a de-chunked or as-is body copied into a fresh buffer, not
+//! a streamed rewrite (see forwardProxyResponse). Upstream hosts are
+//! pre-resolved to an address at route registration, so the data path never
+//! does DNS.
 //!
 //! Connect/send/recv go through xev.TCP rather than raw xev.Completion ops
 //! (the pattern the rest of this file's siblings use for the client socket):
@@ -53,12 +56,17 @@ pub const ProxyState = struct {
     // timeout (see onProxyTimeout) — a cancel op needs its own completion
     // struct, separate from the one it targets.
     cancel_completion: xev.Completion = .{},
+    // Hop-by-hop-stripped, reframed response sent to the client (built by
+    // forwardProxyResponse). Own base_allocator buffer, like request_buf: it
+    // must outlive the async send. Empty until set.
+    client_response: []const u8 = &.{},
 
     pub fn deinit(self: *ProxyState, allocator: std.mem.Allocator) void {
         helpers.closeFd(self.tcp.fd);
         allocator.free(self.request_buf);
         allocator.free(self.recv_buf);
         self.response.deinit(allocator);
+        if (self.client_response.len > 0) allocator.free(self.client_response);
     }
 };
 
@@ -397,18 +405,38 @@ fn onProxyUpstreamRecv(
     return .disarm;
 }
 
-/// Parse the 3-digit status code from a buffered upstream response's status
-/// line (e.g. "HTTP/1.1 502 Bad Gateway\r\n" -> 502). Returns null if the
-/// buffer is too short or doesn't start with a well-formed status line.
-/// Never allocates.
-fn parseUpstreamStatus(response: []const u8) ?u16 {
-    if (response.len < 12) return null;
-    if (!std.mem.startsWith(u8, response, "HTTP/1.")) return null;
-    if (!std.ascii.isDigit(response[7]) or response[8] != ' ') return null;
-    return std.fmt.parseInt(u16, response[9..12], 10) catch null;
+/// True if `headers`' final Transfer-Encoding coding is "chunked" (RFC 7230
+/// §3.3.2/§3.3.3: repeated TE headers combine, so the *last* header's *last*
+/// comma-separated token is what determines chunked-ness). Mirrors the
+/// identical check in Parser.parseRequest, duplicated here rather than
+/// shared: that one operates inline over raw picohttpparser output while
+/// parsing a request, this one over an already-parsed Header slice.
+fn isChunkedResponse(headers: []const http.Header) bool {
+    var te_val: ?[]const u8 = null;
+    for (headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "transfer-encoding")) te_val = h.value;
+    }
+    const val = te_val orelse return false;
+    const last_token = if (std.mem.lastIndexOfScalar(u8, val, ',')) |idx| val[idx + 1 ..] else val;
+    return std.ascii.eqlIgnoreCase(std.mem.trim(u8, last_token, " \t"), "chunked");
 }
 
-/// Relay the buffered upstream response to the client.
+/// True if a response to this exchange carries no body, per RFC 9110
+/// §6.4.1: the request was HEAD, or status is 1xx/204/304.
+fn responseHasNoBody(request_method: []const u8, status: u16) bool {
+    if (std.mem.eql(u8, request_method, "HEAD")) return true;
+    if (status >= 100 and status <= 199) return true;
+    if (status == 204 or status == 304) return true;
+    return false;
+}
+
+/// Parse the buffered upstream response, strip hop-by-hop headers, and
+/// relay it to the client.
+///
+/// ponytail: buffered relay — the whole body is copied into a fresh
+/// base_allocator buffer rather than rewritten in place/streamed. Simple and
+/// correct for the read-to-EOF buffering this file already does; a
+/// zero-copy/streaming relay is future work (out of scope for #182).
 fn forwardProxyResponse(self: *Connection) void {
     self.cancelRequestTimer();
     const ps = &self.proxy_state.?;
@@ -416,19 +444,71 @@ fn forwardProxyResponse(self: *Connection) void {
         proxyFail(self, 502, "proxy upstream empty response");
         return;
     }
-    // Log the real upstream status rather than a hardcoded 200 (#73). The
-    // response bytes are relayed to the client verbatim regardless; if the
-    // status line doesn't parse, the upstream didn't send valid HTTP, so we
-    // log 502 (bad gateway) rather than lie with 200.
-    self.logAccess(parseUpstreamStatus(ps.response.items) orelse 502);
+
+    var parser = http.Parser.init(self.base_allocator);
+    const head = parser.parseResponseHead(ps.response.items) catch {
+        proxyFail(self, 502, "proxy upstream invalid response");
+        return;
+    };
+    defer self.base_allocator.free(head.headers);
+
+    // Log the real upstream status rather than a hardcoded 200 (#73).
+    self.logAccess(head.status);
+
+    var chunked_body: ?[]const u8 = null;
+    defer if (chunked_body) |cb| self.base_allocator.free(cb);
+
+    const body: []const u8 = if (responseHasNoBody(self.http_state.request_method, head.status))
+        ""
+    else if (isChunkedResponse(head.headers)) blk: {
+        const decoded = http.decodeChunkedBody(ps.response.items[head.head_len..], self.base_allocator) catch {
+            proxyFail(self, 502, "proxy upstream invalid chunked body");
+            return;
+        };
+        chunked_body = decoded.body;
+        break :blk decoded.body;
+    } else
+        // Read-to-EOF already gives the full body; the upstream's own
+        // Content-Length (if any) is not authoritative — these bytes are.
+        ps.response.items[head.head_len..];
+
+    // Re-emit into a fresh base_allocator buffer: normalized status line,
+    // every parsed header that isn't hop-by-hop (isHopByHop already strips
+    // framing headers too, so Content-Length/Transfer-Encoding below are the
+    // only ones emitted), regenerated framing, then the body.
+    var aw: std.Io.Writer.Allocating = std.Io.Writer.Allocating.initCapacity(self.base_allocator, ps.response.items.len) catch {
+        proxyFail(self, 502, "proxy response build failed");
+        return;
+    };
+    defer aw.deinit();
+    const w = &aw.writer;
+    const build_ok = blk: {
+        w.print("HTTP/1.1 {d} {s}\r\n", .{ head.status, head.reason }) catch break :blk false;
+        for (head.headers) |h| {
+            if (isHopByHop(h.name, head.headers)) continue;
+            w.print("{s}: {s}\r\n", .{ h.name, h.value }) catch break :blk false;
+        }
+        w.print("Content-Length: {d}\r\n\r\n", .{body.len}) catch break :blk false;
+        w.writeAll(body) catch break :blk false;
+        break :blk true;
+    };
+    if (!build_ok) {
+        proxyFail(self, 502, "proxy response build failed");
+        return;
+    }
+
+    ps.client_response = aw.toOwnedSlice() catch {
+        proxyFail(self, 502, "proxy response build failed");
+        return;
+    };
     // Send directly from proxy_state's base_allocator buffer (arena_dupe=false)
     // rather than through sendRawResponse: that buffer must stay valid until
     // the write completion actually fires (io_uring reads it asynchronously),
     // so cleanupProxy runs from handler.zig's onWrite once the send is
     // confirmed done — not here. Freeing it at submission time would race the
-    // in-flight send; also avoids a full copy of a possibly large response.
+    // in-flight send.
     self.state = .writing;
-    self.submitSend(ps.response.items, handler_mod.Connection.onWrite, false);
+    self.submitSend(ps.client_response, handler_mod.Connection.onWrite, false);
 }
 
 /// Send an error to the client and tear down proxy state. Safe to call from any
@@ -460,30 +540,6 @@ pub fn cleanupProxy(self: *Connection) void {
 // =============================================================================
 // Tests
 // =============================================================================
-
-test "parseUpstreamStatus: well-formed status lines" {
-    try std.testing.expectEqual(@as(?u16, 200), parseUpstreamStatus("HTTP/1.1 200 OK\r\n\r\n"));
-    try std.testing.expectEqual(@as(?u16, 404), parseUpstreamStatus("HTTP/1.1 404 Not Found\r\n\r\n"));
-    try std.testing.expectEqual(@as(?u16, 502), parseUpstreamStatus("HTTP/1.0 502 Bad Gateway\r\n\r\n"));
-}
-
-test "parseUpstreamStatus: 3-digit boundary codes" {
-    try std.testing.expectEqual(@as(?u16, 100), parseUpstreamStatus("HTTP/1.1 100 Continue\r\n\r\n"));
-    try std.testing.expectEqual(@as(?u16, 999), parseUpstreamStatus("HTTP/1.1 999 X\r\n\r\n"));
-    try std.testing.expectEqual(@as(?u16, 200), parseUpstreamStatus("HTTP/1.1 200")); // exact len == 12, no trailing bytes
-}
-
-test "parseUpstreamStatus: malformed status line" {
-    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("not an http response at all"));
-    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1-200 OK\r\n\r\n"));
-    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1 abc OK\r\n\r\n"));
-    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/2 200 OK\r\n\r\n")); // not HTTP/1.x
-}
-
-test "parseUpstreamStatus: short buffer" {
-    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus(""));
-    try std.testing.expectEqual(@as(?u16, null), parseUpstreamStatus("HTTP/1.1 2"));
-}
 
 fn testRoute() router_mod.ProxyRoute {
     return .{
@@ -596,4 +652,32 @@ test "buildUpstreamRequest: GET with no body and no framing headers emits no Con
     defer std.testing.allocator.free(built);
 
     try std.testing.expect(std.mem.indexOf(u8, built, "Content-Length") == null);
+}
+
+test "isChunkedResponse: last Transfer-Encoding header's last coding determines chunked-ness" {
+    try std.testing.expect(isChunkedResponse(&[_]http.Header{
+        .{ .name = "Transfer-Encoding", .value = "chunked" },
+    }));
+    try std.testing.expect(isChunkedResponse(&[_]http.Header{
+        .{ .name = "Transfer-Encoding", .value = "gzip, chunked" },
+    }));
+    try std.testing.expect(!isChunkedResponse(&[_]http.Header{
+        .{ .name = "Transfer-Encoding", .value = "chunked, gzip" },
+    }));
+    try std.testing.expect(!isChunkedResponse(&[_]http.Header{}));
+    // Repeated headers combine (RFC 7230 §3.3.2) — the last one wins.
+    try std.testing.expect(isChunkedResponse(&[_]http.Header{
+        .{ .name = "Transfer-Encoding", .value = "gzip" },
+        .{ .name = "Transfer-Encoding", .value = "chunked" },
+    }));
+}
+
+test "responseHasNoBody: HEAD, 1xx, 204, 304 have no body; everything else does" {
+    try std.testing.expect(responseHasNoBody("HEAD", 200));
+    try std.testing.expect(responseHasNoBody("GET", 100));
+    try std.testing.expect(responseHasNoBody("GET", 199));
+    try std.testing.expect(responseHasNoBody("GET", 204));
+    try std.testing.expect(responseHasNoBody("GET", 304));
+    try std.testing.expect(!responseHasNoBody("GET", 200));
+    try std.testing.expect(!responseHasNoBody("POST", 404));
 }

--- a/tests/fixtures.lua
+++ b/tests/fixtures.lua
@@ -21,6 +21,7 @@ keyway.middleware.register("mw_after", mw_after)
 keyway.proxy["/__keyway/test-proxy"] = { host = "127.0.0.1", port = 38291, strip_prefix = true }
 keyway.proxy["/__keyway/test-proxy-dead"] = { host = "127.0.0.1", port = 1, strip_prefix = true }
 keyway.proxy["/__keyway/test-proxy-hung"] = { host = "127.0.0.1", port = 38292, strip_prefix = true }
+keyway.proxy["/__keyway/test-proxy-raw"] = { host = "127.0.0.1", port = 38293, strip_prefix = true }
 
 keyway.routes["/test/hello"] = {
     GET = function(ctx)

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -18,11 +18,32 @@ const base = () => globalThis.__KEYWAY_BASE;
 const port = () => globalThis.__KEYWAY_PORT;
 const UPSTREAM_PORT = 38291;
 const HUNG_UPSTREAM_PORT = 38292;
+const RAW_UPSTREAM_PORT = 38293;
 const LARGE_SIZE = 500_000; // ~32 chunks at a 16 KB recv buffer
 const LARGE_BODY = "x".repeat(LARGE_SIZE);
 
+// Response bodies for the raw upstream below (#182). Bun.serve's Response
+// object won't let a handler set hop-by-hop headers like Connection/
+// Keep-Alive/Proxy-Authenticate (the runtime owns and strips them), and
+// fetch()'s injects its own Transfer-Encoding for chunked bodies rather than
+// letting us hand-write chunk framing — so both cases need a raw socket that
+// writes the exact bytes on the wire, same pattern as hungUpstream above.
+const HOP_BODY = "hop-body!";
+const HOP_RESPONSE =
+  `HTTP/1.1 200 OK\r\n` +
+  `Keep-Alive: timeout=5\r\n` +
+  `Proxy-Authenticate: Basic\r\n` +
+  `Connection: x-hop\r\n` +
+  `X-Hop: leak\r\n` +
+  `X-Normal: keep\r\n` +
+  `Content-Length: ${HOP_BODY.length}\r\n\r\n` +
+  HOP_BODY;
+const CHUNKED_BODY = "hello world";
+const CHUNKED_RESPONSE = `HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n`;
+
 let upstream: Server | null = null;
 let hungUpstream: TCPSocketListener | null = null;
+let rawUpstream: TCPSocketListener | null = null;
 
 beforeAll(() => {
   upstream = Bun.serve({
@@ -73,6 +94,30 @@ beforeAll(() => {
       error() {},
     },
   });
+
+  // Serves the two raw responses above by request path, then closes — a
+  // real upstream honoring the proxy's forced `Connection: close`.
+  rawUpstream = Bun.listen({
+    hostname: "127.0.0.1",
+    port: RAW_UPSTREAM_PORT,
+    socket: {
+      data(socket, data) {
+        const req = data.toString();
+        if (req.startsWith("GET /hopbyhop ")) {
+          socket.write(HOP_RESPONSE);
+        } else if (req.startsWith("GET /chunked ")) {
+          socket.write(CHUNKED_RESPONSE);
+        } else {
+          socket.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+        }
+        socket.end();
+      },
+      open() {},
+      close() {},
+      drain() {},
+      error() {},
+    },
+  });
 });
 
 afterAll(() => {
@@ -80,6 +125,8 @@ afterAll(() => {
   upstream = null;
   hungUpstream?.stop(true);
   hungUpstream = null;
+  rawUpstream?.stop(true);
+  rawUpstream = null;
 });
 
 // Raw-socket helper (mirrors smuggling.test.ts's rawStatus): fetch() can't
@@ -192,6 +239,47 @@ describe("reverse proxy", () => {
 
     const metrics = await (await fetch(`${base()}/metrics`)).text();
     expect(metrics).toMatch(/keyway_http_requests_total\{[^}]*status="500"[^}]*\}/);
+  });
+
+  // #182: forwardProxyResponse used to relay the buffered upstream response
+  // verbatim, so every hop-by-hop response header (Connection, Keep-Alive,
+  // Proxy-Authenticate, plus anything the upstream's Connection header
+  // nominates) leaked straight to the client.
+  test("strips hop-by-hop response headers, keeps end-to-end ones, and reports a correct Content-Length", async () => {
+    const raw = await rawRequest(
+      `GET /__keyway/test-proxy-raw/hopbyhop HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Connection: close\r\n\r\n`,
+    );
+    const headerEnd = raw.indexOf("\r\n\r\n");
+    const headerBlock = raw.slice(0, headerEnd).toLowerCase();
+    const body = raw.slice(headerEnd + 4);
+
+    expect(headerBlock).not.toContain("keep-alive:");
+    expect(headerBlock).not.toContain("proxy-authenticate:");
+    expect(headerBlock).not.toContain("x-hop:");
+    expect(headerBlock).not.toContain("connection:");
+    expect(headerBlock).toContain("x-normal: keep");
+    expect(headerBlock).toContain(`content-length: ${HOP_BODY.length}`);
+    expect(body).toBe(HOP_BODY);
+  });
+
+  // #182: a chunked upstream response used to be relayed with its original
+  // Transfer-Encoding: chunked header and raw chunk framing still attached —
+  // wrong framing for a response keyway itself didn't chunk-encode.
+  test("re-frames a chunked upstream response as Content-Length", async () => {
+    const raw = await rawRequest(
+      `GET /__keyway/test-proxy-raw/chunked HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port()}\r\n` +
+        `Connection: close\r\n\r\n`,
+    );
+    const headerEnd = raw.indexOf("\r\n\r\n");
+    const headerBlock = raw.slice(0, headerEnd).toLowerCase();
+    const body = raw.slice(headerEnd + 4);
+
+    expect(headerBlock).not.toContain("transfer-encoding");
+    expect(headerBlock).toContain(`content-length: ${CHUNKED_BODY.length}`);
+    expect(body).toBe(CHUNKED_BODY);
   });
 });
 


### PR DESCRIPTION
## Problem
`forwardProxyResponse` (`src/http/proxy.zig`) relayed the buffered upstream response to the client verbatim, unparsed. Every hop-by-hop response header the upstream emitted — `Connection`, `Keep-Alive`, `Transfer-Encoding`, `Proxy-Authenticate`/`-Authorization`, `Upgrade`, `Trailer`, `TE`, plus any header nominated by the upstream's `Connection:` tokens — leaked straight to the client (RFC 7230/9110 §6.1, response side; the request-side twin was #170).

## Fix
Parse → strip → reframe the buffered response before relaying:
- **`src/http/http.zig`:** new `Parser.parseResponseHead` (picohttpparser `phr_parse_response`, mirrors `parseRequest`) returning status/reason/headers/body-offset; `decodeChunkedBody` made `pub`.
- **`src/http/proxy.zig`:** `forwardProxyResponse` now parses the upstream response (invalid → 502), determines body presence per RFC 9110 §6.4.1 (`responseHasNoBody`: HEAD / 1xx / 204 / 304), de-chunks the body if the upstream used `Transfer-Encoding: chunked` (else uses the read-to-EOF bytes), and re-emits into a fresh buffer: normalized `HTTP/1.1 {status} {reason}`, every header where `!isHopByHop(...)` (the existing #170 helper/list already strips framing + hop-by-hop + `Connection`-nominated), a regenerated `Content-Length`, then the body. New `ProxyState.client_response` owns the re-emit buffer (freed in `deinit`). Removed the now-superseded `parseUpstreamStatus`.

Buffered relay (full-body copy), consistent with the read-to-EOF buffering this file already does; a streaming/zero-copy relay is future work (noted in a `ponytail:` comment).

## Tests
- Zig units: `parseResponseHead`, `isChunkedResponse`, `responseHasNoBody`.
- Integration (`proxy.test.ts`, new raw-socket upstream): hop-by-hop headers (`Keep-Alive`/`Proxy-Authenticate`/`Connection`/nominated `X-Hop`) are stripped while an ordinary `X-Normal` passes through and `Content-Length` matches the body; a `Transfer-Encoding: chunked` upstream is re-framed to `Content-Length` with the de-chunked body intact.

Red-first confirmed (hop-by-hop headers + `Transfer-Encoding` present pre-fix). `zig build test` + full bun suite (82/82) green.

Closes #182
