### PR TITLE
feat(http): emit Date header on first-party responses

### DIFF
--- a/src/core/handler.zig
+++ b/src/core/handler.zig
@@ -977,7 +977,9 @@ pub const Connection = struct {
             return;
         };
         const body = allocating_writer.writer.buffered();
-        const full = std.fmt.allocPrint(alloc, "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {d}\r\n\r\n{s}", .{ body.len, body }) catch {
+        var date_buf: [29]u8 = undefined;
+        helpers.formatHttpDate(&date_buf, helpers.realtimeSeconds());
+        const full = std.fmt.allocPrint(alloc, "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nDate: {s}\r\nContent-Length: {d}\r\n\r\n{s}", .{ &date_buf, body.len, body }) catch {
             error_response.sendError(self, .server_error, "metrics response failed");
             return;
         };
@@ -987,7 +989,9 @@ pub const Connection = struct {
 
     /// Format and send a JSON HTTP response with the given status and body.
     fn sendJsonResponse(self: *Connection, alloc: std.mem.Allocator, status_code: u16, status_text: []const u8, body: []const u8) void {
-        const resp = std.fmt.allocPrint(alloc, "HTTP/1.1 {d} {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\n\r\n{s}", .{ status_code, status_text, body.len, body }) catch {
+        var date_buf: [29]u8 = undefined;
+        helpers.formatHttpDate(&date_buf, helpers.realtimeSeconds());
+        const resp = std.fmt.allocPrint(alloc, "HTTP/1.1 {d} {s}\r\nContent-Type: application/json\r\nDate: {s}\r\nContent-Length: {d}\r\n\r\n{s}", .{ status_code, status_text, &date_buf, body.len, body }) catch {
             error_response.sendError(self, .server_error, "response allocation failed");
             return;
         };

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const config = @import("../util/config.zig");
+const helpers = @import("../util/helpers.zig");
 
 // Picohttpparser C bindings
 const c = @cImport({
@@ -92,6 +93,16 @@ pub const Response = struct {
             try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
         }
 
+        // RFC 9110 §6.6.1: an origin server with a clock SHOULD generate a
+        // Date on every response it emits (#238). One vDSO read per
+        // response — no per-second caching (ponytail: add if profiling ever
+        // shows this line matters).
+        {
+            var date_buf: [29]u8 = undefined;
+            helpers.formatHttpDate(&date_buf, helpers.realtimeSeconds());
+            try writer.print("Date: {s}\r\n", .{&date_buf});
+        }
+
         // RFC 9110 §6.4.1 / §15.3.5: 1xx, 204, and 304 responses carry no body.
         // Suppress the engine Content-Length too (simplest and RFC-clean for
         // all three). The 101 handshake is emitted as a raw response by
@@ -127,7 +138,8 @@ fn isEngineOwnedHeader(name: []const u8) bool {
     const n = std.mem.trim(u8, name, " \t");
     return std.ascii.eqlIgnoreCase(n, "content-length") or
         std.ascii.eqlIgnoreCase(n, "transfer-encoding") or
-        std.ascii.eqlIgnoreCase(n, "connection");
+        std.ascii.eqlIgnoreCase(n, "connection") or
+        std.ascii.eqlIgnoreCase(n, "date");
 }
 
 /// True if `cl` could never be satisfied — the read buffer never grows past
@@ -409,8 +421,72 @@ test "response serialization" {
 
     try response.serialize(&buf.writer);
 
-    const expected = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
-    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
+    // Date's value is nondeterministic (#238), so this checks structure
+    // rather than a single exact-match string.
+    const out = buf.writer.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 200 OK\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "Date: ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Content-Length: 13\r\n") != null);
+    try std.testing.expect(std.mem.endsWith(u8, out, "\r\n\r\nHello, World!"));
+}
+
+test "serialize emits an RFC 7231 IMF-fixdate Date header (#238)" {
+    const allocator = std.testing.allocator;
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    response.status = 200;
+    response.body = "hi";
+
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
+    try response.serialize(&buf.writer);
+
+    const out = buf.writer.buffered();
+    const marker = "Date: ";
+    const marker_idx = std.mem.indexOf(u8, out, marker);
+    try std.testing.expect(marker_idx != null);
+    const value_start = marker_idx.? + marker.len;
+    try std.testing.expect(out.len >= value_start + 29);
+    const value = out[value_start..][0..29];
+
+    // "Xxx, DD Xxx YYYY HH:MM:SS GMT" — shape checks on the fixed-width IMF-fixdate.
+    try std.testing.expectEqual(@as(u8, ','), value[3]);
+    try std.testing.expectEqual(@as(u8, ' '), value[4]);
+    try std.testing.expectEqual(@as(u8, ' '), value[7]);
+    try std.testing.expectEqual(@as(u8, ' '), value[11]);
+    try std.testing.expectEqual(@as(u8, ' '), value[16]);
+    try std.testing.expectEqual(@as(u8, ':'), value[19]);
+    try std.testing.expectEqual(@as(u8, ':'), value[22]);
+    try std.testing.expect(std.mem.endsWith(u8, value, " GMT"));
+
+    // Header line is terminated and precedes the blank line separating body.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\r\n\r\n") != null);
+}
+
+test "serialize strips a tenant-set Date header, emitting exactly one engine Date (#238)" {
+    const allocator = std.testing.allocator;
+
+    var response = Response.init(allocator);
+    defer response.deinit();
+    response.status = 200;
+    response.body = "ok";
+    try response.addHeader("Date", "bogus-tenant-date");
+
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
+    try response.serialize(&buf.writer);
+
+    const out = buf.writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, out, "bogus-tenant-date") == null);
+
+    var count: usize = 0;
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, out, pos, "Date: ")) |i| {
+        count += 1;
+        pos = i + 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), count);
 }
 
 test "serialize suppresses Content-Length and body for 204 (#206)" {
@@ -427,8 +503,14 @@ test "serialize suppresses Content-Length and body for 204 (#206)" {
 
     try response.serialize(&buf.writer);
 
-    const expected = "HTTP/1.1 204 No Content\r\n\r\n";
-    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
+    // Date's value is nondeterministic (#238), so this checks structure
+    // rather than a single exact-match string.
+    const out = buf.writer.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 204 No Content\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "Date: ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Content-Length") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "should never be sent") == null);
+    try std.testing.expect(std.mem.endsWith(u8, out, "\r\n\r\n"));
 }
 
 test "serialize suppresses Content-Length and body for 304 (#206)" {
@@ -445,8 +527,12 @@ test "serialize suppresses Content-Length and body for 304 (#206)" {
 
     try response.serialize(&buf.writer);
 
-    const expected = "HTTP/1.1 304 Not Modified\r\n\r\n";
-    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
+    const out = buf.writer.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 304 Not Modified\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "Date: ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Content-Length") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "should never be sent") == null);
+    try std.testing.expect(std.mem.endsWith(u8, out, "\r\n\r\n"));
 }
 
 test "serialize suppresses Content-Length and body for 1xx (#206)" {
@@ -463,8 +549,12 @@ test "serialize suppresses Content-Length and body for 1xx (#206)" {
 
     try response.serialize(&buf.writer);
 
-    const expected = "HTTP/1.1 102 Processing\r\n\r\n";
-    try std.testing.expectEqualStrings(expected, buf.writer.buffered());
+    const out = buf.writer.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 102 Processing\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "Date: ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Content-Length") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "should never be sent") == null);
+    try std.testing.expect(std.mem.endsWith(u8, out, "\r\n\r\n"));
 }
 
 test "isEngineOwnedHeader matches content-length, transfer-encoding, connection case-insensitively" {
@@ -475,6 +565,9 @@ test "isEngineOwnedHeader matches content-length, transfer-encoding, connection 
     try std.testing.expect(isEngineOwnedHeader("transfer-encoding"));
     try std.testing.expect(isEngineOwnedHeader("Connection"));
     try std.testing.expect(isEngineOwnedHeader("connection"));
+    try std.testing.expect(isEngineOwnedHeader("Date"));
+    try std.testing.expect(isEngineOwnedHeader("date"));
+    try std.testing.expect(isEngineOwnedHeader("DATE"));
     try std.testing.expect(!isEngineOwnedHeader("X-Foo"));
     // Whitespace-padded framing names are the classic smuggling obfuscation —
     // still recognized so they can't ride alongside the engine's own header.

--- a/src/http/static.zig
+++ b/src/http/static.zig
@@ -72,31 +72,6 @@ fn getContentType(path: []const u8) []const u8 {
     return mime_types.get(ext) orelse "application/octet-stream";
 }
 
-/// Format a Unix timestamp as HTTP-date (RFC 7231).
-fn formatHttpDate(buf: *[29]u8, epoch_secs: i64) void {
-    const days = [_][]const u8{ "Thu", "Fri", "Sat", "Sun", "Mon", "Tue", "Wed" };
-    const months = [_][]const u8{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-
-    const epoch = std.time.epoch.EpochSeconds{ .secs = @intCast(@max(0, epoch_secs)) };
-    const day_seconds = epoch.getDaySeconds();
-    const epoch_day = epoch.getEpochDay();
-    const year_day = epoch_day.calculateYearDay();
-    const month_day = year_day.calculateMonthDay();
-
-    // Day of week: Jan 1 1970 was Thursday (days[0])
-    const dow_idx: usize = @intCast(@mod(@as(i64, @intCast(epoch_day.day)), 7));
-
-    _ = std.fmt.bufPrint(buf, "{s}, {d:0>2} {s} {d} {d:0>2}:{d:0>2}:{d:0>2} GMT", .{
-        days[dow_idx],
-        month_day.day_index + 1,
-        months[month_day.month.numeric() - 1],
-        year_day.year,
-        day_seconds.getHoursIntoDay(),
-        day_seconds.getMinutesIntoHour(),
-        day_seconds.getSecondsIntoMinute(),
-    }) catch {};
-}
-
 /// Parse an RFC 7231 IMF-fixdate ("Sun, 06 Nov 1994 08:49:37 GMT") to epoch
 /// seconds. Returns null on any deviation (caller then serves 200).
 // ponytail: IMF-fixdate only (the format we emit); other HTTP-date forms fall through to 200
@@ -245,13 +220,16 @@ fn buildStaticHeaders(
     mtime_sec: i64,
 ) ![]const u8 {
     var last_modified_buf: [29]u8 = undefined;
-    formatHttpDate(&last_modified_buf, mtime_sec);
+    helpers.formatHttpDate(&last_modified_buf, mtime_sec);
+    var date_buf: [29]u8 = undefined;
+    helpers.formatHttpDate(&date_buf, helpers.realtimeSeconds());
 
-    return std.fmt.allocPrint(alloc, "HTTP/1.1 200 OK\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nETag: {s}\r\nLast-Modified: {s}\r\nCache-Control: public, max-age=3600\r\n\r\n", .{
+    return std.fmt.allocPrint(alloc, "HTTP/1.1 200 OK\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nETag: {s}\r\nLast-Modified: {s}\r\nDate: {s}\r\nCache-Control: public, max-age=3600\r\n\r\n", .{
         content_type,
         file_size,
         etag,
         &last_modified_buf,
+        &date_buf,
     });
 }
 
@@ -510,13 +488,6 @@ test "getContentType handles no extension" {
     try std.testing.expectEqualStrings("application/octet-stream", getContentType("/Makefile"));
 }
 
-test "formatHttpDate produces valid format" {
-    var buf: [29]u8 = undefined;
-    // Unix epoch: Thu, 01 Jan 1970 00:00:00 GMT
-    formatHttpDate(&buf, 0);
-    try std.testing.expectEqualStrings("Thu, 01 Jan 1970 00:00:00 GMT", &buf);
-}
-
 test "buildStaticHeaders formats status line and cache headers" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -526,6 +497,7 @@ test "buildStaticHeaders formats status line and cache headers" {
     try std.testing.expect(std.mem.indexOf(u8, headers, "Content-Length: 42\r\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, headers, "ETag: \"abc\"\r\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, headers, "Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, headers, "Date: ") != null);
 }
 
 test "isWithinRoot enforces a segment boundary, not just a string prefix" {
@@ -558,12 +530,12 @@ test "ifNoneMatchMatches: weak indicator is ignored" {
 test "parseHttpDate round-trips formatHttpDate" {
     // 784111777 = Sun, 06 Nov 1994 08:49:37 GMT
     var buf: [29]u8 = undefined;
-    formatHttpDate(&buf, 784111777);
+    helpers.formatHttpDate(&buf, 784111777);
     try std.testing.expectEqualStrings("Sun, 06 Nov 1994 08:49:37 GMT", &buf);
     try std.testing.expectEqual(@as(?i64, 784111777), parseHttpDate(&buf));
 
     var epoch_buf: [29]u8 = undefined;
-    formatHttpDate(&epoch_buf, 0);
+    helpers.formatHttpDate(&epoch_buf, 0);
     try std.testing.expectEqual(@as(?i64, 0), parseHttpDate(&epoch_buf));
 
     try std.testing.expectEqual(@as(?i64, null), parseHttpDate("not a date"));

--- a/src/util/helpers.zig
+++ b/src/util/helpers.zig
@@ -26,6 +26,42 @@ pub fn monotonicNanos() i64 {
     return @as(i64, @intCast(ts.sec)) * std.time.ns_per_s + @as(i64, @intCast(ts.nsec));
 }
 
+/// Wall-clock time in whole seconds since the Unix epoch. `std.time.timestamp`
+/// was removed in Zig 0.16; this reads CLOCK_REALTIME via the vDSO (no
+/// syscall) — safe to call per-response, not a proactor violation.
+pub fn realtimeSeconds() i64 {
+    var ts: std.os.linux.timespec = undefined;
+    _ = std.os.linux.clock_gettime(.REALTIME, &ts);
+    return @as(i64, @intCast(ts.sec));
+}
+
+/// Format a Unix timestamp as an RFC 7231 IMF-fixdate HTTP-date, e.g.
+/// "Sun, 06 Nov 1994 08:49:37 GMT". Shared by the Date response header and
+/// static file Last-Modified.
+pub fn formatHttpDate(buf: *[29]u8, epoch_secs: i64) void {
+    const days = [_][]const u8{ "Thu", "Fri", "Sat", "Sun", "Mon", "Tue", "Wed" };
+    const months = [_][]const u8{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+
+    const epoch = std.time.epoch.EpochSeconds{ .secs = @intCast(@max(0, epoch_secs)) };
+    const day_seconds = epoch.getDaySeconds();
+    const epoch_day = epoch.getEpochDay();
+    const year_day = epoch_day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+
+    // Day of week: Jan 1 1970 was Thursday (days[0])
+    const dow_idx: usize = @intCast(@mod(@as(i64, @intCast(epoch_day.day)), 7));
+
+    _ = std.fmt.bufPrint(buf, "{s}, {d:0>2} {s} {d} {d:0>2}:{d:0>2}:{d:0>2} GMT", .{
+        days[dow_idx],
+        month_day.day_index + 1,
+        months[month_day.month.numeric() - 1],
+        year_day.year,
+        day_seconds.getHoursIntoDay(),
+        day_seconds.getMinutesIntoHour(),
+        day_seconds.getSecondsIntoMinute(),
+    }) catch {};
+}
+
 // -- Raw syscall wrappers ---------------------------------------------------
 // Zig 0.16 removed most `std.posix.*` syscall wrappers. These reimplement the
 // few keyway needs via raw `std.os.linux` / libc calls.
@@ -71,4 +107,11 @@ test "castUserdata round-trips a struct pointer" {
     try testing.expectEqual(@as(i32, 42), recovered.x);
     try testing.expectEqual(@as(i32, -7), recovered.y);
     try testing.expect(recovered == &p);
+}
+
+test "formatHttpDate produces valid format" {
+    var buf: [29]u8 = undefined;
+    // Unix epoch: Thu, 01 Jan 1970 00:00:00 GMT
+    formatHttpDate(&buf, 0);
+    try testing.expectEqualStrings("Thu, 01 Jan 1970 00:00:00 GMT", &buf);
 }

--- a/tests/integration/headers.test.ts
+++ b/tests/integration/headers.test.ts
@@ -15,4 +15,13 @@ describe("headers", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("X-MW-Before")).toBeTruthy();
   });
+
+  test("GET /test/headers carries a valid RFC 7231 Date header (#238)", async () => {
+    const res = await fetch(`${base()}/test/headers`);
+    expect(res.status).toBe(200);
+    const date = res.headers.get("date");
+    expect(date).toBeTruthy();
+    expect(Number.isNaN(Date.parse(date!))).toBe(false);
+    expect(date!.endsWith("GMT")).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #238

RFC 9110 §6.6.1: an origin server with a clock SHOULD generate a `Date` header on its responses. Keyway is an origin server for Lua routes, `/health`, `/metrics`, `/reload`, and static files — none of them carried one.

## What changed

Reuses the existing IMF-fixdate formatter (`formatHttpDate`, previously private to `static.zig`, already had a `parseHttpDate` round-trip test) — no new date-formatting logic. Promoted it to `helpers.zig` as `pub fn formatHttpDate`, alongside a new `helpers.realtimeSeconds()` (`CLOCK_REALTIME` via the vDSO, mirrors the existing `monotonicNanos()`). Not blocking I/O, no proactor violation.

`Date: <imf-fixdate>` is now emitted at the four first-party dynamic sites:
- `Response.serialize` (`src/http/http.zig`) — covers every Lua-handler response.
- `servePrometheusMetrics`'s allocPrint (`src/core/handler.zig`) — `/metrics`.
- `sendJsonResponse`'s allocPrint (`src/core/handler.zig`) — `/health`, `/reload`.
- `buildStaticHeaders`'s allocPrint (`src/http/static.zig`) — static-file 200s (already computed an IMF date for `Last-Modified`; now shares the buffer pattern for `Date`).

`isEngineOwnedHeader` now also recognizes `date` (case-insensitive), so a tenant-set `ctx` Date header is stripped from the Lua path instead of riding alongside the engine's own and producing two `Date:` headers. This also protects `serializeChunkedHeaders`, which shares the filter.

## Deliberately not touched

- Canned comptime error responses (`error_response.zig`) — Date is SHOULD, not MUST; keep the single-memcpy `const`.
- Proxy upstream re-emit (`proxy.zig`) — the upstream origin owns Date; adding ours would duplicate it.
- WS 101/426, SSE 200, chunked streaming heads (`serializeChunkedHeaders` callers) — Date on streaming responses is a deliberate later follow-up, not this issue.
- No per-second Date caching — a per-response vDSO read is cheap; a `ponytail:` comment in `Response.serialize` names caching as the upgrade path if it ever shows in a profile.

## Test plan

- [x] `zig build test` — 152/152 pass (moved/updated existing exact-match serialize tests to structural checks since Date's value is nondeterministic; added dedicated IMF-fixdate shape and duplicate-header tests)
- [x] `cd tests && bun run test:ci` — 100/100 pass