### PR TITLE
fix(http): bound Content-Length before framing arithmetic to stop DoS

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -572,6 +572,8 @@ pub const Connection = struct {
         const request = http.parseRequest(self.arena.allocator(), request_data) catch |err| {
             if (err == error.Incomplete) {
                 self.startRead();
+            } else if (err == error.RequestTooLarge) {
+                error_response.sendErrorStatus(self, 413, "content-length exceeds buffer");
             } else {
                 error_response.sendError(self, .client_error, "http parse failed");
             }

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -130,6 +130,14 @@ fn isEngineOwnedHeader(name: []const u8) bool {
         std.ascii.eqlIgnoreCase(n, "connection");
 }
 
+/// True if `cl` could never be satisfied — the read buffer never grows past
+/// config.READ_BUFFER_SIZE, so a Content-Length beyond it is either an
+/// oversized body or (unchecked) an integer-overflow DoS on the
+/// `bytes_consumed + cl` framing arithmetic below (#223).
+fn exceedsReadBuffer(cl: usize) bool {
+    return cl > config.READ_BUFFER_SIZE;
+}
+
 /// True if `s` is a valid HTTP field-value integer: 1*DIGIT, nothing else.
 /// `std.fmt.parseInt` alone also accepts a leading '+', '-', and Zig's '_'
 /// digit separators — none of which RFC 7230 permits for Content-Length.
@@ -290,6 +298,10 @@ pub fn parseRequest(allocator: std.mem.Allocator, buf: []const u8) !Request {
     }
 
     const cl = content_length orelse 0;
+    if (exceedsReadBuffer(cl)) {
+        allocator.free(headers);
+        return error.RequestTooLarge;
+    }
     const total_needed = bytes_consumed + cl;
     if (buf.len < total_needed) {
         // Body not fully received yet — need more data
@@ -566,6 +578,34 @@ test "http parser - rejects Content-Length with digit separator" {
     const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1_0\r\n\r\nping";
     const result = parseRequest(allocator, request);
     try std.testing.expectError(error.InvalidRequest, result);
+}
+
+test "http parser - rejects Content-Length that would overflow bytes_consumed + cl (#223)" {
+    const allocator = std.testing.allocator;
+
+    // 18446744073709551600 is a valid u64 value on its own, but adding
+    // bytes_consumed (the header length) to it overflows usize — this is
+    // the exact DoS primitive #223 fixes.
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 18446744073709551600\r\n\r\n";
+    const result = parseRequest(allocator, request);
+    try std.testing.expectError(error.RequestTooLarge, result);
+}
+
+test "http parser - rejects Content-Length just above READ_BUFFER_SIZE (#223)" {
+    const allocator = std.testing.allocator;
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 65537\r\n\r\n";
+    const result = parseRequest(allocator, request);
+    try std.testing.expectError(error.RequestTooLarge, result);
+}
+
+test "http parser - accepts a normal small Content-Length" {
+    const allocator = std.testing.allocator;
+
+    const request = "POST /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\nping";
+    const request_result = try parseRequest(allocator, request);
+    defer allocator.free(request_result.headers);
+    try std.testing.expectEqualStrings("ping", request_result.body);
 }
 
 test "http parser - plain Transfer-Encoding: chunked decodes" {

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -29,6 +29,24 @@ describe("worker resilience regressions", () => {
     });
   });
 
+  // (#223)
+  test("Content-Length that overflows bytes_consumed + cl returns 413, server keeps serving", async () => {
+    await withServer(async ({ base, port }) => {
+      const status = await rawStatus(
+        port,
+        `POST /test/echo HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nContent-Length: 18446744073709551600\r\nConnection: close\r\n\r\n`,
+      );
+      expect(status).toBe(413);
+
+      // A fresh connection (not the one that got the 413) still routes fine —
+      // proves the process didn't die. Unchecked, this Content-Length
+      // overflows the framing arithmetic and panics the whole worker,
+      // taking every SO_REUSEPORT sibling down with it.
+      const next = await fetch(`${base}/test/hello`);
+      expect(next.status).toBe(200);
+    });
+  });
+
   // (#171)
   test("POST /test/echo body within the read buffer echoes correctly", async () => {
     const body = "x".repeat(32 * 1024);


### PR DESCRIPTION
Closes #223

## Summary
- `parseRequest` parsed `Content-Length` into a raw `usize` with no upper bound. `bytes_consumed + cl` in the no-Transfer-Encoding framing path could overflow on a value like `18446744073709551600`: integer-overflow panic (Debug/ReleaseSafe) that kills the whole process — every `SO_REUSEPORT` worker with it — from one unauthenticated request, or an OOB slice (ReleaseFast).
- Reject any `Content-Length` exceeding `config.READ_BUFFER_SIZE` (65536) before the addition runs, via a new `error.RequestTooLarge` — such a body could never fit the read buffer regardless, so this is a real behavior bound, not a bandaid.
- `handler.zig`'s `parseRequest` catch block maps `error.RequestTooLarge` to a 413 (existing pre-serialized response); all other non-`Incomplete` errors keep the existing 400.

## Test plan
- [x] Red first: unit test with `Content-Length: 18446744073709551600` crashed with `panic: integer overflow` at the exact `bytes_consumed + cl` line; the boundary test (65537) failed with `error.Incomplete` instead of the expected error — confirmed failing for behavioral reasons, not a compile error.
- [x] `zig build test` green after the fix (144 tests).
- [x] `zig build` compiles clean.
- [x] `cd tests && bun run test:ci` green (92 tests), including a new resilience test proving the oversized `Content-Length` gets 413 and a fresh connection still gets served afterward (process didn't die).