### PR TITLE
refactor(lua): drop unused io/os/bit/ffi libs; enforce no-Lua-IO by construction

### DIFF
--- a/lua/response.lua
+++ b/lua/response.lua
@@ -19,18 +19,8 @@ function M.get_header(ctx, name)
     return nil
 end
 
---- Monotonic clock in microseconds (cached timespec)
-local ffi = require("ffi")
-pcall(ffi.cdef, [[
-    typedef long time_t;
-    struct timespec { time_t tv_sec; long tv_nsec; };
-    int clock_gettime(int clockid, struct timespec *tp);
-]])
-local _ts = ffi.new("struct timespec")
-function M.now_us()
-    ffi.C.clock_gettime(1, _ts) -- CLOCK_MONOTONIC
-    return tonumber(_ts.tv_sec) * 1000000 + tonumber(_ts.tv_nsec) / 1000
-end
+--- Monotonic clock in microseconds
+M.now_us = __keyway_now_us
 
 --- Broadcast an SSE event with automatic JSON encoding
 function M.broadcast_event(room, data)

--- a/src/lua/lua_api.zig
+++ b/src/lua/lua_api.zig
@@ -320,6 +320,13 @@ pub fn registerHttpExchangeMetatable(lua: *Lua) void {
 
 // === Keyway Module ===
 
+/// __keyway_log_middleware_error(msg) — see registerKeywayModule.
+fn logMiddlewareError(lua: *Lua) callconv(.c) c_int {
+    const msg = lua.toString(1) catch "unknown error";
+    log.err().string("msg", "middleware error").string("error", std.mem.span(msg)).log();
+    return 0;
+}
+
 /// Register the keyway module with Lua
 /// Creates global `keyway` table (script assigns keyway.routes = {...})
 pub fn registerKeywayModule(lua: *Lua) void {
@@ -329,6 +336,12 @@ pub fn registerKeywayModule(lua: *Lua) void {
     // Create empty keyway table (script populates keyway.routes)
     lua.createTable(0, 1);
     lua.setGlobal("keyway");
+
+    // A misbehaving middleware is caught here via pcall (so it can't unwind
+    // the whole coroutine, see #186) but the error must still be surfaced —
+    // routed through Zig's logger, not io.stderr:write (Lua never does I/O, #227).
+    lua.pushCFunction(logMiddlewareError);
+    lua.setGlobal("__keyway_log_middleware_error");
 
     // Register middleware chain builder as a global helper
     lua.doString(
@@ -340,7 +353,7 @@ pub fn registerKeywayModule(lua: *Lua) void {
         \\        chain = function(ctx)
         \\            local ok, err = pcall(mw, ctx, function() next_fn(ctx) end)
         \\            if not ok then
-        \\                io.stderr:write("middleware error: " .. tostring(err) .. "\n")
+        \\                __keyway_log_middleware_error(tostring(err))
         \\                ctx.status = 500
         \\                ctx.body = "Internal Server Error"
         \\            end

--- a/src/lua/lua_state.zig
+++ b/src/lua/lua_state.zig
@@ -80,12 +80,12 @@ pub const LuaState = struct {
         lua.openTableLib();
         lua.openMathLib();
         lua.openPackageLib();
-        lua.openIOLib(); // Required for LuaRocks to load modules from disk
-        lua.openOSLib(); // Required for some LuaRocks modules (time, execute, etc.)
-        lua.openDebugLib(); // Required for some LuaRocks modules (debug introspection)
-        lua.openBitLib(); // Required for pgmoon and other LuaJIT modules (bit operations)
-        lua.openJITLib(); // Required for JIT control (jit.on/off, jit.opt, etc.)
-        lua.openFFILib(); // Required for FFI (ffi.cdef, ffi.C, ffi.new, etc.)
+        lua.openDebugLib(); // Error tracebacks — not an I/O capability, kept
+        lua.openJITLib(); // JIT control (jit.on/off, jit.opt, etc.) — the compiler itself
+
+        // io/os/bit/ffi are deliberately NOT opened: Lua never does I/O (#227).
+        // require() loads modules via C luaL_loadfile, not the Lua `io` table,
+        // so disk-based requires and LuaRocks still work without it.
 
         // Register keyway module (must be done before creating userdata)
         lua_api.registerKeywayModule(lua);
@@ -99,41 +99,21 @@ pub const LuaState = struct {
         lua.pushCFunction(json.jsonDecode);
         lua.setGlobal("__keyway_json_decode");
 
+        // Register the monotonic clock C function (used by lua/response.lua's
+        // now_us() — used to go through ffi.C.clock_gettime, but ffi isn't
+        // opened anymore, #227).
+        lua.pushCFunction(keywayNowUs);
+        lua.setGlobal("__keyway_now_us");
+
         // Create reusable coroutine thread (avoids lua_newThread per request)
         const cached_thread = lua.newThread();
         const cached_thread_ref = lua.ref(Lua.PseudoIndex.Registry);
 
-        // Configure package.path for app-local requires and LuaRocks.
+        // Configure package.path/cpath for app-local requires and LuaRocks.
         // Stdlib modules are preloaded (above), so no scripts/ prefix needed.
-        // KEYWAY_LUA_PATH / KEYWAY_LUA_CPATH override defaults if set.
-        lua.doString(
-            \\local custom_path = os.getenv("KEYWAY_LUA_PATH")
-            \\local custom_cpath = os.getenv("KEYWAY_LUA_CPATH")
-            \\if custom_path then
-            \\    package.path = custom_path .. ";" .. package.path
-            \\else
-            \\    local home = os.getenv("HOME") or ""
-            \\    package.path = "./?.lua;./?/init.lua;"
-            \\        .. home .. "/.luarocks/share/lua/5.1/?.lua;"
-            \\        .. home .. "/.luarocks/share/lua/5.1/?/init.lua;"
-            \\        .. "/usr/share/lua/5.1/?.lua;"
-            \\        .. "/usr/share/lua/5.1/?/init.lua;"
-            \\        .. package.path
-            \\end
-            \\if custom_cpath then
-            \\    package.cpath = custom_cpath .. ";" .. package.cpath
-            \\else
-            \\    local home = os.getenv("HOME") or ""
-            \\    package.cpath = home .. "/.luarocks/lib/lua/5.1/?.so;"
-            \\        .. "/usr/lib/lua/5.1/?.so;"
-            \\        .. "/usr/lib64/lua/5.1/?.so;"
-            \\        .. "/usr/share/lua/5.1/?.so;"
-            \\        .. "/usr/local/lib/lua/5.1/?.so;"
-            \\        .. package.cpath
-            \\end
-        ) catch |err| {
-            log.warn().string("msg", "failed to configure Lua package paths").err(err).log();
-        };
+        // KEYWAY_LUA_PATH / KEYWAY_LUA_CPATH override defaults if set. Built
+        // in Zig, not via os.getenv — the os lib isn't opened anymore (#227).
+        configurePackagePaths(lua, allocator);
 
         return LuaState{
             .lua = lua,
@@ -427,6 +407,75 @@ pub const LuaState = struct {
         lua.pop(2); // pop preload + package
     }
 
+    /// __keyway_now_us() → monotonic microseconds. Backs lua/response.lua's
+    /// now_us(), which used to read CLOCK_MONOTONIC directly via ffi (#227).
+    fn keywayNowUs(lua: *Lua) callconv(.c) c_int {
+        const us = @divTrunc(helpers.monotonicNanos(), std.time.ns_per_us);
+        lua.pushNumber(@floatFromInt(us));
+        return 1;
+    }
+
+    /// Configure package.path/cpath for app-local requires and LuaRocks.
+    /// Stdlib modules are preloaded (registerEmbeddedModules), so no scripts/
+    /// prefix is needed here. KEYWAY_LUA_PATH / KEYWAY_LUA_CPATH override the
+    /// defaults if set. Built in Zig (not os.getenv) — os isn't opened (#227).
+    fn configurePackagePaths(lua: *Lua, allocator: std.mem.Allocator) void {
+        _ = lua.getGlobal("package"); // stack: [package]
+
+        setPackagePath(lua, allocator) catch |err| {
+            log.warn().string("msg", "failed to configure Lua package.path").err(err).log();
+        };
+        setPackageCpath(lua, allocator) catch |err| {
+            log.warn().string("msg", "failed to configure Lua package.cpath").err(err).log();
+        };
+
+        lua.pop(1); // pop package table
+    }
+
+    fn setPackagePath(lua: *Lua, allocator: std.mem.Allocator) !void {
+        _ = lua.getField(-1, "path"); // stack: [package, old_path]
+        errdefer lua.pop(1); // keep the stack balanced if allocPrint below fails (OOM)
+        const old_path = lua.toLString(-1) catch "";
+
+        const new_path = if (helpers.getenv("KEYWAY_LUA_PATH")) |custom|
+            try std.fmt.allocPrint(allocator, "{s};{s}", .{ custom, old_path })
+        else blk: {
+            const home = helpers.getenv("HOME") orelse "";
+            break :blk try std.fmt.allocPrint(
+                allocator,
+                "./?.lua;./?/init.lua;{0s}/.luarocks/share/lua/5.1/?.lua;{0s}/.luarocks/share/lua/5.1/?/init.lua;/usr/share/lua/5.1/?.lua;/usr/share/lua/5.1/?/init.lua;{1s}",
+                .{ home, old_path },
+            );
+        };
+        defer allocator.free(new_path);
+
+        lua.pop(1); // pop old_path, stack: [package]
+        lua.pushLString(new_path); // stack: [package, new_path]
+        lua.setField(-2, "path"); // package.path = new_path, pops new_path
+    }
+
+    fn setPackageCpath(lua: *Lua, allocator: std.mem.Allocator) !void {
+        _ = lua.getField(-1, "cpath"); // stack: [package, old_cpath]
+        errdefer lua.pop(1); // keep the stack balanced if allocPrint below fails (OOM)
+        const old_cpath = lua.toLString(-1) catch "";
+
+        const new_cpath = if (helpers.getenv("KEYWAY_LUA_CPATH")) |custom|
+            try std.fmt.allocPrint(allocator, "{s};{s}", .{ custom, old_cpath })
+        else blk: {
+            const home = helpers.getenv("HOME") orelse "";
+            break :blk try std.fmt.allocPrint(
+                allocator,
+                "{0s}/.luarocks/lib/lua/5.1/?.so;/usr/lib/lua/5.1/?.so;/usr/lib64/lua/5.1/?.so;/usr/share/lua/5.1/?.so;/usr/local/lib/lua/5.1/?.so;{1s}",
+                .{ home, old_cpath },
+            );
+        };
+        defer allocator.free(new_cpath);
+
+        lua.pop(1); // pop old_cpath, stack: [package]
+        lua.pushLString(new_cpath); // stack: [package, new_cpath]
+        lua.setField(-2, "cpath"); // package.cpath = new_cpath, pops new_cpath
+    }
+
     /// Hot-reload: unref old routes, reset router, clear package.loaded, re-execute script.
     /// On script error: logs the error and leaves the router empty (all requests 404).
     /// Returns true on success, false on failure — callers use this to gate the
@@ -451,9 +500,9 @@ pub const LuaState = struct {
         self.lua.doString(
             \\local keep = {
             \\    ["keyway"] = true, ["keyway.response"] = true,
-            \\    ["string"] = true, ["table"] = true, ["math"] = true, ["io"] = true,
-            \\    ["os"] = true, ["debug"] = true, ["coroutine"] = true, ["package"] = true,
-            \\    ["bit"] = true, ["ffi"] = true, ["jit"] = true, ["jit.opt"] = true,
+            \\    ["string"] = true, ["table"] = true, ["math"] = true,
+            \\    ["debug"] = true, ["coroutine"] = true, ["package"] = true,
+            \\    ["jit"] = true, ["jit.opt"] = true,
             \\    ["jit.util"] = true, ["keyway.json"] = true,
             \\}
             \\for name in pairs(package.loaded) do
@@ -602,6 +651,55 @@ test "embedded stdlib modules are preloaded" {
     // All embedded modules should be available in package.preload
     try state.loadString("assert(type(package.preload['keyway.response']) == 'function')");
     try state.loadString("assert(type(package.preload['keyway.json']) == 'function')");
+}
+
+test "capability surface: io/os/bit/ffi are not loaded (#227)" {
+    const allocator = std.testing.allocator;
+
+    var state = try LuaState.init(allocator);
+    defer state.deinit();
+
+    // Lua never does I/O — these libs are the escape hatches that would let
+    // route scripts bypass the proactor. Nothing in the codebase uses them
+    // (see #227), so they must not be opened at all.
+    try state.loadString(
+        \\assert(io == nil, 'io')
+        \\assert(os == nil, 'os')
+        \\assert(bit == nil, 'bit')
+        \\assert(package.loaded.ffi == nil and ffi == nil, 'ffi')
+    );
+}
+
+test "package.path keeps default search dirs without os.getenv (#227)" {
+    const allocator = std.testing.allocator;
+
+    var state = try LuaState.init(allocator);
+    defer state.deinit();
+
+    // package.path/cpath are now assembled in Zig (no os.getenv) — confirm
+    // the same default search dirs (app-local + LuaRocks) still land.
+    try state.loadString(
+        \\assert(package.path:find("./?.lua", 1, true) ~= nil, "missing ./?.lua")
+        \\assert(package.path:find(".luarocks/share/lua/5.1", 1, true) ~= nil, "missing luarocks share dir")
+        \\assert(package.cpath:find(".luarocks/lib/lua/5.1", 1, true) ~= nil, "missing luarocks cpath dir")
+    );
+}
+
+test "now_us works via keyway.response without ffi (#227)" {
+    const allocator = std.testing.allocator;
+
+    var state = try LuaState.init(allocator);
+    defer state.deinit();
+
+    // now_us() used to shell out to ffi.C.clock_gettime; it's now backed by
+    // a Zig C function. Also proves require() of a pure-Lua module still
+    // works with the io/os/bit/ffi libs gone.
+    try state.loadString(
+        \\local response = require("keyway.response")
+        \\local t = response.now_us()
+        \\assert(type(t) == "number", "now_us must return a number")
+        \\assert(t > 0, "now_us must be positive")
+    );
 }
 
 test "middleware execution order" {


### PR DESCRIPTION
## Summary

Part of #227. Route Lua in keyway is trusted operator config, not an untrusted-input sandbox boundary — and LuaJIT FFI can't be sandboxed anyway. Two independent research passes found the `io`/`os`/`bit`/`ffi` capability surface (plus the LuaRocks-for-DB-drivers justification behind it) is unused dead weight: fossils of a deleted redis test and the deleted cosocket engine. So the fix for the "Lua never does I/O" invariant is to delete the unused libs — the invariant then holds by construction, no sandbox machinery, no MANIFEST downgrade.

- `LuaState.init` no longer opens `io`, `os`, `bit`, `ffi`. `debug` and `jit` are kept (tracebacks, JIT compiler — not I/O capabilities).
- `lua/response.lua`'s `now_us()` used `ffi.C.clock_gettime`; it's now `__keyway_now_us()`, a Zig C function backed by `helpers.monotonicNanos()`.
- `package.path`/`package.cpath` setup used `os.getenv`; it's now built in Zig (`helpers.getenv`) and set via the Lua C API, preserving the same default search dirs (app-local `./?.lua` + LuaRocks) and the `KEYWAY_LUA_PATH`/`KEYWAY_LUA_CPATH` overrides.
- A repo-wide grep for `io.`/`os.`/`bit.`/`ffi.` across both `.lua` files *and* `.zig` files (to catch embedded Lua chunks) turned up one more real usage the file-scoped grep missed: `__keyway_wrap_chain`'s middleware `pcall` error handler (embedded in `src/lua/lua_api.zig`, not a `.lua` file) wrote to `io.stderr` on a middleware failure. Replaced with a Zig-side logger call (`__keyway_log_middleware_error`), same pattern as the other two replacements.
- `LuaState.reload()`'s package.loaded keep-list trimmed of the now-deleted libs.

`require()` is unaffected everywhere — it loads modules via C `luaL_loadfile`, not the Lua `io` table, so disk-based requires and LuaRocks still work with `io` gone.

**Not in scope:** #227's other half — blocking file I/O in `lua_file_io.zig` running on the worker thread — is a separate follow-up, not addressed here.

## Test plan

- [x] Red-green TDD: added a capability-surface test (`assert(io == nil...)` etc.) that fails against pre-change code (libs open) and passes post-change — confirmed by temporarily stashing the fix and re-running.
- [x] Regression guards: `package.path`/`cpath` still contain the expected default search dirs; `now_us()` via `require("keyway.response")` still returns a positive number.
- [x] `zig build` clean, `zig build test` — 150/150 pass.
- [x] `cd tests && bun run test:ci` — 99/99 pass, including dashboard/WS/SSE tests exercising `now_us()`/`broadcast_event`.