### PR TITLE
fix(lua): bound JSON decode recursion depth and guard Lua stack growth

### DIFF
--- a/src/lua/json.zig
+++ b/src/lua/json.zig
@@ -14,6 +14,7 @@ const EncodeError = error{
     OutOfMemory,
     NotSerializable,
     InvalidNumber,
+    StackOverflow,
 };
 
 // ── Encode ──────────────────────────────────────────────────────────
@@ -34,6 +35,7 @@ pub fn jsonEncode(lua: *Lua) callconv(.c) c_int {
             error.OutOfMemory => "JSON encode: out of memory",
             error.NotSerializable => "JSON encode: type is not JSON serializable",
             error.InvalidNumber => "JSON encode: NaN/Inf are not allowed in JSON",
+            error.StackOverflow => "JSON encode: stack overflow",
         };
         lua.pushString(msg);
         lua.raiseError();
@@ -75,12 +77,14 @@ fn encodeString(str: []const u8, buf: *Buf) EncodeError!void {
 
 fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void {
     // Detect array: if table[1] is non-nil, treat as array
+    try lua.checkStack(1);
     const first_type = lua.getTableIndexRaw(abs_idx, 1);
     if (first_type != .nil) {
         lua.pop(1);
         buf.writer.writeByte('[') catch return error.OutOfMemory;
         var i: i32 = 1;
         while (true) {
+            try lua.checkStack(1);
             const t = lua.getTableIndexRaw(abs_idx, i);
             if (t == .nil) {
                 lua.pop(1);
@@ -97,7 +101,9 @@ fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void 
     lua.pop(1); // pop nil from table[1] check
 
     // Object mode (or empty table)
+    try lua.checkStack(1);
     lua.pushNil();
+    try lua.checkStack(2); // next() pops the key, pushes key+value
     if (!lua.next(abs_idx)) {
         buf.writer.writeAll("{}") catch return error.OutOfMemory;
         return;
@@ -121,6 +127,7 @@ fn encodeTable(lua: *Lua, abs_idx: i32, buf: *Buf, depth: u32) EncodeError!void 
             try encodeValue(lua, -1, buf, depth + 1);
         }
         lua.pop(1); // pop value, keep key for next()
+        try lua.checkStack(2);
         if (!lua.next(abs_idx)) break;
     }
     buf.writer.writeByte('}') catch return error.OutOfMemory;
@@ -144,33 +151,74 @@ pub fn jsonDecode(lua: *Lua) callconv(.c) c_int {
         lua.pushString("JSON decode: invalid JSON");
         lua.raiseError();
     };
-    defer parsed.deinit();
 
-    pushJsonValue(lua, parsed.value);
+    // Not `defer parsed.deinit()`: raiseError() below longjmps, which would
+    // skip a defer and leak the parsed tree. Free it explicitly on both the
+    // success and error path, before ever raising.
+    const result = pushJsonValue(lua, parsed.value, 0);
+    parsed.deinit();
+    result catch |err| {
+        const msg: [*:0]const u8 = switch (err) {
+            error.DepthLimitExceeded => "JSON decode: depth limit exceeded (deeply nested input)",
+            error.OutOfMemory => "JSON decode: out of memory",
+            error.StackOverflow => "JSON decode: stack overflow",
+        };
+        lua.pushString(msg);
+        lua.raiseError();
+    };
     return 1;
 }
 
-fn pushJsonValue(lua: *Lua, value: std.json.Value) void {
+const DecodeError = error{
+    DepthLimitExceeded,
+    OutOfMemory,
+    StackOverflow,
+};
+
+fn pushJsonValue(lua: *Lua, value: std.json.Value, depth: u32) DecodeError!void {
     switch (value) {
-        .null => lua.pushNil(),
-        .bool => |b| lua.pushBoolean(b),
-        .integer => |i| lua.pushInteger(@intCast(i)),
-        .float => |f| lua.pushNumber(f),
-        .string => |s| lua.pushLString(s),
-        .number_string => |s| lua.pushLString(s),
+        .null => {
+            try lua.checkStack(1);
+            lua.pushNil();
+        },
+        .bool => |b| {
+            try lua.checkStack(1);
+            lua.pushBoolean(b);
+        },
+        .integer => |i| {
+            try lua.checkStack(1);
+            lua.pushInteger(@intCast(i));
+        },
+        .float => |f| {
+            try lua.checkStack(1);
+            lua.pushNumber(f);
+        },
+        .string => |s| {
+            try lua.checkStack(1);
+            lua.pushLString(s);
+        },
+        .number_string => |s| {
+            try lua.checkStack(1);
+            lua.pushLString(s);
+        },
         .array => |arr| {
+            if (depth >= max_depth) return error.DepthLimitExceeded;
+            try lua.checkStack(1);
             lua.createTable(@intCast(arr.items.len), 0);
             for (arr.items, 1..) |item, i| {
-                pushJsonValue(lua, item);
+                try pushJsonValue(lua, item, depth + 1);
                 lua.setTableIndexRaw(-2, @intCast(i));
             }
         },
         .object => |obj| {
+            if (depth >= max_depth) return error.DepthLimitExceeded;
+            try lua.checkStack(1);
             lua.createTable(0, @intCast(obj.count()));
             var it = obj.iterator();
             while (it.next()) |entry| {
+                try lua.checkStack(1);
                 lua.pushLString(entry.key_ptr.*);
-                pushJsonValue(lua, entry.value_ptr.*);
+                try pushJsonValue(lua, entry.value_ptr.*, depth + 1);
                 lua.setTable(-3); // table[key] = value, pops both
             }
         },
@@ -309,5 +357,77 @@ test "roundtrip encode/decode" {
     );
 }
 
-// Note: error paths (NaN/Inf, depth limit, invalid JSON) use raiseError (longjmp)
-// which crashes Zig's test runner in debug builds. Tested via integration tests.
+test "encode of realistic deep nesting (under max_depth) still succeeds (#226)" {
+    const testing_alloc = std.testing.allocator;
+    const LuaState = @import("lua_state.zig").LuaState;
+
+    var state = try LuaState.init(testing_alloc);
+    defer state.deinit();
+    const lua = state.lua;
+
+    lua.pushCFunction(jsonEncode);
+    lua.setGlobal("json_encode");
+
+    // 120 levels is under max_depth (128) — a regression guard against a
+    // future "fix" that clamps max_depth so low it breaks legitimate
+    // deeply-nested payloads.
+    try state.loadString(
+        \\local t = {}
+        \\local cur = t
+        \\for i = 1, 120 do
+        \\    cur[1] = {}
+        \\    cur = cur[1]
+        \\end
+        \\cur[1] = "leaf"
+        \\assert(type(json_encode(t)) == "string")
+    );
+}
+
+test "decode of realistic deep nesting (under max_depth) still succeeds (#226)" {
+    const testing_alloc = std.testing.allocator;
+    const LuaState = @import("lua_state.zig").LuaState;
+
+    var state = try LuaState.init(testing_alloc);
+    defer state.deinit();
+    const lua = state.lua;
+
+    lua.pushCFunction(jsonDecode);
+    lua.setGlobal("json_decode");
+
+    // Same 120-deep bound as the encode test above.
+    const nested = ("[" ** 120) ++ ("]" ** 120);
+    const code = "local t = json_decode('" ++ nested ++ "')\n" ++
+        "assert(type(t) == \"table\")\n";
+    try state.loadString(code);
+}
+
+test "pushJsonValue rejects input at or past max_depth (#226)" {
+    const testing_alloc = std.testing.allocator;
+    const LuaState = @import("lua_state.zig").LuaState;
+
+    var state = try LuaState.init(testing_alloc);
+    defer state.deinit();
+    const lua = state.lua;
+
+    // Call pushJsonValue directly on a synthetic (not parsed-from-text)
+    // std.json.Value tree, bypassing jsonDecode's raiseError() wrapper
+    // entirely — this is the one depth-limit assertion that doesn't longjmp,
+    // so it's safe to check in a Zig unit test rather than an integration test.
+    var arena = std.heap.ArenaAllocator.init(testing_alloc);
+    defer arena.deinit();
+
+    var value: std.json.Value = .null;
+    var depth: u32 = 0;
+    while (depth <= max_depth) : (depth += 1) {
+        var arr = std.json.Array.init(arena.allocator());
+        try arr.append(value);
+        value = .{ .array = arr };
+    }
+
+    try std.testing.expectError(error.DepthLimitExceeded, pushJsonValue(lua, value, 0));
+}
+
+// Note: error paths reached through jsonEncode/jsonDecode (NaN/Inf, invalid
+// JSON, and the depth-limit/stack-overflow errors once raised as Lua errors)
+// use raiseError (longjmp), which crashes Zig's test runner in debug builds.
+// Tested via integration tests instead.

--- a/tests/fixtures.lua
+++ b/tests/fixtures.lua
@@ -59,6 +59,17 @@ keyway.routes["/test/echo"] = {
     end,
 }
 
+-- (#226) json.decode of an untrusted body must not crash the worker,
+-- however deeply nested the input is.
+keyway.routes["/test/json-decode"] = {
+    POST = function(ctx)
+        local json = require("keyway.json")
+        json.decode(ctx.body)
+        ctx.status = 200
+        ctx.body = "ok"
+    end,
+}
+
 keyway.routes["/test/status/{code}"] = {
     GET = function(ctx)
         local code = tonumber(ctx.params.code) or 200

--- a/tests/integration/resilience.test.ts
+++ b/tests/integration/resilience.test.ts
@@ -38,6 +38,22 @@ describe("worker resilience regressions", () => {
       expect(await res.text()).toBe(body);
     });
   });
+
+  // (#226) A pathologically nested JSON body (well within the 64KB read
+  // buffer, so it actually reaches json.decode) must not hang or crash the
+  // worker — it should fail cleanly, and the worker must keep serving.
+  test("POST body with pathologically nested JSON does not crash the worker", async () => {
+    const depth = 30000;
+    const body = "[".repeat(depth) + "]".repeat(depth);
+    await withServer(async ({ base }) => {
+      const res = await fetch(`${base}/test/json-decode`, { method: "POST", body });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(600);
+
+      const next = await fetch(`${base}/test/hello`);
+      expect(next.status).toBe(200);
+    });
+  });
 });
 
 describe("connection close after error responses (#180)", () => {


### PR DESCRIPTION
## Summary
- `json.decode` had no depth limit at all (unlike `json.encode`'s existing `max_depth = 128`), so `pushJsonValue` recursed once per JSON nesting level with no bound.
- Confirmed by hand against a running server: POSTing a pathologically nested body (30k levels of `[`, ~60KB — well within the 64KB read buffer, so it actually reaches `json.decode`) hung the worker indefinitely (`/health` on the same worker stopped responding too). With the fix, the same request returns a clean `500` in ~35ms and the worker keeps serving.
- `pushJsonValue` now takes a `depth` counter and rejects input at or past `max_depth`, mirroring `encodeValue`'s existing guard. Both `pushJsonValue` and `encodeTable` now call `checkStack()` before each push as well, so stack growth stays correct/bounded regardless of LuaJIT's own auto-growth behavior.
- `jsonDecode` no longer `defer`s `parsed.deinit()` — `raiseError()` longjmps past deferred cleanup, so the parsed tree is now freed explicitly on both the success and error path before ever raising.

Closes #226

## Test plan
- [x] `zig build test` — 143/143 pass. New tests: two "still succeeds under max_depth" regression tests (encode/decode at 120 levels), plus a direct `pushJsonValue` unit test asserting `error.DepthLimitExceeded` at the boundary (confirmed RED beforehand: this test doesn't even compile against the old 2-arg `pushJsonValue` signature — `expected 2 argument(s), found 3` — since the depth-tracking parameter didn't exist pre-fix).
- [x] `zig build` — clean.
- [x] `cd tests && bun run test:ci` — 92/92 pass, including a new integration test posting a 30k-level-deep nested JSON body to a new `/test/json-decode` fixture route, asserting a clean 4xx/5xx and that the worker still serves a follow-up request.
- [x] Manually reproduced the pre-fix hang and the post-fix clean failure against a real running server (not just via tests).