### PR TITLE
fix(http): intern route patterns so they survive Router.reset()

### DIFF
--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -51,10 +51,11 @@ const Node = struct {
             self.allocator.destroy(param);
         }
 
-        // Free pattern string
-        if (self.pattern.len > 0) {
-            self.allocator.free(self.pattern);
-        }
+        // pattern is NOT freed here — it's an interned string owned by the
+        // Router's intern pool (see Router.internPattern), which deliberately
+        // outlives reset()/node teardown so callers who capture a matched
+        // pattern (route_pattern, timing.route, Prometheus labels) don't hold
+        // a dangling slice across a hot-reload (#225).
 
         // Free handler methods map
         if (self.methods) |*m| {
@@ -113,6 +114,12 @@ pub const Router = struct {
     root: *Node,
     static_routes: std.ArrayListUnmanaged(StaticRoute) = .empty,
     proxy_routes: std.ArrayListUnmanaged(ProxyRoute) = .empty,
+
+    // Route pattern strings, deduped and owned independently of the trie.
+    // Patterns are a small, bounded set fixed at route-load time, so this
+    // stays small even under repeated `--watch` reloads. Deliberately NOT
+    // freed by reset() — see internPattern() and node.pattern (#225).
+    intern: std.StringHashMapUnmanaged(void) = .empty,
 
     /// Initialize radix router
     pub fn init(allocator: std.mem.Allocator) !Router {
@@ -271,13 +278,27 @@ pub const Router = struct {
             node.methods = std.StringHashMap(i32).init(self.allocator);
         }
 
-        // Store pattern on the leaf node (for Prometheus route labels)
+        // Store pattern on the leaf node (for Prometheus route labels).
+        // Interned rather than node-owned so it survives Router.reset() (#225).
         if (node.pattern.len == 0) {
-            node.pattern = try self.allocator.dupe(u8, pattern);
+            node.pattern = try self.internPattern(pattern);
         }
 
         const method_copy = try self.allocator.dupe(u8, method);
         try node.methods.?.put(method_copy, lua_ref);
+    }
+
+    /// Return a stable, deduped copy of `pattern` owned by the Router's intern
+    /// pool. Unlike trie-node-owned strings, interned strings are not freed by
+    /// reset() — they live as long as the Router itself, so a pattern handed
+    /// out via RouteMatch stays valid across a hot-reload even after the trie
+    /// node that produced it is torn down (#225).
+    fn internPattern(self: *Router, pattern: []const u8) ![]const u8 {
+        const gop = try self.intern.getOrPut(self.allocator, pattern);
+        if (!gop.found_existing) {
+            gop.key_ptr.* = try self.allocator.dupe(u8, pattern);
+        }
+        return gop.key_ptr.*;
     }
 
     pub const RouteMatch = struct { lua_ref: i32, pattern: []const u8 };
@@ -418,6 +439,12 @@ pub const Router = struct {
         self.freeProxyRoutes();
         self.proxy_routes.deinit(self.allocator);
         self.root.deinit();
+
+        // Intern pool outlives reset() by design — free it only here, on
+        // Router teardown (process/worker shutdown), not on every reload.
+        var it = self.intern.keyIterator();
+        while (it.next()) |key| self.allocator.free(key.*);
+        self.intern.deinit(self.allocator);
     }
 };
 
@@ -616,6 +643,28 @@ test "router reset clears all routes" {
     var p = params.ParamArray{};
     const result = try router.match("GET", "/users", &p);
     try std.testing.expect(result == null);
+}
+
+test "matched route pattern outlives Router.reset() (#225)" {
+    // A WebSocket/SSE connection captures RouteMatch.pattern once at handshake
+    // and never refreshes it, so if reset() frees the memory backing it, the
+    // next read after a hot-reload is a use-after-free. Uses page_allocator
+    // (not std.testing.allocator) because it munmaps on free with no bucket
+    // reuse to mask the bug — a regression here crashes this test outright
+    // instead of silently reading stale-but-still-mapped bytes.
+    var router = try Router.init(std.heap.page_allocator);
+    defer router.deinit();
+
+    try router.addRoute("GET", "/users/{id}", 1);
+    var p = params.ParamArray{};
+    const before = (try router.match("GET", "/users/42", &p)).?;
+    const captured: []const u8 = before.pattern;
+    p.clear();
+
+    try router.reset();
+    try router.addRoute("GET", "/users/{id}", 2); // reload re-registers the same route
+
+    try std.testing.expectEqualStrings("/users/{id}", captured);
 }
 
 test "collectLuaRefs gathers all refs" {

--- a/tests/integration/ws_framing.test.ts
+++ b/tests/integration/ws_framing.test.ts
@@ -425,3 +425,29 @@ describe("websocket handshake validation (#175)", () => {
     });
   });
 });
