### PR TITLE
fix(http): accept absolute-form request-target; If-None-Match list/*/weak (#207)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -74,6 +74,35 @@ pub const TlsState = struct {
     }
 };
 
+/// RFC 9112 §3.2.2 absolute-form: "scheme://authority/path?query" → "/path?query".
+/// Returns the target unchanged if it isn't absolute-form. Does not enforce
+/// that the authority agrees with the Host header (RFC says a server
+/// "should" check this; skipped as low-value extra strictness).
+fn originForm(target: []const u8) []const u8 {
+    // Origin-form always starts with '/'; absolute-form starts with a scheme
+    // letter. This discriminator keeps a query string containing "://"
+    // (e.g. "/redirect?url=http://x") from being misparsed as absolute-form.
+    if (target.len == 0 or target[0] == '/') return target;
+    const sep = std.mem.indexOf(u8, target, "://") orelse return target;
+    const after_authority_start = sep + 3;
+    if (after_authority_start >= target.len) return "/"; // "http://" with nothing after
+    const rel = std.mem.indexOfScalarPos(u8, target, after_authority_start, '/');
+    return if (rel) |i| target[i..] else "/"; // authority with no path → "/"
+}
+
+test "originForm strips scheme and authority from absolute-form" {
+    try std.testing.expectEqualStrings("/path", originForm("http://host/path"));
+    try std.testing.expectEqualStrings("/path?q=1", originForm("http://host:8080/path?q=1"));
+    try std.testing.expectEqualStrings("/", originForm("http://host"));
+    try std.testing.expectEqualStrings("/", originForm("http://"));
+}
+
+test "originForm leaves origin-form untouched" {
+    try std.testing.expectEqualStrings("/path", originForm("/path"));
+    try std.testing.expectEqualStrings("/redirect?url=http://x", originForm("/redirect?url=http://x"));
+    try std.testing.expectEqualStrings("", originForm(""));
+}
+
 /// Connection handler - manages HTTP request/response lifecycle
 pub const Connection = struct {
     pub const State = enum { reading, processing, writing, websocket, sse, streaming, static_file, closing };
@@ -549,8 +578,13 @@ pub const Connection = struct {
             return err;
         };
 
-        const query_pos = std.mem.indexOfScalar(u8, request.path, '?');
-        const clean_path = if (query_pos) |qi| request.path[0..qi] else request.path;
+        // RFC 9112 §3.2.2: normalize absolute-form ("http://host/path") to
+        // origin-form before routing. Authority-vs-Host agreement is
+        // intentionally not enforced (RFC says "should"; low-value here).
+        const target = originForm(request.path);
+
+        const query_pos = std.mem.indexOfScalar(u8, target, '?');
+        const clean_path = if (query_pos) |qi| target[0..qi] else target;
 
         self.http_state.request_method = request.method;
         self.http_state.request_path = clean_path;
@@ -559,7 +593,7 @@ pub const Connection = struct {
         // Parse query string and clear param cache for route matching
         self.query_cache.clear();
         if (query_pos) |qi| {
-            parseQueryString(request.path[qi + 1 ..], &self.query_cache);
+            parseQueryString(target[qi + 1 ..], &self.query_cache);
         }
         self.param_cache.clear();
 

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -255,6 +255,20 @@ fn buildStaticHeaders(
     });
 }
 
+/// RFC 9110 §13.1.2: If-None-Match is a comma-separated list of entity-tags
+/// or "*". The GET/HEAD 304 check uses weak comparison, so a "W/" weak
+/// indicator is ignored. Our own ETag is strong (no W/ prefix).
+fn ifNoneMatchMatches(header_value: []const u8, etag: []const u8) bool {
+    var it = std.mem.splitScalar(u8, header_value, ',');
+    while (it.next()) |raw| {
+        var tok = std.mem.trim(u8, raw, " \t");
+        if (std.mem.eql(u8, tok, "*")) return true;
+        if (std.mem.startsWith(u8, tok, "W/")) tok = tok[2..];
+        if (etag.len != 0 and std.mem.eql(u8, tok, etag)) return true;
+    }
+    return false;
+}
+
 /// Serve a static file. Called from handler.zig routeRequest.
 pub fn serveStaticFile(
     self: *Connection,
@@ -320,7 +334,7 @@ pub fn serveStaticFile(
     // If-None-Match takes precedence over If-Modified-Since (RFC 7232 §6):
     // when present but not matching, serve full — do not consult IMS.
     if (http.Parser.getHeader(request, "If-None-Match")) |inm| {
-        if (std.mem.eql(u8, inm, etag)) {
+        if (ifNoneMatchMatches(inm, etag)) {
             helpers.closeFd(fd);
             self.logAccess(304);
             self.sendRawResponse("HTTP/1.1 304 Not Modified\r\nContent-Length: 0\r\n\r\n");
@@ -519,6 +533,26 @@ test "isWithinRoot enforces a segment boundary, not just a string prefix" {
     try std.testing.expect(isWithinRoot("/x/public/a.css", "/x/public"));
     try std.testing.expect(!isWithinRoot("/x/public-secret/s.txt", "/x/public"));
     try std.testing.expect(!isWithinRoot("/x/pub", "/x/public"));
+}
+
+test "ifNoneMatchMatches: exact match" {
+    try std.testing.expect(ifNoneMatchMatches("\"abc\"", "\"abc\""));
+    try std.testing.expect(!ifNoneMatchMatches("\"xyz\"", "\"abc\""));
+}
+
+test "ifNoneMatchMatches: comma-separated list" {
+    try std.testing.expect(ifNoneMatchMatches("\"wrong-one\", \"abc\"", "\"abc\""));
+    try std.testing.expect(ifNoneMatchMatches("\"abc\", \"wrong-one\"", "\"abc\""));
+    try std.testing.expect(!ifNoneMatchMatches("\"wrong-one\", \"also-wrong\"", "\"abc\""));
+}
+
+test "ifNoneMatchMatches: wildcard matches anything" {
+    try std.testing.expect(ifNoneMatchMatches("*", "\"abc\""));
+}
+
+test "ifNoneMatchMatches: weak indicator is ignored" {
+    try std.testing.expect(ifNoneMatchMatches("W/\"abc\"", "\"abc\""));
+    try std.testing.expect(ifNoneMatchMatches("\"wrong\", W/\"abc\"", "\"abc\""));
 }
 
 test "parseHttpDate round-trips formatHttpDate" {

--- a/tests/integration/http_conformance.test.ts
+++ b/tests/integration/http_conformance.test.ts
@@ -286,3 +286,61 @@ describe("Host header enforcement (#203)", () => {
     expect(status).toBe(200);
   });
 });
+
+describe("absolute-form request-target (#207)", () => {
+  // RFC 9112 §3.2.2: a server MUST accept the absolute-form request-target
+  // ("GET http://host/path HTTP/1.1") a proxy client may send, not just
+  // origin-form. Authority-vs-Host agreement is intentionally not checked.
+  test("(#207) absolute-form request-target is routed as origin-form", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET http://127.0.0.1:${port()}/test/hello HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`,
+    );
+    expect(status).toBe(200);
+  });
+
+  // Control: a normal origin-form request must not regress.
+  test("(#207) origin-form request-target still works (control)", async () => {
+    const status = await rawStatus(
+      port(),
+      `GET /test/hello HTTP/1.1\r\nHost: 127.0.0.1:${port()}\r\n\r\n`,
+    );
+    expect(status).toBe(200);
+  });
+});
+
+describe("If-None-Match (#207)", () => {
+  // RFC 9110 §13.1.2: If-None-Match is a comma-separated list of
+  // entity-tags, or "*". The old check did a single exact-string compare,
+  // ignoring both the list grammar and the wildcard.
+  test("(#207) a comma-separated If-None-Match list matches when any entry equals the ETag", async () => {
+    const first = await fetch(`${base()}/__keyway/dashboard/index.html`);
+    expect(first.status).toBe(200);
+    await first.arrayBuffer();
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
+
+    const second = await fetch(`${base()}/__keyway/dashboard/index.html`, {
+      headers: { "If-None-Match": `"wrong-one", ${etag}` },
+    });
+    expect(second.status).toBe(304);
+    expect((await second.text()).length).toBe(0);
+  });
+
+  test("(#207) If-None-Match: * always matches", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/index.html`, {
+      headers: { "If-None-Match": "*" },
+    });
+    expect(res.status).toBe(304);
+    expect((await res.text()).length).toBe(0);
+  });
+
+  // Control: a single non-matching entity-tag must still serve the file —
+  // guards against over-matching once list/wildcard support is added.
+  test("(#207) a non-matching If-None-Match still serves the file (control)", async () => {
+    const res = await fetch(`${base()}/__keyway/dashboard/index.html`, {
+      headers: { "If-None-Match": '"definitely-wrong"' },
+    });
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Two localized RFC conformance fixes

### 1. absolute-form request-target (RFC 9112 §3.2.2)
`GET http://host/path HTTP/1.1` reached the router as the full URI and 404'd. Added `originForm()` in `handler.zig`, applied in `parseRequest` before the query split: origin-form (`target[0]=='/'`) is a no-op; absolute-form gets `scheme://authority` stripped to the path (bare authority → `/`). The `target[0]=='/'` discriminator keeps a query containing `://` (e.g. `/redirect?url=http://x`) from being misparsed. Host-agreement intentionally not enforced (RFC "should"; low value).

### 2. If-None-Match list / `*` / weak (RFC 9110 §13.1.2)
`static.zig` did a single exact `mem.eql`. Added `ifNoneMatchMatches()`: comma-split + trim, `*` wildcard, strip `W/` weak indicator (GET/HEAD 304 uses weak comparison), match any token. Precedence over If-Modified-Since unchanged.

## Tests
Red-first (Zig helpers stubbed to old behavior to confirm behavioral red, plus integration). Integration: absolute-form GET of a routed path → 200 (+ origin-form control); `If-None-Match: "wrong", <etag>` → 304; `If-None-Match: *` → 304; non-matching → 200 control. Zig units for both helpers incl. the `://`-in-query edge.

`zig build test` (139) + full bun suite (87/87) green.

Closes #207
