### PR TITLE
fix(http): honor client Connection: close and HTTP/1.0 implicit close (#204)

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -59,6 +59,7 @@ pub const HttpState = struct {
     request_path: []const u8 = "",
     request_raw_len: usize = 0, // total bytes consumed by current request (headers + body)
     route_pattern: []const u8 = "", // matched route pattern for Prometheus labels (e.g. "/users/{id}")
+    wants_close: bool = false, // client asked to close, or HTTP/1.0 implicit close (#204)
 };
 
 /// Inbound TLS state — set once at connection init, persists across keep-alive.
@@ -589,6 +590,7 @@ pub const Connection = struct {
         self.http_state.request_method = request.method;
         self.http_state.request_path = clean_path;
         self.http_state.request_raw_len = request.raw_len;
+        self.http_state.wants_close = request.wants_close;
 
         // Parse query string and clear param cache for route matching
         self.query_cache.clear();
@@ -1020,8 +1022,11 @@ pub const Connection = struct {
         // instead of recycling (#180). pending_timer_ops/pending_io_ops may
         // still be non-zero (in-flight completions), so close() ->
         // maybeFinishClose() defers deinit until they drain.
-        // (Honoring the *client's* Connection: close request header on success
-        // responses is separate — deferred to #204.)
+        // (Honoring the *client's* Connection: close request header — and the
+        // HTTP/1.0 implicit-close default — on success responses is handled
+        // in handleHttpPostWrite via http_state.wants_close, not here: this
+        // check runs before the state switch, so it would wrongly close a
+        // WS/SSE/stream upgrade response too. See #204.)
         if (self.timed_out or self.close_after_write) {
             self.close();
             return .disarm;
@@ -1112,6 +1117,15 @@ pub const Connection = struct {
 
         // During drain: close keep-alive connections after current request completes
         if (self.server.draining) {
+            self.close();
+            return;
+        }
+
+        // Client asked to close (Connection: close), or HTTP/1.0 implicit
+        // close (#204) — close instead of recycling for keep-alive. No
+        // `Connection: close` response header is added; the client already
+        // initiated the close expectation.
+        if (self.http_state.wants_close) {
             self.close();
             return;
         }

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -14,6 +14,11 @@ pub const Request = struct {
     body: []const u8,
     /// Total bytes consumed from input buffer (headers + body per Content-Length)
     raw_len: usize,
+    /// True if the connection should be closed after this request's response
+    /// is written (#204): client sent `Connection: close`, or HTTP/1.0
+    /// without an explicit `Connection: keep-alive`. Defaulted so existing
+    /// test call sites that build a Request directly don't need updating.
+    wants_close: bool = false,
 };
 
 /// HTTP response
@@ -211,12 +216,16 @@ pub const Parser = struct {
         const bytes_consumed = @as(usize, @intCast(result));
 
         // Single pass over headers: collect Content-Length (rejecting malformed
-        // values and duplicates whose parsed values disagree) and the value of
+        // values and duplicates whose parsed values disagree), the value of
         // the last Transfer-Encoding header (repeated TE headers combine per
-        // RFC 7230 §3.3.2 — the final coding is what determines chunked-ness).
+        // RFC 7230 §3.3.2 — the final coding is what determines chunked-ness),
+        // and Connection: close/keep-alive tokens (#204) — OR'd across any
+        // repeated Connection headers.
         var content_length: ?usize = null;
         var transfer_encoding: ?[]const u8 = null;
         var host_count: usize = 0;
+        var conn_close = false;
+        var conn_keep_alive = false;
         for (0..num_headers) |i| {
             const h = c_headers[i];
             const name = h.name[0..h.name_len];
@@ -242,8 +251,19 @@ pub const Parser = struct {
                 }
             } else if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) {
                 transfer_encoding = h.value[0..h.value_len];
+            } else if (std.ascii.eqlIgnoreCase(name, "connection")) {
+                var it = std.mem.splitScalar(u8, h.value[0..h.value_len], ',');
+                while (it.next()) |tok| {
+                    const trimmed = std.mem.trim(u8, tok, " \t");
+                    if (std.ascii.eqlIgnoreCase(trimmed, "close")) conn_close = true;
+                    if (std.ascii.eqlIgnoreCase(trimmed, "keep-alive")) conn_keep_alive = true;
+                }
             }
         }
+
+        // RFC 9112 §9.6: HTTP/1.0 defaults to close unless the client asked
+        // to keep-alive; any version closes if the client asked to close.
+        const wants_close = conn_close or (minor_version == 0 and !conn_keep_alive);
 
         // RFC 9112 §3.2: an HTTP/1.1 request MUST have exactly one Host header.
         // HTTP/1.0 has no such requirement.
@@ -285,6 +305,7 @@ pub const Parser = struct {
                 .headers = headers,
                 .body = decoded.body,
                 .raw_len = bytes_consumed + decoded.total_consumed,
+                .wants_close = wants_close,
             };
         }
 
@@ -304,6 +325,7 @@ pub const Parser = struct {
             .headers = headers,
             .body = body,
             .raw_len = total_needed,
+            .wants_close = wants_close,
         };
     }
 
@@ -625,6 +647,68 @@ test "http parser - HTTP/1.0 request with no Host header parses OK" {
     const request_result = try parser.parseRequest(request);
     defer allocator.free(request_result.headers);
     try std.testing.expectEqualStrings("/test", request_result.path);
+}
+
+test "parseRequest wants_close (#204): HTTP/1.0 implicit close" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.0\r\n\r\n";
+    const result = try parser.parseRequest(request);
+    defer allocator.free(result.headers);
+    try std.testing.expect(result.wants_close);
+}
+
+test "parseRequest wants_close (#204): HTTP/1.0 with Connection: keep-alive stays open" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+    const result = try parser.parseRequest(request);
+    defer allocator.free(result.headers);
+    try std.testing.expect(!result.wants_close);
+}
+
+test "parseRequest wants_close (#204): HTTP/1.1 default keep-alive" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    const result = try parser.parseRequest(request);
+    defer allocator.free(result.headers);
+    try std.testing.expect(!result.wants_close);
+}
+
+test "parseRequest wants_close (#204): HTTP/1.1 with Connection: close" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    const result = try parser.parseRequest(request);
+    defer allocator.free(result.headers);
+    try std.testing.expect(result.wants_close);
+}
+
+test "parseRequest wants_close (#204): case-insensitive header name and token, whitespace-trimmed" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    const request = "GET /test HTTP/1.1\r\nHost: localhost\r\nCONNECTION:  CLOSE \r\n\r\n";
+    const result = try parser.parseRequest(request);
+    defer allocator.free(result.headers);
+    try std.testing.expect(result.wants_close);
+}
+
+test "parseRequest wants_close (#204): repeated Connection headers OR their tokens" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+
+    // First Connection header names an unrelated hop-by-hop token, second
+    // carries close — both headers' tokens must be scanned, not just the last.
+    const request = "GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: X-Foo\r\nConnection: close\r\n\r\n";
+    const result = try parser.parseRequest(request);
+    defer allocator.free(result.headers);
+    try std.testing.expect(result.wants_close);
 }
 
 test "serialize no longer special-cases 101 — a tenant ctx.status=101 is framed, not desynced (#194, #206)" {

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -80,3 +80,56 @@ describe("connection close after error responses (#180)", () => {
     });
   });
 });
