### PR TITLE
fix(ws): enforce one send in flight per connection

### DIFF
--- a/src/core/conn_ws.zig
+++ b/src/core/conn_ws.zig
@@ -253,13 +253,18 @@ pub fn processWsFrames(conn: *Connection) void {
 
                 switch (f.frame.opcode) {
                     .ping => {
+                        // sendWsFrame submits a send — must return, not continue
+                        // (#224): looping straight to the next buffered frame
+                        // would process it while the pong send is still in
+                        // flight, clobbering write_completion. onWsControlSent
+                        // re-enters processWsFrames once the pong actually lands.
                         sendWsFrame(conn, .pong, f.frame.payload) catch {
                             sendWsClose(conn, 1002);
                             return;
                         };
-                        continue;
+                        return;
                     },
-                    .pong => continue,
+                    .pong => continue, // no send submitted — safe to keep draining buffered frames
                     .close => {
                         handleWsClose(conn, f.frame.payload);
                         return;

--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -129,6 +129,11 @@ pub const Connection = struct {
     // Completions (must have stable address!)
     read_completion: xev.Completion = .{},
     write_completion: xev.Completion = .{},
+    // Enforces "at most one send in flight" on write_completion: submitSend
+    // refuses to overwrite/re-add it while this is true. A violation means
+    // two sends raced onto the same Completion — double io_uring add and a
+    // clobbered buffer (#224). Cleared in handleSendCompletion.
+    send_in_flight: bool = false,
 
     // Buffers (allocated from base_allocator, persist across requests)
     read_buffer: LinearBuffer,
@@ -915,6 +920,15 @@ pub const Connection = struct {
     /// After kTLS setup, all sends are plaintext — the kernel encrypts transparently.
     /// If arena_dupe is true, data is copied into the arena (for stack-local buffers).
     pub fn submitSend(self: *Connection, data: []const u8, callback: *const fn (?*anyopaque, *xev.Loop, *xev.Completion, xev.Result) xev.CallbackAction, arena_dupe: bool) void {
+        if (self.send_in_flight) {
+            // Invariant violation, not a std.debug.assert (stripped in release,
+            // see zig-gotchas.md): a caller tried to submit a second send while
+            // one was still in flight, which would clobber write_completion and
+            // double-add it to the loop (#224). Fail loud and closed instead.
+            log.err().string("msg", "submitSend: send already in flight, closing connection").int("fd", self.socket).log();
+            self.close();
+            return;
+        }
         const alloc = self.arena.allocator();
         const send_data = if (arena_dupe) alloc.dupe(u8, data) catch {
             self.close();
@@ -925,6 +939,7 @@ pub const Connection = struct {
             .userdata = self,
             .callback = callback,
         };
+        self.send_in_flight = true;
         self.pending_io_ops += 1;
         self.loop.add(&self.write_completion);
     }
@@ -1161,6 +1176,7 @@ pub const Connection = struct {
     /// if the caller should return .disarm (error or closing).
     pub fn handleSendCompletion(self: *Connection, result: xev.Result) ?usize {
         self.pending_io_ops -= 1;
+        self.send_in_flight = false;
         const bytes = result.send catch {
             if (self.state == .closing) {
                 self.maybeFinishClose();

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -70,6 +70,8 @@ async function openRawWs(port: number) {
   return {
     socket,
     readText: () => waitFor(() => readFrame(bytes, 0x1)),
+    // (#224) Reads a pong frame (opcode 0xA) by payload.
+    readPong: () => waitFor(() => readFrame(bytes, 0xa)),
     readClose: () => waitFor(() => (closed || readFrame(bytes, 0x8) !== null ? true : null)),
     // (#175) Parses the close frame's 2-byte big-endian status code instead
     // of just detecting that a close happened.
@@ -305,6 +307,70 @@ describe("websocket adversarial framing", () => {
       ws.socket.flush();
       expect(await ws.readCloseCode()).toBe(1007);
       ws.socket.end();
+    });
+  });
+});
+
+// (#224) Two control frames arriving in a single TCP segment used to be
+// processed synchronously in one pass of the frame loop while the first
+// frame's pong send was still in flight, clobbering the shared
+// write_completion (double io_uring add on a live Completion) — a
+// whole-worker corruption from unauthenticated input. Each write() below is
+// unflushed until the final flush() so both frames land in the same recv().
+describe("websocket queued control frames in one segment (#224)", () => {
+  test("answers back-to-back pings with two pongs and keeps the worker alive", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x9, "a"));
+      ws.socket.write(clientFrame(0x9, "b"));
+      ws.socket.flush();
+      expect(await ws.readPong()).toBe("a");
+      expect(await ws.readPong()).toBe("b");
+      ws.socket.end();
+      // The worker must have survived the double send unscathed.
+      expect(await rawStatus(port, `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`)).toBe(200);
+    });
+  });
+
+  test("answers a queued [ping][close] with a pong then a clean close, and keeps the worker alive", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x9, "a"));
+      ws.socket.write(clientFrame(0x8, ""));
+      ws.socket.flush();
+      expect(await ws.readPong()).toBe("a");
+      expect(await ws.readCloseCode()).toBe(1000);
+      ws.socket.end();
+      expect(await rawStatus(port, `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`)).toBe(200);
+    });
+  });
+
+  // A single [ping][ping] pair doesn't always corrupt anything an observer
+  // can see — the kernel often already captured each pong's buffer when its
+  // send was submitted. But processWsFrames's stray re-arm of the recv
+  // completion each round leaves a dangling operation targeting the same
+  // (stale) buffer offset as the next round's real recv, and repeating the
+  // pair reliably wins that race within a handful of rounds: a later round's
+  // ping payload lands in the wrong recv's buffer and comes back echoed
+  // under the wrong round number below. Left running long enough, the
+  // dangling completions also accumulate forever (never cleaned up until
+  // close) and overflow pending_io_ops (a u8 counter), panicking — and on
+  // this single-worker build, killing — the whole process ("panic: integer
+  // overflow" at handler.zig's submitSend, reached from sendWsFrame <-
+  // processWsFrames's `.ping` arm). 150 rounds is overkill for the fast
+  // corruption but cheap insurance against the slower overflow too.
+  test("many back-to-back ping pairs on one connection don't wedge or crash the worker", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      for (let round = 0; round < 150; round++) {
+        ws.socket.write(clientFrame(0x9, `${round}`));
+        ws.socket.write(clientFrame(0x9, `${round}`));
+        ws.socket.flush();
+        expect(await ws.readPong()).toBe(`${round}`);
+        expect(await ws.readPong()).toBe(`${round}`);
+      }
+      ws.socket.end();
+      expect(await rawStatus(port, `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`)).toBe(200);
     });
   });
 });


