### PR TITLE
fix(ws): reject single WS frames too large for the read buffer with 1009

### DIFF
--- a/src/core/conn_ws.zig
+++ b/src/core/conn_ws.zig
@@ -139,6 +139,11 @@ fn armWsRecv(conn: *Connection) void {
         }
         break :blk cb.writeSlice();
     } else blk: {
+        // Defensive fallback: parseFrame now rejects any single frame whose
+        // declared length exceeds ws.MAX_SINGLE_FRAME_PAYLOAD before this
+        // point, so a legal frame should never fill the buffer without
+        // completing (#228). A bare close() here would still mean a bug
+        // upstream, not an expected path.
         if (conn.read_buffer.availableWrite() == 0) {
             conn.close();
             return;

--- a/src/protocol/ws.zig
+++ b/src/protocol/ws.zig
@@ -50,7 +50,11 @@ pub fn parseFrame(data: []u8) !ParseResult {
         pos += 8;
     }
 
-    if (payload_len > @as(u64, config.WS_MAX_MESSAGE_SIZE)) return error.FrameTooLarge;
+    // A single frame's payload must fit the read buffer in one shot — it can
+    // never be assembled otherwise (#228). This is stricter than (and
+    // supersedes) the reassembled-message limit: a fragmented message may
+    // still reach WS_MAX_MESSAGE_SIZE across many frames, each ≤ this cap.
+    if (payload_len > @as(u64, MAX_SINGLE_FRAME_PAYLOAD)) return error.FrameTooLarge;
     const payload_len_usize: usize = @intCast(payload_len);
 
     if (masked) {
@@ -111,6 +115,23 @@ pub fn serializeFrame(opcode: Opcode, payload: []const u8, buf: []u8) usize {
 
 /// Maximum frame overhead: 1 (fin+opcode) + 9 (extended length) = 10 bytes
 pub const MAX_FRAME_OVERHEAD = 10;
+
+/// RFC 6455 §5.3: client frames carry a 4-byte mask key we don't emit ourselves.
+const MASK_KEY_SIZE = 4;
+
+/// Largest single (unfragmented) frame payload guaranteed to fit the read
+/// buffer in one recv. `config.READ_BUFFER_SIZE` is the hard cap on how much
+/// of one frame we can ever hold; a frame declaring more than this can never
+/// be assembled, so parseFrame rejects it up front (clean 1009) instead of
+/// spinning on `.incomplete` until the buffer fills (#228).
+pub const MAX_SINGLE_FRAME_PAYLOAD = config.READ_BUFFER_SIZE - MAX_FRAME_OVERHEAD - MASK_KEY_SIZE;
+
+comptime {
+    // Defined here (not config.zig) to avoid an import cycle: ws.zig already
+    // imports config.zig for READ_BUFFER_SIZE.
+    if (config.READ_BUFFER_SIZE <= MAX_FRAME_OVERHEAD + MASK_KEY_SIZE)
+        @compileError("READ_BUFFER_SIZE too small to hold even an empty WS frame");
+}
 
 /// Compute the Sec-WebSocket-Accept value per RFC 6455 Section 4.2.2.
 /// sec_key: the client's Sec-WebSocket-Key header value

--- a/src/util/config.zig
+++ b/src/util/config.zig
@@ -3,7 +3,9 @@
 
 /// Read buffer for inbound HTTP data (headers + body) — the hard cap on
 /// request size, since the buffer never grows. A request that doesn't fit
-/// gets 413.
+/// gets 413. Also the recv buffer post-WS-upgrade, so this is the effective
+/// ceiling on a single WS frame's payload — see ws.zig's
+/// MAX_SINGLE_FRAME_PAYLOAD (#228).
 pub const READ_BUFFER_SIZE = 65536;
 
 /// Ciphertext receive buffer for inbound TLS connections.

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -191,6 +191,35 @@ describe("websocket adversarial framing", () => {
     });
   });
 
+  // (#228) A legal single (unfragmented) frame whose declared length is under
+  // the 1MB message limit but over the 64KB read buffer used to be
+  // unassemblable: parseFrame kept returning `.incomplete` until the buffer
+  // filled, then armWsRecv gave up with a bare `close()` (client sees 1006).
+  // It must instead get a clean 1009, same as the existing >1MB case above.
+  test("closes with 1009 on a legal single frame too large for the read buffer", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      ws.socket.write(clientFrame(0x2, "x".repeat(100_000))); // binary, ~100KB
+      ws.socket.flush();
+      expect(await ws.readCloseCode()).toBe(1009);
+      ws.socket.end();
+    });
+  });
+
+  // (#228) The largest single-frame payload guaranteed to fit the read
+  // buffer: 65536 (READ_BUFFER_SIZE) - 10 (max frame header) - 4 (mask key).
+  test("echoes a single frame at the read-buffer capacity and keeps the worker alive", async () => {
+    await withServer(async ({ port }) => {
+      const ws = await openRawWs(port);
+      const payload = "x".repeat(65522);
+      ws.socket.write(clientFrame(0x1, payload));
+      ws.socket.flush();
+      expect(await ws.readText()).toBe(payload);
+      ws.socket.end();
+      expect(await rawStatus(port, `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`)).toBe(200);
+    });
+  });
+
   // (#167)
   test("echoes a text message sent as three continuation frames", async () => {
     await withServer(async ({ port }) => {


### PR DESCRIPTION
## Problem

A legal, unfragmented WebSocket frame declaring a payload larger than the
64KB read buffer (`READ_BUFFER_SIZE`, `src/util/config.zig`) but smaller
than the 1MB reassembled-message limit (`WS_MAX_MESSAGE_SIZE`) could never
be assembled. `parseFrame` checked the declared length against the *message*
limit, not the buffer capacity, so it kept returning `.incomplete`. Once the
read buffer filled without ever completing the frame, `armWsRecv` fell back
to a bare `close()` — the client saw an abnormal closure (1006) instead of a
clean protocol close.

## Fix

- `src/protocol/ws.zig`: added `MAX_SINGLE_FRAME_PAYLOAD`, derived from
  `config.READ_BUFFER_SIZE` minus frame/mask overhead, with a comptime
  assertion that the buffer can hold at least an empty frame. `parseFrame`
  now checks a single frame's declared payload against this cap instead of
  `WS_MAX_MESSAGE_SIZE`, so an oversized frame is rejected the moment its
  length is known (mapped to a clean 1009 via the existing `FrameTooLarge` ->
  1009 path in `conn_ws.zig`) rather than after the buffer fills.
- `src/core/conn_ws.zig`: comment noting the `availableWrite() == 0 ->
  close()` fallback in `armWsRecv` is now a defensive-only path, unreachable
  for legal single frames.
- `src/util/config.zig`: cross-reference comment on `READ_BUFFER_SIZE`
  noting it's also the effective single-WS-frame ceiling.
- The per-message reassembly limit (`WS_MAX_MESSAGE_SIZE`, enforced in
  `conn_ws.zig` during continuation-frame reassembly) is unchanged —
  fragmented messages can still reach 1MB across many frames, each ≤ the new
  per-frame cap.

## Tests

Added to `tests/integration/ws_framing.test.ts` (raw WS client):
- A single ~100KB binary frame now gets a clean 1009 instead of a bare
  drop/timeout.
- A single frame at the exact read-buffer capacity (65522 bytes) is still
  echoed correctly, and the worker stays alive for a subsequent request.

Confirmed red against unfixed code (timeout waiting for the close frame,
i.e. the bare-drop symptom) before implementing the fix.

Closes #228