+
+// (#225) A WebSocket connection captures its route pattern once at handshake
+// and never refreshes it (only method/path are updated per message). A
+// hot-reload frees and rebuilds the whole route trie, so a message on a live
+// WS connection after a reload used to read the freed pattern string. Cycles
+// reload+message repeatedly to widen the race and confirms the connection
+// keeps echoing correctly and the worker stays alive throughout.
+describe("websocket survives hot-reload of its own route (#225)", () => {
+  test("echoes correctly and stays healthy across repeated reloads", async () => {
+    await withServer(async ({ base, port }) => {
+      const ws = await openRawWs(port);
+      for (let round = 0; round < 20; round++) {
+        const res = await fetch(`${base}/__keyway/reload`, { method: "POST" });
+        expect(res.ok).toBe(true);
+        // Give the worker's event loop a turn to process the reload signal
+        // and free the old trie before the next WS message lands.
+        await Bun.sleep(20);
+        ws.socket.write(clientFrame(0x1, `round-${round}`));
+        ws.socket.flush();
+        expect(await ws.readText()).toBe(`round-${round}`);
+      }
+      ws.socket.end();
+      expect(await rawStatus(port, `GET /health HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\n\r\n`)).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`RouteMatch.pattern` was a slice into the trie node's own memory (`node.pattern`, set at `addRoute`). `Router.reset()` (hot-reload) frees the whole trie, including that memory. A WebSocket/SSE connection captures `route_pattern` once at handshake and never refreshes it (only method/path are updated per message), so the next message on a live connection after a reload read freed memory — a real use-after-free, remotely triggerable and constantly hit in dev `--watch` with the dashboard's WS/SSE open.

`conn.arena` is reset per-WS-message, so the fix can't be an arena copy at match time (it would be invalidated on the very next message). Instead: intern route pattern strings in a small deduped pool owned by the `Router`. `reset()` deliberately leaves the pool intact (it only tears down the trie), so a pattern handed out via `RouteMatch`/`route_pattern`/`timing.route`/Prometheus labels stays valid across a hot-reload. The pool is freed only on `Router.deinit()` (worker teardown), not on every reload — dedup means repeated `--watch` cycles re-registering the same routes add zero new entries.

## Root cause fix, not a band-aid

- `node.pattern` now points at the interned copy instead of a node-owned dupe; `Node.deinit()` no longer frees it (ownership moved to the intern pool).
- `Router.reset()` is unchanged — it already didn't touch anything outside the trie/static/proxy routes, so the intern pool survives by construction.
- `Router.deinit()` frees the intern pool's entries once, at real teardown.

## Test plan

- [x] `zig build test` passes (147/147), including a new regression test that captures a matched pattern, calls `Router.reset()` + rebuild, and asserts the captured pattern is still valid. It uses `std.heap.page_allocator` (which munmaps on free, unlike the bucketing debug allocator) so a regression crashes the test outright instead of silently reading stale-but-mapped bytes. Confirmed RED by reverting the fix: deterministic segfault at the `expectEqualStrings` call reading the freed/unmapped pattern. Confirmed GREEN with the fix restored, twice.
- [x] `zig build test -Doptimize=ReleaseSafe` passes (147/147).
- [x] `zig build` clean.
- [x] New bun integration test in `tests/integration/ws_framing.test.ts`: opens a raw WS connection, cycles POST `/__keyway/reload` + a WS message 20 times, asserts each echoes correctly and `/health` stays 200 afterward. Passes against the fix (built ReleaseSafe). Note: this integration-level race did not reproduce a visible failure against the pre-fix code even under a tight-race/high-round-count manual repro (3000 rounds) — the production allocator doesn't poison freed memory on free, and this fixture's route set is small/static so a freed slot tends to get refilled with byte-identical content on reload, masking the corruption. The unit-level repro (above) is the deterministic proof; this integration test is kept as a functional regression guard for WS-survives-reload behavior.
- [x] `cd tests && bun run test:ci`: hit the known #216 spawn-timeout flake (unrelated file, `--bail` aborts). Re-ran without `--bail`: 97/97 pass.

Closes #225