### PR DESCRIPTION
## Summary

`processWsFrames`'s `.ping` arm submitted a pong send then `continue`d the
frame loop, processing the next buffered frame **synchronously** while that
send was still in flight. `submitSend` unconditionally overwrites and
re-`loop.add`s `write_completion`, so a second queued control frame arriving
in the same TCP segment (`[ping][ping]`, `[ping][close]`, ...) clobbered a
libxev `Completion` still in flight — a whole-worker corruption reachable
from unauthenticated input.

- Verified directly: repeating a `[ping][ping]` pair on one connection
  reliably corrupts pong content within a handful of rounds, and left running
  long enough overflows `pending_io_ops` (a `u8`), panicking (`integer
  overflow` at `submitSend`) and killing the single-worker process.

## Fix

- `conn_ws.zig`: the `.ping` arm now `return`s instead of `continue`s after
  submitting the pong send — `onWsControlSent` already re-enters
  `processWsFrames` once that send completes, so nothing is lost, it just
  stops happening out of turn. Audited every other arm of the frame loop:
  `.pong` is the only remaining `continue` and it submits no send, so it's
  safe as-is.
- `handler.zig`: added a `send_in_flight` guard on `Connection`. `submitSend`
  refuses to overwrite `write_completion` while a send is outstanding —
  instead of corrupting the connection, it logs and closes loudly (not a
  `std.debug.assert`, which is stripped in release). Cleared in the shared
  `handleSendCompletion`, which every send-completion callback in the
  codebase already routes through.

### Audit note (not part of this fix)

`conn_tls.zig`'s `sendTlsData` submits its handshake-write send by hand
(bypasses `submitSend`, doesn't set `send_in_flight`). It's safe: the
handshake is a strictly serial recv → send → recv chain with no timer path
that can submit a send during it, so it can never race a second send. Flagging
for visibility since it's the one send-completion path not covered by the new
guard.

## Test plan

- [x] Bun test added in `tests/integration/ws_framing.test.ts` (`#224` describe
      block): `[ping][ping]` and `[ping][close]` pairs in a single segment, plus
      a 150-round repeated-pair test that is the actual red/green proof (fails
      fast with corrupted pong content pre-fix; on unfixed code, prolonged
      repetition also reproduces the `pending_io_ops` overflow panic directly).
- [x] Confirmed red against pre-fix code (reverted locally), confirmed green
      after the fix, several times each to rule out flake.
- [x] `zig build` clean, `zig build test` passes.
- [x] `cd tests && bun run test:ci` passes (95/95). Hit the known
      `withServer` spawn-timeout flake once under heavy sibling-agent load on
      this shared machine (unrelated file); re-ran clean.