+
+describe("connection close semantics (#204)", () => {
+  // RFC 9112 §9.6: HTTP/1.0 defaults to close unless the client explicitly
+  // asked to keep-alive.
+  test("HTTP/1.0 with no Connection header closes (implicit close)", async () => {
+    await withServer(async ({ port }) => {
+      const { response, serverClosed } = await rawResponseAndClose(
+        port,
+        `GET /health HTTP/1.0\r\n\r\n`,
+      );
+      expect(response.split(" ")[1]).toBe("200");
+      expect(serverClosed).toBe(true);
+    });
+  });
+
+  // RFC 9112 §9.6: a client's `Connection: close` request header must be
+  // honored on ANY version, including success responses.
+  test("HTTP/1.1 with Connection: close closes after the response", async () => {
+    await withServer(async ({ port }) => {
+      const { response, serverClosed } = await rawResponseAndClose(
+        port,
+        `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\n\r\n`,
+      );
+      expect(response.split(" ")[1]).toBe("200");
+      expect(serverClosed).toBe(true);
+    });
+  });
+
+  // Guard against over-closing: HTTP/1.0 with an explicit keep-alive request
+  // must NOT be closed by the server.
+  test("HTTP/1.0 with Connection: keep-alive stays open", async () => {
+    await withServer(async ({ port }) => {
+      const { response, serverClosed } = await rawResponseAndClose(
+        port,
+        `GET /health HTTP/1.0\r\nConnection: keep-alive\r\n\r\n`,
+      );
+      expect(response.split(" ")[1]).toBe("200");
+      expect(serverClosed).toBe(false);
+    });
+  });
+
+  // Control: HTTP/1.1 default (no Connection header) keeps the connection open.
+  test("HTTP/1.1 with no Connection header stays open (default keep-alive)", async () => {
+    await withServer(async ({ port }) => {
+      const { response, serverClosed } = await rawResponseAndClose(
+        port,
+        `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`,
+      );
+      expect(response.split(" ")[1]).toBe("200");
+      expect(serverClosed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Parts 1 & 3 of #204 (connection-close semantics). Part 2 (HTTP/1.0 stream upgrade → close-delimited body) is split to **#220** — it entangles the streaming state machine for a case with essentially zero real traffic.

## Problem
`minor_version` was parsed and discarded, so: (1) HTTP/1.0 clients got implicit keep-alive and blocked waiting for a close that never came; (3) a client's `Connection: close` was ignored on any version (the client-close case deferred from #180).

## Fix
`Parser.parseRequest` now computes `Request.wants_close` in its existing single header pass: scan `Connection` tokens (case-insensitive, comma-split, OR'd across repeated headers) → `wants_close = conn_close or (minor_version == 0 and !conn_keep_alive)`. `handleHttpPostWrite` closes instead of recycling when `http_state.wants_close` is set.

Deliberately checked in `handleHttpPostWrite`, NOT via the `close_after_write`/`onWrite` branch: `onWrite` runs its close check before the state switch, so it would wrongly close a WS/SSE/stream **upgrade** response. `handleHttpPostWrite` is only reached by normal HTTP + static responses, so upgrades correctly ignore the close request. No `Connection: close` response header is added (the client already initiated the close).

## Tests
Zig units: `wants_close` across 1.0-implicit / 1.0-keep-alive / 1.1-default / 1.1-close / case-insensitive / repeated-headers. Integration (`resilience.test.ts`, via `rawResponseAndClose`): 1.0 no-Connection → closes; 1.1 `Connection: close` → closes; 1.0 `keep-alive` → stays open; 1.1 default → stays open. Upgrade safety confirmed by the green `streaming`/`sse`/`websocket` suites.

`zig build test` (145) + full bun suite (91/91) green.

Closes #204
